### PR TITLE
refactor: require VITE_API_URL env for frontend API

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -50,7 +50,8 @@ The optimized bundle is written to the `dist` folder.
 
 The following variables from `.env.example` configure the frontend:
 
-- `VITE_API_URL` – Base URL for API requests.
+- `VITE_API_URL` – Base URL for API requests. **This must be set**; the frontend
+  throws an error if it's missing.
  - `VITE_SOCKET_URL` – WebSocket endpoint used for real‑time features. **This must be set** to receive live updates; leaving it empty falls back to offline mode.
 - `CORS_ORIGIN` – Origin allowed when using the local API server.
 

--- a/Frontend/src/utils/api.ts
+++ b/Frontend/src/utils/api.ts
@@ -11,8 +11,13 @@ import type {
   Message,
   Channel,
 } from "../types";
+import { config } from "./env";
 
-const baseURL = import.meta.env.VITE_API_URL ?? 'http://localhost:5010/api';
+const baseURL = config.apiUrl;
+
+if (!baseURL) {
+  throw new Error("VITE_API_URL is not defined");
+}
 
 const api = axios.create({
   baseURL,


### PR DESCRIPTION
## Summary
- throw error if `VITE_API_URL` is missing and remove hard-coded default
- document required `VITE_API_URL` frontend environment variable

## Testing
- `npm test` *(fails: vitest not found; npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b53865313c832380557fe92bea1526