### PR TITLE
feat: add purchase order and goods receipt handling

### DIFF
--- a/Backend/controllers/GoodsReceiptController.ts
+++ b/Backend/controllers/GoodsReceiptController.ts
@@ -1,0 +1,61 @@
+import { Request, Response, NextFunction } from 'express';
+import GoodsReceipt from '../models/GoodsReceipt';
+import PurchaseOrder from '../models/PurchaseOrder';
+import Vendor from '../models/Vendor';
+import { addStock } from '../services/inventory';
+import nodemailer from 'nodemailer';
+
+export const createGoodsReceipt = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const tenantId = (req as any).tenantId as string | undefined;
+    const { purchaseOrder: poId, items } = req.body as any;
+
+    const po = await PurchaseOrder.findById(poId);
+    if (!po) return res.status(404).json({ message: 'PO not found' });
+
+    for (const grItem of items) {
+      await addStock(grItem.item, grItem.quantity, grItem.uom);
+      const poItem = po.items.find((i) => i.item.toString() === grItem.item);
+      if (poItem) {
+        let qty = grItem.quantity;
+        if (grItem.uom && poItem.uom && grItem.uom.toString() !== poItem.uom.toString()) {
+          const conv = await (await import('mongoose')).default.connection.db
+            .collection('conversions')
+            .findOne({ from: grItem.uom, to: poItem.uom });
+          if (conv) qty = qty * conv.factor;
+        }
+        poItem.received += qty;
+      }
+    }
+
+    if (po.items.every((i) => i.received >= i.quantity)) {
+      po.status = 'closed';
+    }
+
+    await po.save();
+
+    const gr = await GoodsReceipt.create({
+      purchaseOrder: po._id,
+      items,
+      ...(tenantId ? { tenantId } : {}),
+    });
+
+    const vendor = await Vendor.findById(po.vendor).lean();
+    if (vendor?.email) {
+      const transporter = nodemailer.createTransport({ jsonTransport: true });
+      await transporter.sendMail({
+        to: vendor.email,
+        subject: `Goods received for PO ${po._id}`,
+        text: 'Items received',
+      });
+    }
+
+    res.status(201).json(gr);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/Backend/controllers/PurchaseOrderController.ts
+++ b/Backend/controllers/PurchaseOrderController.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from 'express';
+import PurchaseOrder from '../models/PurchaseOrder';
+
+export const createPurchaseOrder = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const tenantId = (req as any).tenantId as string | undefined;
+    const po = await PurchaseOrder.create({
+      ...req.body,
+      ...(tenantId ? { tenantId } : {}),
+    });
+    res.status(201).json(po);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getPurchaseOrder = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { id } = req.params;
+    const po = await PurchaseOrder.findById(id).lean();
+    if (!po) return res.status(404).json({ message: 'Not found' });
+    res.json(po);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/Backend/models/GoodsReceipt.ts
+++ b/Backend/models/GoodsReceipt.ts
@@ -1,0 +1,32 @@
+import mongoose, { Schema, Types, Document } from 'mongoose';
+
+export interface IGoodsReceiptItem {
+  item: Types.ObjectId;
+  quantity: number;
+  uom?: Types.ObjectId;
+}
+
+export interface IGoodsReceipt extends Document {
+  tenantId: Types.ObjectId;
+  purchaseOrder: Types.ObjectId;
+  items: IGoodsReceiptItem[];
+  receiptDate: Date;
+}
+
+const goodsReceiptSchema = new Schema<IGoodsReceipt>(
+  {
+    tenantId: { type: Schema.Types.ObjectId, ref: 'Tenant', required: true, index: true },
+    purchaseOrder: { type: Schema.Types.ObjectId, ref: 'PurchaseOrder', required: true },
+    items: [
+      {
+        item: { type: Schema.Types.ObjectId, ref: 'InventoryItem', required: true },
+        quantity: { type: Number, required: true },
+        uom: { type: Schema.Types.ObjectId, ref: 'unitOfMeasure' },
+      },
+    ],
+    receiptDate: { type: Date, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model<IGoodsReceipt>('GoodsReceipt', goodsReceiptSchema);

--- a/Backend/models/PurchaseOrder.ts
+++ b/Backend/models/PurchaseOrder.ts
@@ -1,0 +1,36 @@
+import mongoose, { Schema, Types, Document } from 'mongoose';
+
+export interface IPurchaseOrderItem {
+  item: Types.ObjectId;
+  quantity: number;
+  uom?: Types.ObjectId;
+  unitCost?: number;
+  received: number;
+}
+
+export interface IPurchaseOrder extends Document {
+  tenantId: Types.ObjectId;
+  vendor: Types.ObjectId;
+  items: IPurchaseOrderItem[];
+  status: 'open' | 'closed';
+}
+
+const purchaseOrderSchema = new Schema<IPurchaseOrder>(
+  {
+    tenantId: { type: Schema.Types.ObjectId, ref: 'Tenant', required: true, index: true },
+    vendor: { type: Schema.Types.ObjectId, ref: 'Vendor', required: true },
+    items: [
+      {
+        item: { type: Schema.Types.ObjectId, ref: 'InventoryItem', required: true },
+        quantity: { type: Number, required: true },
+        uom: { type: Schema.Types.ObjectId, ref: 'unitOfMeasure' },
+        unitCost: Number,
+        received: { type: Number, default: 0 },
+      },
+    ],
+    status: { type: String, enum: ['open', 'closed'], default: 'open' },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model<IPurchaseOrder>('PurchaseOrder', purchaseOrderSchema);

--- a/Backend/routes/GoodsReceiptRoutes.ts
+++ b/Backend/routes/GoodsReceiptRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { createGoodsReceipt } from '../controllers/GoodsReceiptController';
+
+const router = Router();
+
+router.post('/', createGoodsReceipt);
+
+export default router;

--- a/Backend/routes/PurchaseOrderRoutes.ts
+++ b/Backend/routes/PurchaseOrderRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { createPurchaseOrder, getPurchaseOrder } from '../controllers/PurchaseOrderController';
+
+const router = Router();
+
+router.post('/', createPurchaseOrder);
+router.get('/:id', getPurchaseOrder);
+
+export default router;

--- a/Backend/services/inventory.ts
+++ b/Backend/services/inventory.ts
@@ -1,0 +1,26 @@
+import mongoose, { Types } from 'mongoose';
+import InventoryItem from '../models/InventoryItem';
+
+/**
+ * Increase inventory for an item, converting units if needed.
+ */
+export const addStock = async (
+  itemId: Types.ObjectId,
+  quantity: number,
+  fromUom?: Types.ObjectId,
+) => {
+  const item = await InventoryItem.findById(itemId);
+  if (!item) throw new Error('Item not found');
+
+  let baseQty = quantity;
+  if (fromUom && item.uom && item.uom.toString() !== fromUom.toString()) {
+    const conv = await mongoose.connection
+      .db.collection('conversions')
+      .findOne({ from: fromUom, to: item.uom });
+    if (!conv) throw new Error('Conversion not found');
+    baseQty = quantity * conv.factor;
+  }
+  item.quantity += baseQty;
+  await item.save();
+  return item;
+};

--- a/Backend/tests/purchaseOrderLifecycle.test.ts
+++ b/Backend/tests/purchaseOrderLifecycle.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+
+import purchaseOrderRoutes from '../routes/PurchaseOrderRoutes';
+import goodsReceiptRoutes from '../routes/GoodsReceiptRoutes';
+import InventoryItem from '../models/InventoryItem';
+import PurchaseOrder from '../models/PurchaseOrder';
+import User from '../models/User';
+import Vendor from '../models/Vendor';
+import nodemailer from 'nodemailer';
+
+vi.mock('nodemailer', () => {
+  const sendMail = vi.fn().mockResolvedValue(true);
+  return {
+    createTransport: vi.fn(() => ({ sendMail })),
+    __esModule: true,
+  };
+});
+
+const app = express();
+app.use(express.json());
+app.use('/purchase-orders', purchaseOrderRoutes);
+app.use('/goods-receipts', goodsReceiptRoutes);
+
+let mongo: MongoMemoryServer;
+let token: string;
+let user: any;
+let item: any;
+let pieceUom: mongoose.Types.ObjectId;
+let boxUom: mongoose.Types.ObjectId;
+
+let vendor: any;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  user = await User.create({
+    name: 'Tester',
+    email: 'tester@example.com',
+    password: 'pass123',
+    role: 'manager',
+    tenantId: new mongoose.Types.ObjectId(),
+  });
+  token = jwt.sign({ id: user._id.toString(), role: user.role }, process.env.JWT_SECRET!);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+  pieceUom = new mongoose.Types.ObjectId();
+  boxUom = new mongoose.Types.ObjectId();
+  await mongoose.connection.db.collection('unitOfMeasure').insertMany([
+    { _id: pieceUom, name: 'piece' },
+    { _id: boxUom, name: 'box' },
+  ]);
+  await mongoose.connection.db.collection('conversions').insertOne({
+    from: boxUom,
+    to: pieceUom,
+    factor: 10,
+  });
+  vendor = await Vendor.create({ name: 'Vendor', email: 'vendor@example.com', tenantId: user.tenantId });
+  item = await InventoryItem.create({
+    name: 'Part',
+    quantity: 0,
+    uom: pieceUom,
+    tenantId: user.tenantId,
+  });
+});
+
+describe('Purchase order lifecycle', () => {
+  it('handles partial receipts, conversions, and emails', async () => {
+    const poRes = await request(app)
+      .post('/purchase-orders')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        vendor: vendor._id.toString(),
+        items: [{ item: item._id.toString(), quantity: 15, uom: pieceUom.toString() }],
+        tenantId: user.tenantId.toString(),
+      })
+      .expect(201);
+
+    const poId = poRes.body._id;
+
+    await request(app)
+      .post('/goods-receipts')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        purchaseOrder: poId,
+        items: [{ item: item._id.toString(), quantity: 5, uom: pieceUom.toString() }],
+        tenantId: user.tenantId.toString(),
+      })
+      .expect(201);
+
+    let updated = await InventoryItem.findById(item._id);
+    expect(updated?.quantity).toBe(5);
+    let po = await PurchaseOrder.findById(poId);
+    expect(po?.status).toBe('open');
+    expect(po?.items[0].received).toBe(5);
+
+    await request(app)
+      .post('/goods-receipts')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        purchaseOrder: poId,
+        items: [{ item: item._id.toString(), quantity: 1, uom: boxUom.toString() }],
+        tenantId: user.tenantId.toString(),
+      })
+      .expect(201);
+
+    updated = await InventoryItem.findById(item._id);
+    expect(updated?.quantity).toBe(15);
+    po = await PurchaseOrder.findById(poId);
+    expect(po?.status).toBe('closed');
+    expect(po?.items[0].received).toBe(15);
+
+    const transport = (nodemailer.createTransport as any).mock.results[0].value;
+    expect(transport.sendMail).toHaveBeenCalled();
+  });
+});

--- a/Frontend/src/purchasing/GoodsReceiptPage.tsx
+++ b/Frontend/src/purchasing/GoodsReceiptPage.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { createGoodsReceipt } from '../utils/api';
+
+export default function GoodsReceiptPage() {
+  const [po, setPo] = useState('');
+  const [item, setItem] = useState('');
+  const [qty, setQty] = useState(0);
+
+  const submit = async () => {
+    await createGoodsReceipt({ purchaseOrder: po, items: [{ item, quantity: qty }] });
+    setPo('');
+    setItem('');
+    setQty(0);
+  };
+
+  return (
+    <div>
+      <h1>Goods Receipt</h1>
+      <input
+        placeholder="PO ID"
+        value={po}
+        onChange={(e) => setPo(e.target.value)}
+      />
+      <input
+        placeholder="Item ID"
+        value={item}
+        onChange={(e) => setItem(e.target.value)}
+      />
+      <input
+        type="number"
+        placeholder="Quantity"
+        value={qty}
+        onChange={(e) => setQty(Number(e.target.value))}
+      />
+      <button onClick={submit}>Receive</button>
+    </div>
+  );
+}

--- a/Frontend/src/purchasing/PurchaseOrderPage.tsx
+++ b/Frontend/src/purchasing/PurchaseOrderPage.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { createPurchaseOrder } from '../utils/api';
+
+export default function PurchaseOrderPage() {
+  const [vendor, setVendor] = useState('');
+  const [item, setItem] = useState('');
+  const [qty, setQty] = useState(0);
+
+  const submit = async () => {
+    await createPurchaseOrder({ vendor, items: [{ item, quantity: qty }] });
+    setVendor('');
+    setItem('');
+    setQty(0);
+  };
+
+  return (
+    <div>
+      <h1>Create Purchase Order</h1>
+      <input
+        placeholder="Vendor ID"
+        value={vendor}
+        onChange={(e) => setVendor(e.target.value)}
+      />
+      <input
+        placeholder="Item ID"
+        value={item}
+        onChange={(e) => setItem(e.target.value)}
+      />
+      <input
+        type="number"
+        placeholder="Quantity"
+        value={qty}
+        onChange={(e) => setQty(Number(e.target.value))}
+      />
+      <button onClick={submit}>Create</button>
+    </div>
+  );
+}

--- a/Frontend/src/utils/api.ts
+++ b/Frontend/src/utils/api.ts
@@ -170,4 +170,11 @@ export const searchMessages = (channelId: string, q: string) =>
     .get<Message[]>(`/channels/${channelId}/messages/search`, { params: { q } })
     .then((res) => res.data);
 
+// ----- Purchasing -----
+export const createPurchaseOrder = (payload: any) =>
+  api.post('/purchase-orders', payload).then((res) => res.data);
+
+export const createGoodsReceipt = (payload: any) =>
+  api.post('/goods-receipts', payload).then((res) => res.data);
+
 export default api;


### PR DESCRIPTION
## Summary
- add purchase order and goods receipt models, controllers, routes
- adjust inventory service for receipts and notify vendors
- provide basic purchasing screens and API helpers
- test purchase order lifecycle with receipts, conversions, and notifications

## Testing
- `npm install --prefix Backend` *(fails: ENOTEMPTY rename)*
- `npm test --prefix Backend` *(fails: vitest: not found)*
- `npm install --prefix Frontend` *(fails: 403 Forbidden)*
- `npm test --prefix Frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b54e39b458832384f23f8212a1fdf8