### PR TITLE
feat: add typed payload interfaces

### DIFF
--- a/Backend/server.ts
+++ b/Backend/server.ts
@@ -37,6 +37,11 @@ import mongoose from 'mongoose';
 import errorHandler from './middleware/errorHandler';
 import { validateEnv } from './config/validateEnv';
 import { initChatSocket } from './socket/chatSocket';
+import type {
+  WorkOrderUpdatePayload,
+  InventoryUpdatePayload,
+  NotificationPayload,
+} from './types/Payloads';
 
 
 dotenv.config();
@@ -162,15 +167,15 @@ if (process.env.NODE_ENV !== 'test') {
     });
 }
 
-export const emitWorkOrderUpdate = (workOrder: any) => {
+export const emitWorkOrderUpdate = (workOrder: WorkOrderUpdatePayload) => {
   void sendKafkaEvent('workOrderUpdates', workOrder);
 };
 
-export const emitInventoryUpdate = (item: any) => {
+export const emitInventoryUpdate = (item: InventoryUpdatePayload) => {
   void sendKafkaEvent('inventoryUpdates', item);
 };
 
-export const emitNotification = (notification: any) => {
+export const emitNotification = (notification: NotificationPayload) => {
   io.emit('notification', notification);
 };
 

--- a/Backend/types/Payloads.ts
+++ b/Backend/types/Payloads.ts
@@ -1,0 +1,27 @@
+export interface WorkOrderUpdatePayload {
+  _id: string;
+  tenantId: string;
+  title: string;
+  status: 'open' | 'in-progress' | 'on-hold' | 'completed';
+}
+
+export interface InventoryUpdatePayload {
+  _id: string;
+  tenantId: string;
+  name: string;
+  quantity: number;
+}
+
+export type NotificationType = 'info' | 'warning' | 'critical';
+
+export interface NotificationPayload {
+  _id: string;
+  title: string;
+  message: string;
+  type: NotificationType;
+  assetId?: string;
+  tenantId: string;
+  createdAt: Date;
+  read: boolean;
+}
+


### PR DESCRIPTION
## Summary
- define payload interfaces for work orders, inventory items, and notifications
- update server emit helpers to use payload interfaces instead of `any`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b53877ce788323a1e29faef1465b2b