### PR TITLE
feat: add webhook subscriptions with idempotency

### DIFF
--- a/Backend/middleware/idempotency.ts
+++ b/Backend/middleware/idempotency.ts
@@ -1,0 +1,35 @@
+import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
+
+// In-memory store for processed idempotency keys and their request hashes
+const processed = new Map<string, string>();
+
+export default function idempotency(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const key = req.get('Idempotency-Key');
+  if (!key) {
+    next();
+    return;
+  }
+
+  const bodyHash = crypto
+    .createHash('sha256')
+    .update(JSON.stringify(req.body || {}))
+    .digest('hex');
+
+  const existing = processed.get(key);
+  if (existing) {
+    if (existing === bodyHash) {
+      res.status(409).json({ message: 'Duplicate request' });
+    } else {
+      res.status(409).json({ message: 'Idempotency key conflict' });
+    }
+    return;
+  }
+
+  processed.set(key, bodyHash);
+  next();
+}

--- a/Backend/models/Webhook.ts
+++ b/Backend/models/Webhook.ts
@@ -1,0 +1,21 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export interface WebhookDocument extends Document {
+  url: string;
+  event: string;
+  secret: string;
+  createdAt: Date;
+}
+
+const webhookSchema = new Schema<WebhookDocument>({
+  url: { type: String, required: true },
+  event: { type: String, required: true },
+  secret: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+webhookSchema.index({ event: 1 });
+
+const Webhook: Model<WebhookDocument> = mongoose.model<WebhookDocument>('Webhook', webhookSchema);
+
+export default Webhook;

--- a/Backend/routes/webhooks.ts
+++ b/Backend/routes/webhooks.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import crypto from 'crypto';
+import Webhook from '../models/Webhook';
+import idempotency from '../middleware/idempotency';
+
+const router = express.Router();
+
+// Subscribe to events
+router.post('/subscribe', idempotency, async (req, res) => {
+  const { url, event } = req.body;
+  if (!url || !event) {
+    return res.status(400).json({ message: 'url and event required' });
+  }
+  const secret = crypto.randomBytes(32).toString('hex');
+  const hook = await Webhook.create({ url, event, secret });
+  res.status(201).json({ id: hook._id, url: hook.url, event: hook.event, secret });
+});
+
+export default router;

--- a/Backend/server.ts
+++ b/Backend/server.ts
@@ -26,6 +26,8 @@ import teamRoutes from './routes/TeamRoutes';
 import notificationsRoutes from './routes/notifications';
 import TenantRoutes from './routes/TenantRoutes';
 
+import webhooksRoutes from './routes/webhooks';
+
 import ThemeRoutes from './routes/ThemeRoutes';
  
 import chatRoutes from './routes/ChatRoutes';
@@ -138,6 +140,7 @@ app.use('/api/team', teamRoutes);
 app.use('/api/theme', ThemeRoutes);
 app.use('/api/request-portal', requestPortalRoutes);
 app.use('/api/chat', chatRoutes);
+app.use('/api/webhooks', webhooksRoutes);
 
 app.use('/api/summary', summaryRoutes);
 

--- a/Backend/tests/webhooks.test.ts
+++ b/Backend/tests/webhooks.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import crypto from 'crypto';
+
+import webhooksRoutes from '../routes/webhooks';
+import Webhook from '../models/Webhook';
+import { dispatchEvent, RETRY_DELAY_MS } from '../utils/webhookDispatcher';
+
+const app = express();
+app.use(express.json());
+app.use('/api/webhooks', webhooksRoutes);
+
+let mongo: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create({ binary: { version: '7.0.3' } });
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+});
+
+describe('Webhook subscription', () => {
+  it('creates a subscription', async () => {
+    const res = await request(app)
+      .post('/api/webhooks/subscribe')
+      .send({ url: 'http://example.com', event: 'WO.created' })
+      .expect(201);
+
+    expect(res.body.secret).toBeDefined();
+    const count = await Webhook.countDocuments();
+    expect(count).toBe(1);
+  });
+
+  it('prevents duplicate subscriptions via Idempotency-Key', async () => {
+    const key = 'abc123';
+    await request(app)
+      .post('/api/webhooks/subscribe')
+      .set('Idempotency-Key', key)
+      .send({ url: 'http://example.com', event: 'WO.created' })
+      .expect(201);
+
+    await request(app)
+      .post('/api/webhooks/subscribe')
+      .set('Idempotency-Key', key)
+      .send({ url: 'http://example.com', event: 'WO.created' })
+      .expect(409);
+  });
+});
+
+describe('Webhook dispatch', () => {
+  it('sends signed events', async () => {
+    const hook = await Webhook.create({
+      url: 'http://example.com',
+      event: 'WO.created',
+      secret: 'shhh',
+    });
+    const payload = { id: 1 };
+    const body = { event: 'WO.created', data: payload };
+    const expectedSig = crypto
+      .createHmac('sha256', hook.secret)
+      .update(JSON.stringify(body))
+      .digest('hex');
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dispatchEvent('WO.created', payload);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const args = fetchMock.mock.calls[0];
+    expect(args[1].headers['X-Signature']).toBe(expectedSig);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('retries on failure', async () => {
+    await Webhook.create({
+      url: 'http://example.com',
+      event: 'WO.created',
+      secret: 'shhh',
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useFakeTimers();
+
+    await dispatchEvent('WO.created', {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+});

--- a/Backend/utils/webhookDispatcher.ts
+++ b/Backend/utils/webhookDispatcher.ts
@@ -1,0 +1,39 @@
+import crypto from 'crypto';
+import Webhook from '../models/Webhook';
+
+export const RETRY_DELAY_MS = 1000;
+const MAX_RETRIES = 3;
+
+async function sendWithRetry(
+  url: string,
+  body: unknown,
+  secret: string,
+  attempt = 0,
+): Promise<void> {
+  const payload = JSON.stringify(body);
+  const signature = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Signature': signature,
+      },
+      body: payload,
+    });
+    if (!res.ok) throw new Error(`status ${res.status}`);
+  } catch (_err) {
+    if (attempt < MAX_RETRIES) {
+      setTimeout(() => {
+        void sendWithRetry(url, body, secret, attempt + 1);
+      }, RETRY_DELAY_MS);
+    }
+  }
+}
+
+export async function dispatchEvent(event: string, data: any): Promise<void> {
+  const hooks = await Webhook.find({ event }).lean();
+  const body = { event, data };
+  await Promise.all(hooks.map((h) => sendWithRetry(h.url, body, h.secret)));
+}


### PR DESCRIPTION
## Summary
- add webhook subscription model and routes
- sign outbound webhooks and retry failures
- track Idempotency-Key headers to prevent duplicate requests

## Testing
- `npm install --include=dev` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fbcryptjs)*


------
https://chatgpt.com/codex/tasks/task_e_68b54e3d93f883238cbf1046c26a4eab