### PR TITLE
Add KPI analytics service with exports and dashboard widgets

### DIFF
--- a/Backend/controllers/AnalyticsController.ts
+++ b/Backend/controllers/AnalyticsController.ts
@@ -1,0 +1,66 @@
+import { AuthedRequestHandler } from '../types/AuthedRequestHandler';
+import { getKPIs } from '../services/analytics';
+import { Parser as Json2csvParser } from 'json2csv';
+import PDFDocument from 'pdfkit';
+
+export const kpiJson: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const data = await getKPIs(req.tenantId!);
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const kpiCsv: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const data = await getKPIs(req.tenantId!);
+    const parser = new Json2csvParser();
+    const csv = parser.parse([data]);
+    res.header('Content-Type', 'text/csv');
+    res.attachment('kpis.csv');
+    res.send(csv);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const kpiXlsx: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const data = await getKPIs(req.tenantId!);
+    const xml = `<?xml version="1.0"?>\n<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet" xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"><Worksheet ss:Name="KPIs"><Table><Row><Cell><Data ss:Type="String">Metric</Data></Cell><Cell><Data ss:Type="String">Value</Data></Cell></Row>${Object.entries(data)
+      .map(
+        ([k, v]) => `<Row><Cell><Data ss:Type="String">${k}</Data></Cell><Cell><Data ss:Type="Number">${v}</Data></Cell></Row>`
+      )
+      .join('')}</Table></Worksheet></Workbook>`;
+    res.header('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.attachment('kpis.xlsx');
+    res.send(xml);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const kpiPdf: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const data = await getKPIs(req.tenantId!);
+    const doc = new PDFDocument();
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'attachment; filename=kpis.pdf');
+    doc.pipe(res);
+    doc.fontSize(18).text('KPIs', { align: 'center' });
+    Object.entries(data).forEach(([k, v]) => {
+      doc.fontSize(12).text(`${k}: ${v}`);
+    });
+    doc.end();
+  } catch (err) {
+    next(err);
+  }
+};
+
+export default {
+  kpiJson,
+  kpiCsv,
+  kpiXlsx,
+  kpiPdf,
+};

--- a/Backend/routes/AnalyticsRoutes.ts
+++ b/Backend/routes/AnalyticsRoutes.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import { requireAuth } from '../middleware/authMiddleware';
+import { kpiJson, kpiCsv, kpiXlsx, kpiPdf } from '../controllers/AnalyticsController';
+
+const router = express.Router();
+router.use(requireAuth);
+
+router.get('/kpis', kpiJson);
+router.get('/kpis.csv', kpiCsv);
+router.get('/kpis.xlsx', kpiXlsx);
+router.get('/kpis.pdf', kpiPdf);
+
+export default router;

--- a/Backend/server.ts
+++ b/Backend/server.ts
@@ -21,6 +21,7 @@ import LineRoutes from './routes/LineRoutes';
 import StationRoutes from './routes/StationRoutes';
 import departmentRoutes from './routes/DepartmentRoutes';
 import inventoryRoutes from './routes/InventoryRoutes';
+import analyticsRoutes from './routes/AnalyticsRoutes';
  
 import teamRoutes from './routes/TeamRoutes';
 import notificationsRoutes from './routes/notifications';
@@ -134,6 +135,7 @@ app.use('/api/reports', reportsRoutes);
 app.use('/api/lines', LineRoutes);
 app.use('/api/stations', StationRoutes);
 app.use('/api/inventory', inventoryRoutes);
+app.use('/api/v1/analytics', analyticsRoutes);
 app.use('/api/team', teamRoutes);
 app.use('/api/theme', ThemeRoutes);
 app.use('/api/request-portal', requestPortalRoutes);

--- a/Backend/services/analytics.ts
+++ b/Backend/services/analytics.ts
@@ -1,0 +1,48 @@
+import WorkOrder from '../models/WorkOrder';
+
+export interface KPIResult {
+  mttr: number; // Mean time to repair in hours
+  mtbf: number; // Mean time between failures in hours
+  backlog: number; // Number of open work orders
+}
+
+function calculateMTTR(workOrders: { createdAt: Date; completedAt?: Date | null }[]): number {
+  const completed = workOrders.filter((w) => w.completedAt);
+  if (completed.length === 0) return 0;
+  const total = completed.reduce((sum, w) => {
+    const end = w.completedAt!.getTime();
+    const start = w.createdAt.getTime();
+    return sum + (end - start);
+  }, 0);
+  return total / completed.length / 36e5; // ms to hours
+}
+
+function calculateMTBF(workOrders: { completedAt?: Date | null }[]): number {
+  const failures = workOrders
+    .filter((w) => w.completedAt)
+    .sort((a, b) => a.completedAt!.getTime() - b.completedAt!.getTime());
+  if (failures.length < 2) return 0;
+  let total = 0;
+  for (let i = 1; i < failures.length; i++) {
+    total += failures[i].completedAt!.getTime() - failures[i - 1].completedAt!.getTime();
+  }
+  return total / (failures.length - 1) / 36e5; // ms to hours
+}
+
+function calculateBacklog(workOrders: { status: string }[]): number {
+  return workOrders.filter((w) => w.status !== 'completed').length;
+}
+
+export async function getKPIs(tenantId: string): Promise<KPIResult> {
+  const workOrders = await WorkOrder.find({ tenantId }).select('createdAt completedAt status').lean();
+  return {
+    mttr: calculateMTTR(workOrders),
+    mtbf: calculateMTBF(workOrders),
+    backlog: calculateBacklog(workOrders),
+  };
+}
+
+export default {
+  getKPIs,
+};
+

--- a/Backend/tests/analyticsRoutes.test.ts
+++ b/Backend/tests/analyticsRoutes.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import AnalyticsRoutes from '../routes/AnalyticsRoutes';
+import WorkOrder from '../models/WorkOrder';
+import User from '../models/User';
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/analytics', AnalyticsRoutes);
+
+let mongo: MongoMemoryServer;
+let token: string;
+let tenantId: mongoose.Types.ObjectId;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+  const user = await User.create({
+    name: 'Tester',
+    email: 'tester@example.com',
+    password: 'pass123',
+    role: 'manager',
+    tenantId: new mongoose.Types.ObjectId(),
+  });
+  tenantId = user.tenantId;
+  token = jwt.sign({ id: user._id.toString(), role: user.role }, process.env.JWT_SECRET!);
+
+  const base = new Date('2023-01-01T00:00:00Z');
+  await WorkOrder.create({
+    title: 'WO1',
+    status: 'completed',
+    tenantId,
+    createdAt: base,
+    dateCreated: base,
+    completedAt: new Date(base.getTime() + 10 * 36e5),
+  });
+  await WorkOrder.create({
+    title: 'WO2',
+    status: 'completed',
+    tenantId,
+    createdAt: new Date(base.getTime() + 20 * 36e5),
+    dateCreated: new Date(base.getTime() + 20 * 36e5),
+    completedAt: new Date(base.getTime() + 30 * 36e5),
+  });
+  await WorkOrder.create({
+    title: 'WO3',
+    status: 'open',
+    tenantId,
+    createdAt: base,
+    dateCreated: base,
+  });
+});
+
+function binaryParser(res: any, callback: any) {
+  res.setEncoding('binary');
+  let data = '';
+  res.on('data', (chunk: string) => { data += chunk; });
+  res.on('end', () => callback(null, Buffer.from(data, 'binary')));
+}
+
+describe('Analytics KPIs', () => {
+  it('calculates MTTR, MTBF and backlog', async () => {
+    const res = await request(app)
+      .get('/api/v1/analytics/kpis')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body.mttr).toBeCloseTo(10, 1);
+    expect(res.body.mtbf).toBeCloseTo(20, 1);
+    expect(res.body.backlog).toBe(1);
+  });
+
+  it('exports CSV, XLSX and PDF', async () => {
+    const csvRes = await request(app)
+      .get('/api/v1/analytics/kpis.csv')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(csvRes.headers['content-type']).toContain('text/csv');
+    expect(csvRes.text).toContain('mttr');
+
+    const xlsxRes = await request(app)
+      .get('/api/v1/analytics/kpis.xlsx')
+      .set('Authorization', `Bearer ${token}`)
+      .buffer()
+      .parse(binaryParser)
+      .expect(200);
+    expect(xlsxRes.headers['content-type']).toContain('spreadsheet');
+    expect(xlsxRes.body.length).toBeGreaterThan(0);
+
+    const pdfRes = await request(app)
+      .get('/api/v1/analytics/kpis.pdf')
+      .set('Authorization', `Bearer ${token}`)
+      .buffer()
+      .parse(binaryParser)
+      .expect(200);
+    expect(pdfRes.headers['content-type']).toBe('application/pdf');
+    expect(pdfRes.body.slice(0, 4).toString()).toBe('%PDF');
+  });
+});
+

--- a/Frontend/src/components/kpi/KpiExportButtons.tsx
+++ b/Frontend/src/components/kpi/KpiExportButtons.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Button from '../common/Button';
+import { Download } from 'lucide-react';
+
+const formats = ['csv', 'xlsx', 'pdf'] as const;
+
+const exportFile = (format: string) => {
+  const link = document.createElement('a');
+  link.href = `/api/v1/analytics/kpis.${format}`;
+  link.download = `kpis.${format}`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+};
+
+const KpiExportButtons: React.FC = () => (
+  <div className="flex gap-2">
+    {formats.map((f) => (
+      <Button
+        key={f}
+        variant="outline"
+        icon={<Download size={16} />}
+        onClick={() => exportFile(f)}
+      >
+        {f.toUpperCase()}
+      </Button>
+    ))}
+  </div>
+);
+
+export default KpiExportButtons;

--- a/Frontend/src/components/kpi/KpiWidget.tsx
+++ b/Frontend/src/components/kpi/KpiWidget.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Card from '../common/Card';
+
+interface Props {
+  label: string;
+  value: number | string;
+  suffix?: string;
+}
+
+const KpiWidget: React.FC<Props> = ({ label, value, suffix }) => (
+  <Card>
+    <div className="space-y-1">
+      <h3 className="text-sm font-medium text-neutral-500">{label}</h3>
+      <p className="text-2xl font-semibold">{value}{suffix}</p>
+    </div>
+  </Card>
+);
+
+export default KpiWidget;

--- a/Frontend/src/pages/Analytics.tsx
+++ b/Frontend/src/pages/Analytics.tsx
@@ -7,6 +7,8 @@ import Badge from '../components/common/Badge';
 import api from '../utils/api';
 import { useDashboardStore } from '../store/dashboardStore';
 import { useAuth } from '../context/AuthContext';
+import KpiWidget from '../components/kpi/KpiWidget';
+import KpiExportButtons from '../components/kpi/KpiExportButtons';
 
 interface AnalyticsData {
   workOrderCompletionRate: number;
@@ -18,21 +20,30 @@ interface AnalyticsData {
   topAssets: { name: string; downtime: number; issues: number; cost: number }[];
 }
 
+interface KPIData {
+  mttr: number;
+  mtbf: number;
+  backlog: number;
+}
+
 const Analytics: React.FC = () => {
   const [data, setData] = useState<AnalyticsData | null>(null);
+  const [kpis, setKpis] = useState<KPIData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
- 
+
   const [showFilters, setShowFilters] = useState(false);
- 
+
   const { selectedRole: role, setSelectedRole } = useDashboardStore();
- 
+
 
   const fetchData = async () => {
     setLoading(true);
     try {
       const res = await api.get('/reports/analytics', { params: { role } });
       setData(res.data);
+      const kpiRes = await api.get('/v1/analytics/kpis');
+      setKpis(kpiRes.data);
       setError(null);
     } catch (err) {
       console.error('Error fetching analytics:', err);
@@ -41,11 +52,11 @@ const Analytics: React.FC = () => {
       setLoading(false);
     }
   };
- 
+
 
   useEffect(() => {
     fetchData();
- 
+
   }, [role]);
 
   const handleRoleChange = (role: string) => {
@@ -142,6 +153,15 @@ const Analytics: React.FC = () => {
             </div>
           </Card>
         )}
+
+        <div className="space-y-4">
+          <KpiExportButtons />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <KpiWidget label="MTTR" value={kpis?.mttr.toFixed(1) ?? '0'} suffix="h" />
+            <KpiWidget label="MTBF" value={kpis?.mtbf.toFixed(1) ?? '0'} suffix="h" />
+            <KpiWidget label="Backlog" value={kpis?.backlog ?? 0} />
+          </div>
+        </div>
 
         {/* KPI Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- implement analytics service computing MTTR, MTBF, and backlog
- expose `/api/v1/analytics/kpis` with CSV, XLSX, and PDF exports
- add React KPI widgets and export buttons on analytics dashboard

## Testing
- `cd Backend && npm test` *(fails: vitest not found)*
- `cd Frontend && npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b54e3b4a708323b95a00304f793542