### PR TITLE
Normalize dashboard summaries and guard widgets

### DIFF
--- a/Frontend/src/components/dashboard/WorkOrdersChart.tsx
+++ b/Frontend/src/components/dashboard/WorkOrdersChart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Card from '../common/Card';
 
 interface WorkOrdersChartProps {
-  data: {
+  data?: {
     open: number;
     inProgress: number;
     onHold: number;
@@ -11,74 +11,87 @@ interface WorkOrdersChartProps {
 }
 
 const WorkOrdersChart: React.FC<WorkOrdersChartProps> = ({ data }) => {
-  const total = data.open + data.inProgress + data.onHold + data.completed;
-  
+  const total =
+    (data?.open ?? 0) +
+    (data?.inProgress ?? 0) +
+    (data?.onHold ?? 0) +
+    (data?.completed ?? 0);
+
   const calculatePercentage = (value: number) => {
     if (total === 0) {
       return 0;
     }
     return Math.round((value / total) * 100);
   };
-  
+
   return (
-    <Card 
-      title="Work Orders by Status"
-      subtitle="Last 30 days performance"
-    >
+    <Card title="Work Orders by Status" subtitle="Last 30 days performance">
       <div className="space-y-4">
         <div className="flex items-center justify-between">
           <div className="w-full max-w-xs bg-neutral-100 rounded-full h-2.5">
-            <div className="bg-primary-600 h-2.5 rounded-full" style={{ width: `${calculatePercentage(data.open)}%` }}></div>
+            <div
+              className="bg-primary-600 h-2.5 rounded-full"
+              style={{ width: `${calculatePercentage(data?.open ?? 0)}%` }}
+            ></div>
           </div>
           <div className="ml-4 min-w-[80px]">
             <div className="flex items-center">
               <div className="w-3 h-3 bg-primary-600 rounded-full mr-2"></div>
               <span className="text-sm font-medium">Open</span>
             </div>
-            <span className="text-lg font-semibold">{data.open}</span>
+            <span className="text-lg font-semibold">{data?.open ?? 0}</span>
           </div>
         </div>
-        
+
         <div className="flex items-center justify-between">
           <div className="w-full max-w-xs bg-neutral-100 rounded-full h-2.5">
-            <div className="bg-accent-500 h-2.5 rounded-full" style={{ width: `${calculatePercentage(data.inProgress)}%` }}></div>
+            <div
+              className="bg-accent-500 h-2.5 rounded-full"
+              style={{ width: `${calculatePercentage(data?.inProgress ?? 0)}%` }}
+            ></div>
           </div>
           <div className="ml-4 min-w-[80px]">
             <div className="flex items-center">
               <div className="w-3 h-3 bg-accent-500 rounded-full mr-2"></div>
               <span className="text-sm font-medium">In Progress</span>
             </div>
-            <span className="text-lg font-semibold">{data.inProgress}</span>
+            <span className="text-lg font-semibold">{data?.inProgress ?? 0}</span>
           </div>
         </div>
-        
+
         <div className="flex items-center justify-between">
           <div className="w-full max-w-xs bg-neutral-100 rounded-full h-2.5">
-            <div className="bg-warning-500 h-2.5 rounded-full" style={{ width: `${calculatePercentage(data.onHold)}%` }}></div>
+            <div
+              className="bg-warning-500 h-2.5 rounded-full"
+              style={{ width: `${calculatePercentage(data?.onHold ?? 0)}%` }}
+            ></div>
           </div>
           <div className="ml-4 min-w-[80px]">
             <div className="flex items-center">
               <div className="w-3 h-3 bg-warning-500 rounded-full mr-2"></div>
               <span className="text-sm font-medium">On Hold</span>
             </div>
-            <span className="text-lg font-semibold">{data.onHold}</span>
+            <span className="text-lg font-semibold">{data?.onHold ?? 0}</span>
           </div>
         </div>
-        
+
         <div className="flex items-center justify-between">
           <div className="w-full max-w-xs bg-neutral-100 rounded-full h-2.5">
-            <div className="bg-success-500 h-2.5 rounded-full" style={{ width: `${calculatePercentage(data.completed)}%` }}></div>
+            <div
+              className="bg-success-500 h-2.5 rounded-full"
+              style={{ width: `${calculatePercentage(data?.completed ?? 0)}%` }}
+            ></div>
           </div>
           <div className="ml-4 min-w-[80px]">
             <div className="flex items-center">
               <div className="w-3 h-3 bg-success-500 rounded-full mr-2"></div>
               <span className="text-sm font-medium">Completed</span>
             </div>
-            <span className="text-lg font-semibold">{data.completed}</span>
+            <span className="text-lg font-semibold">{data?.completed ?? 0}</span>
           </div>
         </div>
       </div>
-      
+
       <div className="mt-6 pt-6 border-t border-neutral-200">
         <div className="flex justify-between">
           <div>
@@ -87,7 +100,7 @@ const WorkOrdersChart: React.FC<WorkOrdersChartProps> = ({ data }) => {
           </div>
           <div>
             <p className="text-sm text-neutral-500">Completion Rate</p>
-            <p className="text-xl font-semibold">{calculatePercentage(data.completed)}%</p>
+            <p className="text-xl font-semibold">{calculatePercentage(data?.completed ?? 0)}%</p>
           </div>
         </div>
       </div>

--- a/Frontend/src/hooks/useDashboardData.ts
+++ b/Frontend/src/hooks/useDashboardData.ts
@@ -1,169 +1,123 @@
-import axios from "axios";
-
+import { useCallback, useEffect, useState } from 'react';
+import api from '../utils/api';
 import type {
-  AuthUser,
-  DashboardSummary,
-  Line,
-  Station,
-  Department,
-  NotificationType,
-  Member,
-  Message,
-  Channel,
   StatusCountResponse,
   UpcomingMaintenanceResponse,
   CriticalAlertResponse,
-  LowStockPartResponse,
-} from "../types";
+  UpcomingMaintenanceItem,
+  CriticalAlertItem,
+} from '../types';
 
-const baseURL = import.meta.env.VITE_API_URL ?? "http://localhost:5010/api";
+// normalize backend work-order status keys to camelCase
+const normalizeWOKey = (key: string): keyof WorkOrderStatusMap => {
+  if (key === 'in-progress') return 'inProgress';
+  if (key === 'on-hold') return 'onHold';
+  return key as keyof WorkOrderStatusMap;
+};
 
-const api = axios.create({
-  baseURL,
-  withCredentials: true,
-});
+interface WorkOrderStatusMap {
+  open: number;
+  inProgress: number;
+  onHold: number;
+  completed: number;
+}
 
-api.interceptors.request.use((config) => {
-  const userStr = localStorage.getItem("user");
-  if (userStr) {
+const defaultWOStatus: WorkOrderStatusMap = {
+  open: 0,
+  inProgress: 0,
+  onHold: 0,
+  completed: 0,
+};
+
+interface AssetStatusMap {
+  Active: number;
+  Offline: number;
+  'In Repair': number;
+}
+
+const defaultAssetStatus: AssetStatusMap = {
+  Active: 0,
+  Offline: 0,
+  'In Repair': 0,
+};
+
+export default function useDashboardData(role?: string) {
+  const [workOrdersByStatus, setWorkOrdersByStatus] = useState<WorkOrderStatusMap>(defaultWOStatus);
+  const [assetsByStatus, setAssetsByStatus] = useState<AssetStatusMap>(defaultAssetStatus);
+  const [upcomingMaintenance, setUpcomingMaintenance] = useState<UpcomingMaintenanceItem[]>([]);
+  const [criticalAlerts, setCriticalAlerts] = useState<CriticalAlertItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
     try {
-      const { token, tenantId } = JSON.parse(userStr) as AuthUser;
-      config.headers = config.headers ?? {};
-      if (token) (config.headers as any).Authorization = `Bearer ${token}`;
-      if (tenantId) (config.headers as any)["x-tenant-id"] = tenantId;
-    } catch {
-      // ignore parse errors
-    }
-  }
-  return config;
-});
+      const query = role ? `?role=${role}` : '';
+      const [woRes, assetRes, upcomingRes, alertRes] = await Promise.all([
+        api.get<StatusCountResponse[]>(`/summary/workorders${query}`),
+        api.get<StatusCountResponse[]>(`/summary/assets${query}`),
+        api.get<UpcomingMaintenanceResponse[]>(`/summary/upcoming-maintenance${query}`),
+        api.get<CriticalAlertResponse[]>(`/summary/critical-alerts${query}`),
+      ]);
 
-api.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    if (
-      error.response?.status === 401 &&
-      error.config?.url !== "/auth/logout" &&
-      error.config?.url !== "/auth/login"
-    ) {
-      try {
-        await api.post("/auth/logout");
-      } catch {
-        // ignore
-      } finally {
-        if (typeof window !== "undefined") {
-          localStorage.removeItem("user");
-          localStorage.removeItem("auth-storage");
-          window.location.href = "/login";
-        }
+      const woCounts: WorkOrderStatusMap = { ...defaultWOStatus };
+      if (Array.isArray(woRes.data)) {
+        woRes.data.forEach(({ _id, count }) => {
+          const key = normalizeWOKey(_id as string);
+          if (key in woCounts) woCounts[key] = count;
+        });
       }
+      setWorkOrdersByStatus(woCounts);
+
+      const assetCounts: AssetStatusMap = { ...defaultAssetStatus };
+      if (Array.isArray(assetRes.data)) {
+        assetRes.data.forEach(({ _id, count }) => {
+          if (_id in assetCounts) {
+            assetCounts[_id as keyof AssetStatusMap] = count;
+          }
+        });
+      }
+      setAssetsByStatus(assetCounts);
+
+      const upcoming: UpcomingMaintenanceItem[] = Array.isArray(upcomingRes.data)
+        ? upcomingRes.data.map((u) => ({
+            id: u._id ?? u.id ?? '',
+            assetName: u.asset?.name ?? 'Unknown',
+            assetId: u.asset?._id ?? u.asset?.id ?? '',
+            date: u.nextDue,
+            type: u.type ?? '',
+            assignedTo: u.assignedTo ?? '',
+            estimatedDuration: u.estimatedDuration ?? 0,
+          }))
+        : [];
+      setUpcomingMaintenance(upcoming);
+
+      const alerts: CriticalAlertItem[] = Array.isArray(alertRes.data)
+        ? alertRes.data.map((a) => ({
+            id: a._id ?? a.id ?? '',
+            assetName: a.asset?.name ?? 'Unknown',
+            severity: a.priority,
+            issue: a.description ?? a.title ?? '',
+            timestamp: a.createdAt,
+          }))
+        : [];
+      setCriticalAlerts(alerts);
+    } catch (err) {
+      console.error('dashboard refresh failed', err);
+    } finally {
+      setLoading(false);
     }
-    return Promise.reject(error);
-  },
-);
+  }, [role]);
 
-// ----- Summary endpoints -----
-export const fetchSummary = (params?: Record<string, unknown>) =>
-  api.get<DashboardSummary>("/summary", { params }).then((res) => res.data);
+  useEffect(() => {
+    refresh().catch(() => {});
+  }, [refresh]);
 
-export const fetchAssetSummary = (params?: Record<string, unknown>) =>
-  api.get<StatusCountResponse[]>("/summary/assets", { params }).then((res) => res.data);
-
-export const fetchWorkOrderSummary = (params?: Record<string, unknown>) =>
-  api.get<StatusCountResponse[]>("/summary/workorders", { params }).then((res) => res.data);
-
-export const fetchUpcomingMaintenance = (params?: Record<string, unknown>) =>
-  api
-    .get<UpcomingMaintenanceResponse[]>("/summary/upcoming-maintenance", { params })
-    .then((res) => res.data);
-
-export const fetchCriticalAlerts = (params?: Record<string, unknown>) =>
-  api
-    .get<CriticalAlertResponse[]>("/summary/critical-alerts", { params })
-    .then((res) => res.data);
-
-export const fetchLowStock = (params?: Record<string, unknown>) =>
-  api
-    .get<LowStockPartResponse[]>("/summary/low-stock", { params })
-    .then((res) => res.data);
-
-// ----- Notifications -----
-export const fetchNotifications = (params?: Record<string, unknown>) =>
-  api.get<NotificationType[]>("/notifications", { params }).then((res) => res.data);
-
-export const updateNotification = (id: string, data: Partial<NotificationType>) =>
-  api.put<NotificationType>(`/notifications/${id}`, data).then((res) => res.data);
-
-export const getNotifications = () =>
-  api.get<NotificationType[]>("/notifications").then((res) => res.data);
-
-export const createNotification = (payload: Partial<NotificationType>) =>
-  api.post<NotificationType>("/notifications", payload).then((res) => res.data);
-
-export const markNotificationRead = (id: string) =>
-  api.patch<NotificationType>(`/notifications/${id}/read`).then((res) => res.data);
-
-// ----- Org data -----
-export const fetchDepartments = () =>
-  api.get<Department[]>("/departments").then((res) =>
-    (res.data as unknown[]).map((d: any) => ({
-      id: (d as any)._id ?? (d as any).id,
-      name: (d as any).name,
-    })),
-  );
-
-export const getLines = () => api.get<Line[]>("/lines").then((res) => res.data);
-
-export const getStationsByLine = (lineId: string) =>
-  api.get<Station[]>(`/stations/line/${lineId}`).then((res) => res.data);
-
-// ----- Search -----
-export const searchAssets = (q: string) =>
-  api.get("/assets/search", { params: { q } }).then((res) => res.data);
-
-export const searchParts = (q: string) =>
-  api.get("/inventory/search", { params: { q } }).then((res) => res.data);
-
-// ----- Channels & Messages -----
-export const listChannels = (params?: Record<string, unknown>) =>
-  api.get<Channel[]>("/channels", { params }).then((res) => res.data);
-
-export const createChannel = (payload: Partial<Channel>) =>
-  api.post<Channel>("/channels", payload).then((res) => res.data);
-
-export const togglePin = (id: string) =>
-  api.post<Channel>(`/channels/${id}/pin`).then((res) => res.data);
-
-export const toggleMute = (id: string) =>
-  api.post<Channel>(`/channels/${id}/mute`).then((res) => res.data);
-
-export const getChannelMembers = (channelId: string) =>
-  api.get<Member[]>(`/channels/${channelId}/members`).then((res) => res.data);
-
-export const addMembers = (channelId: string, members: string[]) =>
-  api.post<Channel>(`/channels/${channelId}/members`, { members }).then((res) => res.data);
-
-export const removeMember = (channelId: string, memberId: string) =>
-  api.delete<Channel>(`/channels/${channelId}/members/${memberId}`).then((res) => res.data);
-
-// Messages
-export const listMessages = (channelId: string, params?: Record<string, unknown>) =>
-  api.get<Message[]>(`/channels/${channelId}/messages`, { params }).then((res) => res.data);
-
-export const sendMessage = (channelId: string, payload: Partial<Message>) =>
-  api.post<Message>(`/channels/${channelId}/messages`, payload).then((res) => res.data);
-
-export const reactMessage = (channelId: string, messageId: string, reaction: { emoji: string }) =>
-  api
-    .post<Message>(`/channels/${channelId}/messages/${messageId}/reactions`, reaction)
-    .then((res) => res.data);
-
-export const markMessageRead = (channelId: string, messageId: string) =>
-  api.post<Message>(`/channels/${channelId}/messages/${messageId}/read`).then((res) => res.data);
-
-export const searchMessages = (channelId: string, q: string) =>
-  api
-    .get<Message[]>(`/channels/${channelId}/messages/search`, { params: { q } })
-    .then((res) => res.data);
-
-export default api;
+  return {
+    workOrdersByStatus,
+    assetsByStatus,
+    upcomingMaintenance,
+    criticalAlerts,
+    refresh,
+    loading,
+  };
+}

--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -182,18 +182,18 @@ const Dashboard: React.FC = () => {
           <div className="rounded-xl border p-4">
             <h2 className="font-semibold mb-2">Work Orders by Status</h2>
             <ul className="space-y-1 text-sm">
-              <li>Open: <b>{workOrdersByStatus.open}</b></li>
-              <li>In Progress: <b>{workOrdersByStatus.inProgress}</b></li>
-              <li>On Hold: <b>{workOrdersByStatus.onHold}</b></li>
-              <li>Completed: <b>{workOrdersByStatus.completed}</b></li>
+              <li>Open: <b>{workOrdersByStatus?.open ?? 0}</b></li>
+              <li>In Progress: <b>{workOrdersByStatus?.inProgress ?? 0}</b></li>
+              <li>On Hold: <b>{workOrdersByStatus?.onHold ?? 0}</b></li>
+              <li>Completed: <b>{workOrdersByStatus?.completed ?? 0}</b></li>
             </ul>
           </div>
           <div className="rounded-xl border p-4">
             <h2 className="font-semibold mb-2">Assets by Status</h2>
             <ul className="space-y-1 text-sm">
-              <li>Active: <b>{assetsByStatus.Active}</b></li>
-              <li>Offline: <b>{assetsByStatus.Offline}</b></li>
-              <li>In Repair: <b>{assetsByStatus['In Repair']}</b></li>
+              <li>Active: <b>{assetsByStatus?.Active ?? 0}</b></li>
+              <li>Offline: <b>{assetsByStatus?.Offline ?? 0}</b></li>
+              <li>In Repair: <b>{assetsByStatus?.['In Repair'] ?? 0}</b></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Consolidate dashboard data fetching into hook using shared API client
- Map work order and asset status counts with defaults and normalization
- Safeguard dashboard components with optional chaining to render without data

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b547e447208323ab4ec30107735ab3