### PR TITLE
Add unit of measure support with conversions

### DIFF
--- a/Backend/routes/InventoryRoutes.ts
+++ b/Backend/routes/InventoryRoutes.ts
@@ -8,6 +8,7 @@ import {
   deleteInventoryItem,
   getLowStockItems,
   searchInventoryItems,
+  useInventoryItem,
 } from '../controllers/InventoryController';
 import { requireAuth } from '../middleware/authMiddleware';
 
@@ -25,6 +26,7 @@ router.get('/', getAllInventoryItems);
 router.get('/:id', getInventoryItemById);
 router.post('/', createInventoryItem);
 router.put('/:id', updateInventoryItem);
+router.post('/:id/use', useInventoryItem);
 router.delete('/:id', deleteInventoryItem);
 
 export default router;

--- a/Backend/scripts/migrations/uom.js
+++ b/Backend/scripts/migrations/uom.js
@@ -1,0 +1,33 @@
+const { MongoClient, ObjectId } = require('mongodb');
+
+async function run() {
+  const uri = process.env.MONGO_URI || 'mongodb://localhost:27017/workpro';
+  const client = new MongoClient(uri);
+
+  const eachId = new ObjectId();
+  const caseId = new ObjectId();
+
+  try {
+    await client.connect();
+    const db = client.db();
+
+    await db.collection('unitOfMeasure').insertMany([
+      { _id: eachId, name: 'Each', abbr: 'ea' },
+      { _id: caseId, name: 'Case', abbr: 'case' },
+    ]);
+
+    await db.collection('conversions').insertMany([
+      { from: caseId, to: eachId, factor: 12 },
+      { from: eachId, to: caseId, factor: 1 / 12 },
+    ]);
+
+    console.log('UoM migration complete');
+  } finally {
+    await client.close();
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add migration script creating `unitOfMeasure` and `conversions` collections
- reference unit of measure in inventory items and support quantity conversion
- expose usage endpoint with tests for case↔each conversion and error handling

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b54a95b0fc8323a3db2cdb0defeffe