### PR TITLE
fix: remove admin tenants route

### DIFF
--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -55,7 +55,7 @@ function App() {
         <Route path="/notifications" element={<ProtectedRoute><Notifications /></ProtectedRoute>} />
  
         <Route
-          path="/admin/tenants"
+          path="/tenants"
           element={
             <ProtectedRoute role="admin">
               <AdminTenants />


### PR DESCRIPTION
## Summary
- drop legacy `/admin/tenants` route in favor of `/tenants`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b547e489788323a8c5aa2c1347da8e