### PR TITLE
feat: add strong typing for dashboard and team members

### DIFF
--- a/Frontend/src/components/layout/Sidebar.tsx
+++ b/Frontend/src/components/layout/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
 import { useNavigate, NavLink } from 'react-router-dom';
 import { useAuthStore, isAdmin as selectIsAdmin, isManager as selectIsManager } from '../../store/authStore';
 import { useSummary } from '../../hooks/useSummaryData';
+import type { DashboardSummary } from '../../types';
 import {
   DndContext,
   closestCenter,
@@ -121,7 +122,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     navigate('/login');
   };
 
-  const [summary] = useSummary<any>('/summary', []);
+  const [summary] = useSummary<DashboardSummary>('/summary', []);
   const completion =
     summary && summary.totalWorkOrders > 0
       ? Math.round((summary.completedWorkOrders / summary.totalWorkOrders) * 100)

--- a/Frontend/src/hooks/useDashboardData.ts
+++ b/Frontend/src/hooks/useDashboardData.ts
@@ -5,6 +5,13 @@ import {
   fetchUpcomingMaintenance,
   fetchCriticalAlerts,
 } from '../utils/api';
+import type {
+  StatusCount,
+  UpcomingMaintenanceResponse,
+  UpcomingMaintenanceItem,
+  CriticalAlertResponse,
+  CriticalAlertItem,
+} from '../types';
 
 interface WorkOrderStatusCounts {
   open: number;
@@ -33,8 +40,10 @@ const useDashboardData = (role?: string) => {
     'In Repair': 0,
   });
 
-  const [upcomingMaintenance, setUpcomingMaintenance] = useState<any[]>([]);
-  const [criticalAlerts, setCriticalAlerts] = useState<any[]>([]);
+  const [upcomingMaintenance, setUpcomingMaintenance] = useState<
+    UpcomingMaintenanceItem[]
+  >([]);
+  const [criticalAlerts, setCriticalAlerts] = useState<CriticalAlertItem[]>([]);
   const [loading, setLoading] = useState(true);
 
   const refresh = useCallback(async () => {
@@ -42,10 +51,10 @@ const useDashboardData = (role?: string) => {
     try {
       const params = role ? { role } : undefined;
       const [assetSummaryData, workOrders, upcoming, alerts] = await Promise.all([
-        fetchAssetSummary(params),
-        fetchWorkOrderSummary(params),
-        fetchUpcomingMaintenance(params),
-        fetchCriticalAlerts(params),
+        fetchAssetSummary<StatusCount[]>(params),
+        fetchWorkOrderSummary<StatusCount[]>(params),
+        fetchUpcomingMaintenance<UpcomingMaintenanceResponse[]>(params),
+        fetchCriticalAlerts<CriticalAlertResponse[]>(params),
       ]);
 
       const statusCounts: WorkOrderStatusCounts = {
@@ -75,8 +84,8 @@ const useDashboardData = (role?: string) => {
 
       setUpcomingMaintenance(
         Array.isArray(upcoming)
-          ? upcoming.map((t) => ({
-              id: t._id ?? t.id,
+          ? upcoming.map<UpcomingMaintenanceItem>((t) => ({
+              id: t._id ?? t.id ?? '',
               assetName: t.asset?.name || 'Unknown',
               assetId: t.asset?._id ?? '',
               date: t.nextDue,
@@ -89,11 +98,11 @@ const useDashboardData = (role?: string) => {
 
       setCriticalAlerts(
         Array.isArray(alerts)
-          ? alerts.map((a) => ({
-              id: a._id ?? a.id,
+          ? alerts.map<CriticalAlertItem>((a) => ({
+              id: a._id ?? a.id ?? '',
               assetName: a.asset?.name || 'Unknown',
               severity: a.priority,
-              issue: a.description || a.title,
+              issue: a.description || a.title || '',
               timestamp: a.createdAt,
             }))
           : [],

--- a/Frontend/src/hooks/useSummaryData.ts
+++ b/Frontend/src/hooks/useSummaryData.ts
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import api from '../utils/api';
 
 type CacheEntry<T> = { promise?: Promise<T>; data?: T; ts?: number };
-const cache: Record<string, CacheEntry<any>> = {};
+const cache: Record<string, CacheEntry<unknown>> = {};
 
-export function useSummary<T = any>(
+export function useSummary<T = unknown>(
   path: string,
-  deps: any[] = [],
+  deps: unknown[] = [],
   options: { auto?: boolean; poll?: boolean; ttlMs?: number } = {},
 ): [T | undefined, () => Promise<T | undefined>] {
   const { auto = true, poll = true, ttlMs = 30_000 } = options;
@@ -17,9 +17,9 @@ export function useSummary<T = any>(
 
   const fetcher = useCallback(async () => {
     const now = Date.now();
-    const c = cache[path] || (cache[path] = {});
+    const c = (cache[path] as CacheEntry<T>) || (cache[path] = {} as CacheEntry<T>);
     if (c.data && c.ts && now - c.ts < ttlMs) return c.data as T;
-    if (c.promise) return c.promise as Promise<T>;
+    if (c.promise) return c.promise;
 
     abortRef.current?.abort();
     const controller = new AbortController();

--- a/Frontend/src/store/useTeamMembers.ts
+++ b/Frontend/src/store/useTeamMembers.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import api from '../utils/api';
-import type { TeamMember } from '../types';
+import type { TeamMember, TeamMemberResponse } from '../types';
 
 interface TeamMemberState {
   members: TeamMember[];
@@ -13,9 +13,9 @@ interface TeamMemberState {
 export const useTeamMembers = create<TeamMemberState>((set, get) => ({
   members: [],
   fetchMembers: async () => {
-    const res = await api.get('/team');
-    const members = (res.data as any[]).map((m) => ({
-      id: m._id ?? m.id,
+    const res = await api.get<TeamMemberResponse[]>('/team');
+    const members = res.data.map<TeamMember>((m) => ({
+      id: m._id ?? m.id ?? '',
       name: m.name,
       email: m.email,
       role: m.role,
@@ -23,17 +23,17 @@ export const useTeamMembers = create<TeamMemberState>((set, get) => ({
       employeeId: m.employeeId,
       managerId: m.managerId ?? m.reportsTo ?? null,
       avatar: m.avatar,
-    })) as TeamMember[];
+    }));
     set({ members });
     return members;
   },
   addMember: async (data) => {
     const isForm = data instanceof FormData;
-    const res = await api.post('/team', data, {
+    const res = await api.post<TeamMemberResponse>('/team', data, {
       headers: isForm ? { 'Content-Type': 'multipart/form-data' } : undefined,
     });
-    const member = {
-      id: res.data._id ?? res.data.id,
+    const member: TeamMember = {
+      id: res.data._id ?? res.data.id ?? '',
       name: res.data.name,
       email: res.data.email,
       role: res.data.role,
@@ -41,17 +41,17 @@ export const useTeamMembers = create<TeamMemberState>((set, get) => ({
       employeeId: res.data.employeeId,
       managerId: res.data.managerId ?? res.data.reportsTo ?? null,
       avatar: res.data.avatar,
-    } as TeamMember;
+    };
     set((state) => ({ members: [...state.members, member] }));
     return member;
   },
   updateMember: async (id, data) => {
     const isForm = data instanceof FormData;
-    const res = await api.put(`/team/${id}`, data, {
+    const res = await api.put<TeamMemberResponse>(`/team/${id}`, data, {
       headers: isForm ? { 'Content-Type': 'multipart/form-data' } : undefined,
     });
-    const member = {
-      id: res.data._id ?? res.data.id,
+    const member: TeamMember = {
+      id: res.data._id ?? res.data.id ?? '',
       name: res.data.name,
       email: res.data.email,
       role: res.data.role,
@@ -59,7 +59,7 @@ export const useTeamMembers = create<TeamMemberState>((set, get) => ({
       employeeId: res.data.employeeId,
       managerId: res.data.managerId ?? res.data.reportsTo ?? null,
       avatar: res.data.avatar,
-    } as TeamMember;
+    };
     set((state) => ({
       members: state.members.map((m) => (m.id === id ? member : m)),
     }));

--- a/Frontend/src/types/index.ts
+++ b/Frontend/src/types/index.ts
@@ -243,6 +243,21 @@ export interface TeamMember {
   avatar?: string;
 }
 
+/** Raw response shape returned by the API for team members */
+export interface TeamMemberResponse {
+  _id?: string;
+  id?: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'manager' | 'technician' | 'viewer';
+  department?: string;
+  employeeId?: string;
+  managerId?: string | null;
+  /** Some endpoints may return this field instead of managerId */
+  reportsTo?: string | null;
+  avatar?: string;
+}
+
 
 export interface AuthUser {
   id: string;
@@ -291,6 +306,72 @@ export interface DashboardSummary {
   activeWorkOrders: number;
   completedWorkOrders: number;
   overduePmTasks: number;
+}
+
+/** Generic status/count pair used in dashboard summaries */
+export interface StatusCount {
+  _id: string;
+  count: number;
+}
+
+/** Response shape returned by the low stock endpoint */
+export interface LowStockPartResponse {
+  _id?: string;
+  id?: string;
+  name: string;
+  quantity: number;
+  reorderThreshold?: number;
+  reorderPoint?: number;
+}
+
+/** Simplified state used within the dashboard for low stock parts */
+export interface LowStockPart {
+  id: string;
+  name: string;
+  quantity: number;
+  reorderPoint: number;
+}
+
+/** Response shape for upcoming maintenance tasks */
+export interface UpcomingMaintenanceResponse {
+  _id?: string;
+  id?: string;
+  asset?: { name?: string; _id?: string };
+  nextDue: string;
+  type?: string;
+  assignedTo?: string;
+  estimatedDuration?: number;
+}
+
+/** State shape for upcoming maintenance tasks used in the dashboard */
+export interface UpcomingMaintenanceItem {
+  id: string;
+  assetName: string;
+  assetId: string;
+  date: string;
+  type: string;
+  assignedTo: string;
+  estimatedDuration: number;
+}
+
+/** Response shape for critical alert items */
+export interface CriticalAlertResponse {
+  _id?: string;
+  id?: string;
+  asset?: { name?: string };
+  priority: string;
+  description?: string;
+  title?: string;
+  createdAt: string;
+}
+
+/** State shape for critical alerts displayed on the dashboard */
+export interface CriticalAlertItem {
+  id: string;
+  assetName: string;
+  severity: string;
+  issue: string;
+  timestamp: string;
 }
 
 

--- a/Frontend/src/utils/api.ts
+++ b/Frontend/src/utils/api.ts
@@ -10,6 +10,10 @@ import type {
   Member,
   Message,
   Channel,
+  StatusCount,
+  UpcomingMaintenanceResponse,
+  CriticalAlertResponse,
+  LowStockPartResponse,
 } from "../types";
 
 const baseURL = import.meta.env.VITE_API_URL ?? 'http://localhost:5010/api';
@@ -63,20 +67,28 @@ api.interceptors.response.use(
   },
 );
 
-export const fetchSummary = (params?: Record<string, any>) =>
+export const fetchSummary = (params?: Record<string, unknown>) =>
   api.get<DashboardSummary>("/summary", { params }).then((res) => res.data);
-export const fetchAssetSummary = (params?: Record<string, any>) =>
-  api.get("/summary/assets", { params }).then((res) => res.data);
-export const fetchWorkOrderSummary = (params?: Record<string, any>) =>
-  api.get("/summary/workorders", { params }).then((res) => res.data);
-export const fetchUpcomingMaintenance = (params?: Record<string, any>) =>
-  api.get("/summary/upcoming-maintenance", { params }).then((res) => res.data);
-export const fetchCriticalAlerts = (params?: Record<string, any>) =>
-  api.get("/summary/critical-alerts", { params }).then((res) => res.data);
-export const fetchLowStock = (params?: Record<string, any>) =>
-  api.get("/summary/low-stock", { params }).then((res) => res.data);
+export const fetchAssetSummary = <T = StatusCount[]>(
+  params?: Record<string, unknown>,
+) => api.get<T>("/summary/assets", { params }).then((res) => res.data);
+export const fetchWorkOrderSummary = <T = StatusCount[]>(
+  params?: Record<string, unknown>,
+) => api.get<T>("/summary/workorders", { params }).then((res) => res.data);
+export const fetchUpcomingMaintenance = <T = UpcomingMaintenanceResponse[]>(
+  params?: Record<string, unknown>,
+) =>
+  api
+    .get<T>("/summary/upcoming-maintenance", { params })
+    .then((res) => res.data);
+export const fetchCriticalAlerts = <T = CriticalAlertResponse[]>(
+  params?: Record<string, unknown>,
+) => api.get<T>("/summary/critical-alerts", { params }).then((res) => res.data);
+export const fetchLowStock = <T = LowStockPartResponse[]>(
+  params?: Record<string, unknown>,
+) => api.get<T>("/summary/low-stock", { params }).then((res) => res.data);
 
-export const fetchNotifications = (params?: Record<string, any>) =>
+export const fetchNotifications = (params?: Record<string, unknown>) =>
   api
     .get<NotificationType[]>("/notifications", { params })
     .then((res) => res.data);
@@ -90,7 +102,7 @@ export const fetchDepartments = () =>
   api
     .get<Department[]>("/departments")
     .then((res) =>
-      (res.data as any[]).map((d) => ({ id: d._id ?? d.id, name: d.name })),
+      (res.data as unknown[]).map((d: any) => ({ id: (d as any)._id ?? (d as any).id, name: (d as any).name })),
     );
 
 export const getLines = () => api.get<Line[]>("/lines").then((res) => res.data);
@@ -116,7 +128,7 @@ export const markNotificationRead = (id: string) =>
     .then((res) => res.data);
 
 // Channels
-export const listChannels = (params?: Record<string, any>) =>
+export const listChannels = (params?: Record<string, unknown>) =>
   api.get<Channel[]>("/channels", { params }).then((res) => res.data);
 
 export const createChannel = (payload: Partial<Channel>) =>
@@ -144,7 +156,7 @@ export const removeMember = (channelId: string, memberId: string) =>
 // Messages
 export const listMessages = (
   channelId: string,
-  params?: Record<string, any>,
+  params?: Record<string, unknown>,
 ) =>
   api
     .get<Message[]>(`/channels/${channelId}/messages`, { params })


### PR DESCRIPTION
## Summary
- define interfaces for team member responses and dashboard data
- apply generics to API calls and summary hook
- update dashboard state and team member store to drop `any` casts

## Testing
- `npm test --prefix Frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5371236908323976e25c1aa00212f