### PR TITLE
Add condition rule engine with worker and UI

### DIFF
--- a/Backend/controllers/ConditionRuleController.ts
+++ b/Backend/controllers/ConditionRuleController.ts
@@ -1,0 +1,83 @@
+import { Request, Response, NextFunction } from 'express';
+import ConditionRule from '../models/ConditionRule';
+
+export const getAllConditionRules = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const items = await ConditionRule.find({ tenantId: (req as any).tenantId });
+    res.json(items);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getConditionRuleById = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const item = await ConditionRule.findOne({
+      _id: req.params.id,
+      tenantId: (req as any).tenantId,
+    });
+    if (!item) return res.status(404).json({ message: 'Not found' });
+    res.json(item);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createConditionRule = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const tenantId = (req as any).tenantId;
+    const newItem = new ConditionRule({ ...req.body, tenantId });
+    const saved = await newItem.save();
+    res.status(201).json(saved);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateConditionRule = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const tenantId = (req as any).tenantId;
+    const updated = await ConditionRule.findOneAndUpdate(
+      { _id: req.params.id, tenantId },
+      { ...req.body, tenantId },
+      { new: true, runValidators: true }
+    );
+    if (!updated) return res.status(404).json({ message: 'Not found' });
+    res.json(updated);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const deleteConditionRule = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const deleted = await ConditionRule.findOneAndDelete({
+      _id: req.params.id,
+      tenantId: (req as any).tenantId,
+    });
+    if (!deleted) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted successfully' });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/Backend/models/ConditionRule.ts
+++ b/Backend/models/ConditionRule.ts
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose';
+
+const conditionRuleSchema = new mongoose.Schema(
+  {
+    asset: { type: mongoose.Schema.Types.ObjectId, ref: 'Asset', required: true },
+    metric: { type: String, required: true },
+    operator: {
+      type: String,
+      enum: ['>', '<', '>=', '<=', '=='],
+      default: '>',
+    },
+    threshold: { type: Number, required: true },
+    workOrderTitle: { type: String, required: true },
+    workOrderDescription: String,
+    active: { type: Boolean, default: true },
+    tenantId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Tenant',
+      required: true,
+      index: true,
+    },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('ConditionRule', conditionRuleSchema);

--- a/Backend/routes/ConditionRuleRoutes.ts
+++ b/Backend/routes/ConditionRuleRoutes.ts
@@ -1,0 +1,38 @@
+import express from 'express';
+import {
+  getAllConditionRules,
+  getConditionRuleById,
+  createConditionRule,
+  updateConditionRule,
+  deleteConditionRule,
+} from '../controllers/ConditionRuleController';
+import { requireAuth } from '../middleware/authMiddleware';
+import requireRole from '../middleware/requireRole';
+import { validate } from '../middleware/validationMiddleware';
+import { conditionRuleValidators } from '../validators/conditionRuleValidators';
+
+const router = express.Router();
+
+router.use(requireAuth);
+router.get('/', getAllConditionRules);
+router.get('/:id', getConditionRuleById);
+
+router.post(
+  '/',
+  requireRole('admin', 'manager'),
+  conditionRuleValidators,
+  validate,
+  createConditionRule
+);
+
+router.put(
+  '/:id',
+  requireRole('admin', 'manager'),
+  conditionRuleValidators,
+  validate,
+  updateConditionRule
+);
+
+router.delete('/:id', requireRole('admin', 'manager'), deleteConditionRule);
+
+export default router;

--- a/Backend/server.ts
+++ b/Backend/server.ts
@@ -30,6 +30,7 @@ import ThemeRoutes from './routes/ThemeRoutes';
  
 import chatRoutes from './routes/ChatRoutes';
 import requestPortalRoutes from './routes/requestPortal';
+import conditionRuleRoutes from './routes/ConditionRuleRoutes';
  
   
  
@@ -128,6 +129,7 @@ app.use('/api', generalLimiter);
 
 app.use('/api/workorders', workOrdersRoutes);
 app.use('/api/assets', assetsRoutes);
+app.use('/api/condition-rules', conditionRuleRoutes);
 app.use('/api/tenants', TenantRoutes);
 app.use('/api/pm-tasks', pmTasksRoutes);
 app.use('/api/reports', reportsRoutes);

--- a/Backend/tests/conditionEvaluator.test.ts
+++ b/Backend/tests/conditionEvaluator.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+
+import conditionRuleRoutes from '../routes/ConditionRuleRoutes';
+import { evaluateCondition } from '../workers/conditionEvaluator';
+import User from '../models/User';
+import Asset from '../models/Asset';
+import WorkOrder from '../models/WorkOrder';
+import ConditionRule from '../models/ConditionRule';
+
+const app = express();
+app.use(express.json());
+app.use('/api/condition-rules', conditionRuleRoutes);
+
+let mongo: MongoMemoryServer;
+let token: string;
+let user: Awaited<ReturnType<typeof User.create>>;
+let asset: Awaited<ReturnType<typeof Asset.create>>;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  user = await User.create({
+    name: 'Tester',
+    email: 'tester@example.com',
+    password: 'pass123',
+    role: 'manager',
+    tenantId: new mongoose.Types.ObjectId(),
+    employeeId: 'EMP001',
+  });
+  token = jwt.sign({ id: user._id.toString(), role: user.role }, process.env.JWT_SECRET!);
+  asset = await Asset.create({
+    name: 'A1',
+    type: 'Mechanical',
+    location: 'Loc1',
+    tenantId: user.tenantId,
+  });
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+  await User.create({
+    _id: user._id,
+    name: user.name,
+    email: user.email,
+    password: 'pass123',
+    role: user.role,
+    tenantId: user.tenantId,
+    employeeId: user.employeeId,
+  });
+  asset = await Asset.create({
+    _id: asset._id,
+    name: 'A1',
+    type: 'Mechanical',
+    location: 'Loc1',
+    tenantId: user.tenantId,
+  });
+});
+
+describe('Condition rules', () => {
+  it('creates work order when threshold exceeded', async () => {
+    await ConditionRule.create({
+      asset: asset._id,
+      metric: 'temp',
+      operator: '>',
+      threshold: 50,
+      workOrderTitle: 'Check temp',
+      tenantId: user.tenantId,
+      active: true,
+    });
+
+    await evaluateCondition({
+      asset: asset._id.toString(),
+      metric: 'temp',
+      value: 55,
+      tenantId: user.tenantId.toString(),
+    });
+    expect(await WorkOrder.countDocuments()).toBe(1);
+
+    await evaluateCondition({
+      asset: asset._id.toString(),
+      metric: 'temp',
+      value: 45,
+      tenantId: user.tenantId.toString(),
+    });
+    expect(await WorkOrder.countDocuments()).toBe(1);
+  });
+
+  it('respects updated thresholds', async () => {
+    const createRes = await request(app)
+      .post('/api/condition-rules')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        asset: asset._id.toString(),
+        metric: 'vibration',
+        operator: '>',
+        threshold: 40,
+        workOrderTitle: 'Check vib',
+        active: true,
+      })
+      .expect(201);
+
+    const ruleId = createRes.body._id;
+
+    await evaluateCondition({
+      asset: asset._id.toString(),
+      metric: 'vibration',
+      value: 45,
+      tenantId: user.tenantId.toString(),
+    });
+    expect(await WorkOrder.countDocuments()).toBe(1);
+
+    await request(app)
+      .put(`/api/condition-rules/${ruleId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        asset: asset._id.toString(),
+        metric: 'vibration',
+        operator: '>',
+        threshold: 60,
+        workOrderTitle: 'Check vib',
+        active: true,
+      })
+      .expect(200);
+
+    await evaluateCondition({
+      asset: asset._id.toString(),
+      metric: 'vibration',
+      value: 55,
+      tenantId: user.tenantId.toString(),
+    });
+    expect(await WorkOrder.countDocuments()).toBe(1);
+
+    await evaluateCondition({
+      asset: asset._id.toString(),
+      metric: 'vibration',
+      value: 65,
+      tenantId: user.tenantId.toString(),
+    });
+    expect(await WorkOrder.countDocuments()).toBe(2);
+  });
+});

--- a/Backend/validators/conditionRuleValidators.ts
+++ b/Backend/validators/conditionRuleValidators.ts
@@ -1,0 +1,14 @@
+import { body } from 'express-validator';
+
+export const conditionRuleValidators = [
+  body('asset').isMongoId().withMessage('asset is required'),
+  body('metric').notEmpty().withMessage('metric is required'),
+  body('operator')
+    .optional()
+    .isIn(['>', '<', '>=', '<=', '=='])
+    .withMessage('invalid operator'),
+  body('threshold').isNumeric().withMessage('threshold must be number'),
+  body('workOrderTitle').notEmpty().withMessage('workOrderTitle is required'),
+  body('workOrderDescription').optional().isString(),
+  body('active').optional().isBoolean(),
+];

--- a/Backend/workers/conditionEvaluator.ts
+++ b/Backend/workers/conditionEvaluator.ts
@@ -1,0 +1,48 @@
+import ConditionRule from '../models/ConditionRule';
+import WorkOrder from '../models/WorkOrder';
+
+export interface ConditionReading {
+  asset: string;
+  metric: string;
+  value: number;
+  tenantId: string;
+}
+
+function compare(value: number, operator: string, threshold: number): boolean {
+  switch (operator) {
+    case '>':
+      return value > threshold;
+    case '<':
+      return value < threshold;
+    case '>=':
+      return value >= threshold;
+    case '<=':
+      return value <= threshold;
+    case '==':
+      return value === threshold;
+    default:
+      return false;
+  }
+}
+
+export async function evaluateCondition(reading: ConditionReading): Promise<void> {
+  const rules = await ConditionRule.find({
+    asset: reading.asset,
+    metric: reading.metric,
+    tenantId: reading.tenantId,
+    active: true,
+  });
+
+  for (const rule of rules) {
+    if (compare(reading.value, rule.operator, rule.threshold)) {
+      await WorkOrder.create({
+        title: rule.workOrderTitle,
+        description: rule.workOrderDescription,
+        asset: reading.asset,
+        tenantId: reading.tenantId,
+      });
+    }
+  }
+}
+
+export default { evaluateCondition };

--- a/Frontend/src/pm/ConditionRules.tsx
+++ b/Frontend/src/pm/ConditionRules.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '../components/layout/Layout';
+import Button from '../components/common/Button';
+import api from '../utils/api';
+
+interface ConditionRule {
+  _id?: string;
+  asset: string;
+  metric: string;
+  operator: '>' | '<' | '>=' | '<=' | '==' ;
+  threshold: number;
+  workOrderTitle: string;
+  workOrderDescription?: string;
+  active: boolean;
+}
+
+const emptyRule: ConditionRule = {
+  asset: '',
+  metric: '',
+  operator: '>',
+  threshold: 0,
+  workOrderTitle: '',
+  workOrderDescription: '',
+  active: true,
+};
+
+const ConditionRules: React.FC = () => {
+  const [rules, setRules] = useState<ConditionRule[]>([]);
+  const [form, setForm] = useState<ConditionRule | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadRules = async () => {
+    try {
+      const res = await api.get('/condition-rules', { withCredentials: true });
+      setRules(res.data as ConditionRule[]);
+    } catch (err) {
+      console.error(err);
+      setError('Failed to load rules');
+    }
+  };
+
+  useEffect(() => { loadRules(); }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form) return;
+    try {
+      if (form._id) {
+        await api.put(`/condition-rules/${form._id}`, form, { withCredentials: true });
+      } else {
+        await api.post('/condition-rules', form, { withCredentials: true });
+      }
+      setForm(null);
+      await loadRules();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Layout title="Condition Rules">
+      <div className="p-6 space-y-6">
+        <div className="flex justify-between items-center">
+          <h1 className="text-2xl font-bold">Condition Rules</h1>
+          <Button variant="primary" onClick={() => setForm({ ...emptyRule })}>
+            New Rule
+          </Button>
+        </div>
+        {error && <p className="text-error-500">{error}</p>}
+        <ul className="divide-y divide-neutral-200">
+          {rules.map(r => (
+            <li key={r._id} className="py-2 flex justify-between items-center">
+              <div>
+                <p className="font-medium">{r.metric} {r.operator} {r.threshold}</p>
+                <p className="text-sm text-neutral-500">{r.workOrderTitle}</p>
+              </div>
+              <Button size="sm" variant="outline" onClick={() => setForm(r)}>
+                Edit
+              </Button>
+            </li>
+          ))}
+          {rules.length === 0 && <li className="py-2 text-neutral-500">No rules</li>}
+        </ul>
+        {form && (
+          <div className="bg-white p-4 rounded shadow">
+            <form className="space-y-2" onSubmit={handleSubmit}>
+              <input
+                className="border p-1 w-full"
+                placeholder="Asset ID"
+                value={form.asset}
+                onChange={e => setForm({ ...form, asset: e.target.value })}
+              />
+              <input
+                className="border p-1 w-full"
+                placeholder="Metric"
+                value={form.metric}
+                onChange={e => setForm({ ...form, metric: e.target.value })}
+              />
+              <select
+                className="border p-1 w-full"
+                value={form.operator}
+                onChange={e => setForm({ ...form, operator: e.target.value as ConditionRule['operator'] })}
+              >
+                <option value=">">&gt;</option>
+                <option value="<">&lt;</option>
+                <option value=">=">&gt;=</option>
+                <option value="<=">&lt;=</option>
+                <option value="==">==</option>
+              </select>
+              <input
+                className="border p-1 w-full"
+                type="number"
+                placeholder="Threshold"
+                value={form.threshold}
+                onChange={e => setForm({ ...form, threshold: Number(e.target.value) })}
+              />
+              <input
+                className="border p-1 w-full"
+                placeholder="Work Order Title"
+                value={form.workOrderTitle}
+                onChange={e => setForm({ ...form, workOrderTitle: e.target.value })}
+              />
+              <input
+                className="border p-1 w-full"
+                placeholder="Work Order Description"
+                value={form.workOrderDescription}
+                onChange={e => setForm({ ...form, workOrderDescription: e.target.value })}
+              />
+              <div className="flex items-center space-x-2">
+                <input
+                  type="checkbox"
+                  checked={form.active}
+                  onChange={e => setForm({ ...form, active: e.target.checked })}
+                />
+                <span>Active</span>
+              </div>
+              <div className="flex space-x-2">
+                <Button type="submit" variant="primary">Save</Button>
+                <Button type="button" variant="outline" onClick={() => setForm(null)}>Cancel</Button>
+              </div>
+            </form>
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+};
+
+export default ConditionRules;


### PR DESCRIPTION
## Summary
- model and API for condition-based rules
- worker evaluates sensor readings and creates work orders
- basic UI for configuring condition rules

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` *(frontend, fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b54e3dbb3483238c1c46bea25361c6