### PR TITLE
feat: add typed interfaces for dashboard data

### DIFF
--- a/Frontend/src/components/layout/Sidebar.tsx
+++ b/Frontend/src/components/layout/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
 import { useNavigate, NavLink } from 'react-router-dom';
 import { useAuthStore, isAdmin as selectIsAdmin, isManager as selectIsManager } from '../../store/authStore';
 import { useSummary } from '../../hooks/useSummaryData';
+import type { DashboardSummary } from '../../types';
 import {
   DndContext,
   closestCenter,
@@ -121,7 +122,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     navigate('/login');
   };
 
-  const [summary] = useSummary<any>('/summary', []);
+  const [summary] = useSummary<DashboardSummary>('/summary', []);
   const completion =
     summary && summary.totalWorkOrders > 0
       ? Math.round((summary.completedWorkOrders / summary.totalWorkOrders) * 100)

--- a/Frontend/src/hooks/useDashboardData.ts
+++ b/Frontend/src/hooks/useDashboardData.ts
@@ -5,6 +5,13 @@ import {
   fetchUpcomingMaintenance,
   fetchCriticalAlerts,
 } from '../utils/api';
+import type {
+  StatusCountResponse,
+  UpcomingMaintenanceItem,
+  UpcomingMaintenanceResponse,
+  CriticalAlertItem,
+  CriticalAlertResponse,
+} from '../types';
 
 interface WorkOrderStatusCounts {
   open: number;
@@ -33,15 +40,20 @@ const useDashboardData = (role?: string) => {
     'In Repair': 0,
   });
 
-  const [upcomingMaintenance, setUpcomingMaintenance] = useState<any[]>([]);
-  const [criticalAlerts, setCriticalAlerts] = useState<any[]>([]);
+  const [upcomingMaintenance, setUpcomingMaintenance] = useState<UpcomingMaintenanceItem[]>([]);
+  const [criticalAlerts, setCriticalAlerts] = useState<CriticalAlertItem[]>([]);
   const [loading, setLoading] = useState(true);
 
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
       const params = role ? { role } : undefined;
-      const [assetSummaryData, workOrders, upcoming, alerts] = await Promise.all([
+      const [assetSummaryData, workOrders, upcoming, alerts] = await Promise.all<[
+        StatusCountResponse[],
+        StatusCountResponse[],
+        UpcomingMaintenanceResponse[],
+        CriticalAlertResponse[],
+      ]>([
         fetchAssetSummary(params),
         fetchWorkOrderSummary(params),
         fetchUpcomingMaintenance(params),

--- a/Frontend/src/hooks/useSummaryData.ts
+++ b/Frontend/src/hooks/useSummaryData.ts
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import api from '../utils/api';
 
 type CacheEntry<T> = { promise?: Promise<T>; data?: T; ts?: number };
-const cache: Record<string, CacheEntry<any>> = {};
+const cache: Record<string, CacheEntry<unknown>> = {};
 
-export function useSummary<T = any>(
+export function useSummary<T = unknown>(
   path: string,
-  deps: any[] = [],
+  deps: unknown[] = [],
   options: { auto?: boolean; poll?: boolean; ttlMs?: number } = {},
 ): [T | undefined, () => Promise<T | undefined>] {
   const { auto = true, poll = true, ttlMs = 30_000 } = options;

--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -22,7 +22,7 @@ import useDashboardData from '../hooks/useDashboardData';
 import { useSummary } from '../hooks/useSummaryData';
  import { getChatSocket } from '../utils/chatSocket';
  
-import type { Department } from '../types';
+import type { Department, DashboardSummary, Part } from '../types';
 import { useSocketStore } from '../store/socketStore';
 
 
@@ -74,13 +74,23 @@ const Dashboard: React.FC = () => {
     maintenanceCompliance: 0,
     inventoryAlerts: 0,
   });
-  const [lowStockParts, setLowStockParts] = useState<any[]>([]);
+  interface LowStockPart {
+    id: string;
+    name: string;
+    quantity: number;
+    reorderPoint: number;
+  }
+  const [lowStockParts, setLowStockParts] = useState<LowStockPart[]>([]);
+  interface AnalyticsData {
+    laborUtilization: number;
+  }
+  const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
   const [departments, setDepartments] = useState<Department[]>([]);
-  const [summary] = useSummary<any>(
+  const [summary] = useSummary<DashboardSummary>(
     `/summary${selectedRole ? `?role=${selectedRole}` : ''}`,
     [selectedRole],
   );
-  const [lowStock] = useSummary<any[]>(
+  const [lowStock] = useSummary<Part[]>(
     `/summary/low-stock${selectedRole ? `?role=${selectedRole}` : ''}`,
     [selectedRole],
   );
@@ -90,7 +100,6 @@ const Dashboard: React.FC = () => {
     { ttlMs: 60_000 },
   );
 
-  const [analytics, setAnalytics] = useState<any | null>(null);
 
 
   useEffect(() => {
@@ -108,7 +117,7 @@ const Dashboard: React.FC = () => {
     const fetchAnalytics = async () => {
       try {
         const query = role ? `?role=${role}` : '';
-        const res = await api.get(`/reports/analytics${query}`);
+        const res = await api.get<AnalyticsData>(`/reports/analytics${query}`);
         setAnalytics(res.data);
       } catch (err) {
         console.error('Error fetching analytics', err);

--- a/Frontend/src/types/index.ts
+++ b/Frontend/src/types/index.ts
@@ -243,6 +243,19 @@ export interface TeamMember {
   avatar?: string;
 }
 
+export interface TeamMemberResponse {
+  _id?: string;
+  id?: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'manager' | 'technician' | 'viewer';
+  department?: string;
+  employeeId?: string;
+  managerId?: string | null;
+  reportsTo?: string | null;
+  avatar?: string;
+}
+
 
 export interface AuthUser {
   id: string;
@@ -291,6 +304,49 @@ export interface DashboardSummary {
   activeWorkOrders: number;
   completedWorkOrders: number;
   overduePmTasks: number;
+}
+
+export interface StatusCountResponse {
+  _id: string;
+  count: number;
+}
+
+export interface UpcomingMaintenanceResponse {
+  _id?: string;
+  id?: string;
+  asset?: { _id?: string; name?: string };
+  nextDue: string;
+  type?: string;
+  assignedTo?: string;
+  estimatedDuration?: number;
+}
+
+export interface UpcomingMaintenanceItem {
+  id: string;
+  assetName: string;
+  assetId: string;
+  date: string;
+  type: string;
+  assignedTo: string;
+  estimatedDuration: number;
+}
+
+export interface CriticalAlertResponse {
+  _id?: string;
+  id?: string;
+  asset?: { name?: string };
+  priority: string;
+  description?: string;
+  title?: string;
+  createdAt: string;
+}
+
+export interface CriticalAlertItem {
+  id: string;
+  assetName: string;
+  severity: string;
+  issue: string;
+  timestamp: string;
 }
 
 

--- a/Frontend/src/utils/api.ts
+++ b/Frontend/src/utils/api.ts
@@ -10,6 +10,10 @@ import type {
   Member,
   Message,
   Channel,
+  StatusCountResponse,
+  UpcomingMaintenanceResponse,
+  CriticalAlertResponse,
+  Part,
 } from "../types";
 
 const baseURL = import.meta.env.VITE_API_URL ?? 'http://localhost:5010/api';
@@ -66,15 +70,25 @@ api.interceptors.response.use(
 export const fetchSummary = (params?: Record<string, any>) =>
   api.get<DashboardSummary>("/summary", { params }).then((res) => res.data);
 export const fetchAssetSummary = (params?: Record<string, any>) =>
-  api.get("/summary/assets", { params }).then((res) => res.data);
+  api
+    .get<StatusCountResponse[]>("/summary/assets", { params })
+    .then((res) => res.data);
 export const fetchWorkOrderSummary = (params?: Record<string, any>) =>
-  api.get("/summary/workorders", { params }).then((res) => res.data);
+  api
+    .get<StatusCountResponse[]>("/summary/workorders", { params })
+    .then((res) => res.data);
 export const fetchUpcomingMaintenance = (params?: Record<string, any>) =>
-  api.get("/summary/upcoming-maintenance", { params }).then((res) => res.data);
+  api
+    .get<UpcomingMaintenanceResponse[]>("/summary/upcoming-maintenance", { params })
+    .then((res) => res.data);
 export const fetchCriticalAlerts = (params?: Record<string, any>) =>
-  api.get("/summary/critical-alerts", { params }).then((res) => res.data);
+  api
+    .get<CriticalAlertResponse[]>("/summary/critical-alerts", { params })
+    .then((res) => res.data);
 export const fetchLowStock = (params?: Record<string, any>) =>
-  api.get("/summary/low-stock", { params }).then((res) => res.data);
+  api
+    .get<Part[]>("/summary/low-stock", { params })
+    .then((res) => res.data);
 
 export const fetchNotifications = (params?: Record<string, any>) =>
   api


### PR DESCRIPTION
## Summary
- add interfaces for dashboard and team member API responses
- type hooks and stores to avoid `any`
- provide generic API helpers for dashboard calls

## Testing
- `npm test` *(fails: vitest not found and npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b53700ab548323a44deada3b308277