### PR TITLE
feat: add site scoped inventory and shared parts

### DIFF
--- a/Backend/controllers/AssetController.ts
+++ b/Backend/controllers/AssetController.ts
@@ -12,7 +12,9 @@ export const getAllAssets: AuthedRequestHandler = async (
   next
 ) => {
   try {
-    const assets = await Asset.find({ tenantId: req.tenantId });
+    const filter: any = { tenantId: req.tenantId };
+    if (req.siteId) filter.siteId = req.siteId;
+    const assets = await Asset.find(filter);
     res.json(assets);
   } catch (err) {
     next(err);
@@ -25,7 +27,9 @@ export const getAssetById: AuthedRequestHandler = async (
   next
 ) => {
   try {
-    const asset = await Asset.findOne({ _id: req.params.id, tenantId: req.tenantId });
+    const filter: any = { _id: req.params.id, tenantId: req.tenantId };
+    if (req.siteId) filter.siteId = req.siteId;
+    const asset = await Asset.findOne(filter);
     if (!asset) return res.status(404).json({ message: 'Not found' });
     res.json(asset);
   } catch (err) {
@@ -63,7 +67,9 @@ export const createAsset: AuthedRequestHandler = async (
 
     const tenantId = resolvedTenantId;
 
-    const newAsset = await Asset.create({ ...req.body, tenantId });
+    const payload: any = { ...req.body, tenantId };
+    if (req.siteId && !payload.siteId) payload.siteId = req.siteId;
+    const newAsset = await Asset.create(payload);
     const assetObj = newAsset.toObject();
     const response = { ...assetObj, tenantId: assetObj.tenantId.toString() };
 
@@ -96,8 +102,10 @@ export const updateAsset: AuthedRequestHandler = async (
     if (!errors.isEmpty()) {
       return res.status(400).json({ errors: errors.array() });
     }
+    const filter: any = { _id: req.params.id, tenantId };
+    if (req.siteId) filter.siteId = req.siteId;
     const asset = await Asset.findOneAndUpdate(
-      { _id: req.params.id, tenantId },
+      filter,
       req.body,
       {
         new: true,
@@ -117,7 +125,9 @@ export const deleteAsset: AuthedRequestHandler = async (
   next
 ) => {
   try {
-    const asset = await Asset.findOneAndDelete({ _id: req.params.id, tenantId: req.tenantId });
+    const filter: any = { _id: req.params.id, tenantId: req.tenantId };
+    if (req.siteId) filter.siteId = req.siteId;
+    const asset = await Asset.findOneAndDelete(filter);
     if (!asset) return res.status(404).json({ message: 'Not found' });
     res.json({ message: 'Deleted successfully' });
   } catch (err) {
@@ -133,10 +143,12 @@ export const searchAssets: AuthedRequestHandler = async (
   try {
     const q = (req.query.q as string) || '';
     const regex = new RegExp(q, 'i');
-    const assets = await Asset.find({
+    const filter: any = {
       name: { $regex: regex },
       tenantId: req.tenantId,
-    }).limit(10);
+    };
+    if (req.siteId) filter.siteId = req.siteId;
+    const assets = await Asset.find(filter).limit(10);
     res.json(assets);
   } catch (err) {
     next(err);

--- a/Backend/middleware/siteScope.ts
+++ b/Backend/middleware/siteScope.ts
@@ -1,0 +1,12 @@
+import { RequestHandler } from 'express';
+
+// Middleware to capture x-site-id header and attach to request
+const siteScope: RequestHandler = (req, _res, next) => {
+  const siteId = req.header('x-site-id');
+  if (siteId) {
+    (req as any).siteId = siteId;
+  }
+  next();
+};
+
+export default siteScope;

--- a/Backend/models/Asset.ts
+++ b/Backend/models/Asset.ts
@@ -29,6 +29,11 @@ const assetSchema = new mongoose.Schema(
       required: true,
       index: true,
     },
+    siteId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Site',
+      index: true,
+    },
     criticality: {
       type: String,
       enum: ['high', 'medium', 'low'],

--- a/Backend/models/Inventory.ts
+++ b/Backend/models/Inventory.ts
@@ -13,7 +13,9 @@ const inventorySchema = new mongoose.Schema({
   vendor: { type: mongoose.Schema.Types.ObjectId, ref: 'Vendor' },
   lastRestockDate: Date,
   lastOrderDate: Date,
-  image: String
+  image: String,
+  siteId: { type: mongoose.Schema.Types.ObjectId, ref: 'Site', index: true },
+  sharedPartId: { type: mongoose.Schema.Types.ObjectId, ref: 'SharedPart' },
 }, { timestamps: true });
 
 export default mongoose.model('Inventory', inventorySchema);

--- a/Backend/models/InventoryItem.ts
+++ b/Backend/models/InventoryItem.ts
@@ -22,6 +22,8 @@ export interface IInventoryItem extends Document {
   vendor?: Types.ObjectId;
   asset?: Types.ObjectId;
   image?: string;
+  siteId?: Types.ObjectId;
+  sharedPartId?: Types.ObjectId;
   consume: (amount: number, fromUom: Types.ObjectId) => Promise<IInventoryItem>;
 }
 
@@ -46,6 +48,8 @@ const inventoryItemSchema = new Schema<IInventoryItem>(
     vendor: { type: Schema.Types.ObjectId, ref: 'Vendor' },
     asset: { type: Schema.Types.ObjectId, ref: 'Asset' },
     image: String,
+    siteId: { type: Schema.Types.ObjectId, ref: 'Site', index: true },
+    sharedPartId: { type: Schema.Types.ObjectId, ref: 'SharedPart' },
   },
   { timestamps: true }
 );

--- a/Backend/models/RequestForm.ts
+++ b/Backend/models/RequestForm.ts
@@ -4,6 +4,7 @@ const requestFormSchema = new mongoose.Schema(
   {
     slug: { type: String, required: true, unique: true },
     schema: { type: mongoose.Schema.Types.Mixed, required: true },
+    siteId: { type: mongoose.Schema.Types.ObjectId, ref: 'Site', index: true },
   },
   { timestamps: true }
 );

--- a/Backend/models/SharedPart.ts
+++ b/Backend/models/SharedPart.ts
@@ -1,0 +1,18 @@
+import mongoose from 'mongoose';
+
+const sharedPartSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    description: String,
+    partNumber: String,
+    tenantId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Tenant',
+      required: true,
+      index: true,
+    },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('SharedPart', sharedPartSchema);

--- a/Backend/models/Site.ts
+++ b/Backend/models/Site.ts
@@ -1,0 +1,28 @@
+import mongoose from 'mongoose';
+
+const siteSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    tenantId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Tenant',
+      required: true,
+      index: true,
+    },
+  },
+  { timestamps: true }
+);
+
+// Enforce per-tenant site creation limits using Tenant.maxSites
+siteSchema.pre('save', async function (next) {
+  const Site = this.constructor as mongoose.Model<any>;
+  const tenant = await mongoose.model('Tenant').findById(this.tenantId);
+  const max = (tenant as any)?.maxSites ?? Infinity;
+  const count = await Site.countDocuments({ tenantId: this.tenantId });
+  if (count >= max) {
+    return next(new Error('Site limit reached'));
+  }
+  next();
+});
+
+export default mongoose.model('Site', siteSchema);

--- a/Backend/models/Tenant.ts
+++ b/Backend/models/Tenant.ts
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 const tenantSchema = new mongoose.Schema(
   {
     name: { type: String, required: true },
+    maxSites: { type: Number, default: 5 },
   },
   { timestamps: true }
 );

--- a/Backend/routes/AssetRoutes.ts
+++ b/Backend/routes/AssetRoutes.ts
@@ -12,6 +12,7 @@ import { requireAuth } from '../middleware/authMiddleware';
 import requireRole from '../middleware/requireRole';
 import { validate } from '../middleware/validationMiddleware';
 import { assetValidators } from '../validators/assetValidators';
+import siteScope from '../middleware/siteScope';
 
 const router = express.Router();
 
@@ -39,6 +40,7 @@ const handleUpload: express.RequestHandler = (req, res, next) => {
 };
 
 router.use(requireAuth);
+router.use(siteScope);
 router.get('/', getAllAssets);
 router.get('/search', searchAssets);
 router.get('/:id', getAssetById);

--- a/Backend/routes/InventoryRoutes.ts
+++ b/Backend/routes/InventoryRoutes.ts
@@ -11,10 +11,12 @@ import {
   useInventoryItem,
 } from '../controllers/InventoryController';
 import { requireAuth } from '../middleware/authMiddleware';
+import siteScope from '../middleware/siteScope';
 
 const router = express.Router();
 
 router.use(requireAuth);
+router.use(siteScope);
 
 // Summary route retained for dashboards
 router.get('/summary', getInventoryItems);

--- a/Backend/scripts/migrations/addSiteId.js
+++ b/Backend/scripts/migrations/addSiteId.js
@@ -1,0 +1,22 @@
+const { MongoClient } = require('mongodb');
+
+async function run() {
+  const uri = process.env.MONGO_URI || 'mongodb://localhost:27017/workpro';
+  const client = new MongoClient(uri);
+
+  try {
+    await client.connect();
+    const db = client.db();
+    await db.collection('assets').updateMany({ siteId: { $exists: false } }, { $set: { siteId: null } });
+    await db.collection('inventoryitems').updateMany({ siteId: { $exists: false } }, { $set: { siteId: null } });
+    await db.collection('requestforms').updateMany({ siteId: { $exists: false } }, { $set: { siteId: null } });
+    console.log('addSiteId migration complete');
+  } finally {
+    await client.close();
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/Backend/tests/sharedPartLinking.test.ts
+++ b/Backend/tests/sharedPartLinking.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import SharedPart from '../models/SharedPart';
+import InventoryItem from '../models/InventoryItem';
+
+let mongo: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+});
+
+describe('Shared part linking', () => {
+  it('links inventory to shared part', async () => {
+    const tenantId = new mongoose.Types.ObjectId();
+    const siteId = new mongoose.Types.ObjectId();
+
+    const part = await SharedPart.create({
+      name: 'Bolt',
+      tenantId,
+    });
+
+    const item = await InventoryItem.create({
+      name: 'Bolt stock',
+      quantity: 5,
+      tenantId,
+      siteId,
+      sharedPartId: part._id,
+    });
+
+    const fetched = await InventoryItem.findById(item._id).populate('sharedPartId').lean();
+    expect(fetched?.sharedPartId).toBeDefined();
+    expect((fetched!.sharedPartId as any).name).toBe('Bolt');
+  });
+});

--- a/Backend/tests/siteIsolation.test.ts
+++ b/Backend/tests/siteIsolation.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import User from '../models/User';
+import AssetRoutes from '../routes/AssetRoutes';
+
+const app = express();
+app.use(express.json());
+app.use('/api/assets', AssetRoutes);
+
+let mongo: MongoMemoryServer;
+let token: string;
+let user: Awaited<ReturnType<typeof User.create>>;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+  user = await User.create({
+    name: 'Tester',
+    email: 'tester@example.com',
+    password: 'pass123',
+    role: 'manager',
+    tenantId: new mongoose.Types.ObjectId(),
+  });
+  token = jwt.sign({ id: user._id.toString(), role: user.role }, process.env.JWT_SECRET!);
+});
+
+describe('Site isolation', () => {
+  it('returns assets scoped to site header', async () => {
+    const siteA = new mongoose.Types.ObjectId();
+    const siteB = new mongoose.Types.ObjectId();
+
+    await request(app)
+      .post('/api/assets')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'A', type: 'Mechanical', location: 'L', siteId: siteA })
+      .expect(201);
+    await request(app)
+      .post('/api/assets')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'B', type: 'Mechanical', location: 'L', siteId: siteB })
+      .expect(201);
+
+    const res = await request(app)
+      .get('/api/assets')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-site-id', siteA.toString())
+      .expect(200);
+
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].name).toBe('A');
+  });
+});

--- a/Backend/tests/siteModel.test.ts
+++ b/Backend/tests/siteModel.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import Tenant from '../models/Tenant';
+import Site from '../models/Site';
+
+let mongo: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+});
+
+describe('Site creation limits', () => {
+  it('prevents creating more sites than allowed', async () => {
+    const tenant = await Tenant.create({ name: 'T1', maxSites: 1 });
+    await Site.create({ name: 'Main', tenantId: tenant._id });
+    await expect(Site.create({ name: 'Extra', tenantId: tenant._id })).rejects.toThrow(
+      /Site limit reached/
+    );
+  });
+});

--- a/Backend/types/AuthedRequest.ts
+++ b/Backend/types/AuthedRequest.ts
@@ -9,4 +9,5 @@ export interface AuthedRequest<P = any, ResBody = any, ReqBody = any, ReqQuery =
   extends Request<P, ResBody, ReqBody, ReqQuery> {
   user: RequestUser;
   tenantId: string;
+  siteId?: string;
 }

--- a/Backend/types/express/index.d.ts
+++ b/Backend/types/express/index.d.ts
@@ -20,6 +20,11 @@ declare global {
        */
       tenantId?: string;
 
+      /**
+       * Optional site identifier supplied by siteScope middleware.
+       */
+      siteId?: string;
+
       thirdParty?: any;
     }
   }

--- a/Frontend/src/store/siteStore.ts
+++ b/Frontend/src/store/siteStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface SiteState {
+  siteId: string | null;
+  setSiteId: (id: string | null) => void;
+}
+
+export const useSiteStore = create<SiteState>()(
+  persist(
+    (set) => ({
+      siteId: null,
+      setSiteId: (id) => set({ siteId: id }),
+    }),
+    { name: 'site-storage' }
+  )
+);

--- a/Frontend/src/utils/api.ts
+++ b/Frontend/src/utils/api.ts
@@ -41,6 +41,19 @@ api.interceptors.request.use((cfg) => {
       // ignore parse errors
     }
   }
+  const siteStr = localStorage.getItem('site-storage');
+  if (siteStr) {
+    try {
+      const { state } = JSON.parse(siteStr);
+      const siteId = state?.siteId;
+      if (siteId) {
+        cfg.headers = cfg.headers ?? {};
+        (cfg.headers as any)['x-site-id'] = siteId;
+      }
+    } catch {
+      // ignore
+    }
+  }
   return cfg;
 });
 


### PR DESCRIPTION
## Summary
- add Site and SharedPart models with tenant site limits
- scope assets and inventory to sites and shared parts
- track selected site on the frontend and send site headers

## Testing
- `npm test` (fails: vitest not found)
- `npm test` in `Frontend` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68b54e397e08832390aa9b2dc3124de0