### PR TITLE
feat: add MQTT ingestion and configuration

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -30,6 +30,7 @@
     "node-cron": "^4.2.1",
     "nodemailer": "^6.9.6",
     "pdfkit": "^0.17.1",
+    "mqtt": "^5.10.1",
     "redis": "^5.6.1",
     "socket.io": "^4.8.1",
     "winston": "^3.17.0",

--- a/Backend/services/mqttIngest.ts
+++ b/Backend/services/mqttIngest.ts
@@ -1,0 +1,61 @@
+import type { MqttClient } from 'mqtt';
+import SensorReading from '../models/SensorReading';
+import Notification from '../models/Notification';
+
+export interface MQTTOptions {
+  url: string;
+  username?: string;
+  password?: string;
+}
+
+const THRESHOLD = 100; // simple rule threshold
+
+export async function startMQTTIngest(
+  options: MQTTOptions,
+  client?: MqttClient
+): Promise<MqttClient> {
+  const mqttClient =
+    client ||
+    (await import('mqtt')).connect(options.url, {
+      username: options.username,
+      password: options.password,
+    });
+
+  mqttClient.on('connect', () => {
+    mqttClient.subscribe('tenants/+/meters');
+  });
+
+  mqttClient.on('error', (err) => {
+    console.error('MQTT error', err.message);
+  });
+
+  mqttClient.on('message', async (topic, payload) => {
+    try {
+      const match = topic.match(/^tenants\/(.+?)\/meters$/);
+      if (!match) return;
+      const tenantId = match[1];
+      const data = JSON.parse(payload.toString());
+      if (!data.asset || !data.metric || typeof data.value !== 'number') return;
+
+      await SensorReading.create({
+        asset: data.asset,
+        metric: data.metric,
+        value: data.value,
+        tenantId,
+      });
+
+      if (data.value > THRESHOLD) {
+        await Notification.create({
+          tenantId,
+          message: `Threshold exceeded for asset ${data.asset}`,
+        });
+      }
+    } catch (err) {
+      console.error('Failed to process MQTT message', err);
+    }
+  });
+
+  return mqttClient;
+}
+
+export default { startMQTTIngest };

--- a/Backend/tests/mqttIngest.test.ts
+++ b/Backend/tests/mqttIngest.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect, vi } from 'vitest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { EventEmitter } from 'events';
+
+import { startMQTTIngest } from '../services/mqttIngest';
+import SensorReading from '../models/SensorReading';
+import Notification from '../models/Notification';
+
+class MockClient extends EventEmitter {
+  subscribe(topic: string) {
+    // no-op for tests
+  }
+  publish(topic: string, message: string) {
+    this.emit('message', topic, Buffer.from(message));
+  }
+}
+
+describe('MQTT ingestion', () => {
+  let mongo: MongoMemoryServer;
+  let tenantId: string;
+  let client: MockClient;
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create();
+    await mongoose.connect(mongo.getUri());
+    tenantId = new mongoose.Types.ObjectId().toString();
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongo.stop();
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.db?.dropDatabase();
+    client = new MockClient();
+    await startMQTTIngest({ url: 'mqtt://test' }, client as any);
+  });
+
+  it('stores meter readings from MQTT messages', async () => {
+    const asset = new mongoose.Types.ObjectId().toString();
+    client.publish(`tenants/${tenantId}/meters`, JSON.stringify({
+      asset,
+      metric: 'kWh',
+      value: 50,
+    }));
+    await new Promise((r) => setTimeout(r, 10));
+    const readings = await SensorReading.find();
+    expect(readings.length).toBe(1);
+    expect(readings[0].asset.toString()).toBe(asset);
+    expect(readings[0].tenantId.toString()).toBe(tenantId);
+    const notes = await Notification.find();
+    expect(notes.length).toBe(0);
+  });
+
+  it('triggers threshold rule and creates notification', async () => {
+    const asset = new mongoose.Types.ObjectId().toString();
+    client.publish(`tenants/${tenantId}/meters`, JSON.stringify({
+      asset,
+      metric: 'kWh',
+      value: 150,
+    }));
+    await new Promise((r) => setTimeout(r, 10));
+    const notes = await Notification.find();
+    expect(notes.length).toBe(1);
+    expect(notes[0].tenantId.toString()).toBe(tenantId);
+  });
+
+  it('handles authentication errors from MQTT broker', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    client.emit('error', new Error('Not authorized'));
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+

--- a/Frontend/src/integrations/MQTTConfig.tsx
+++ b/Frontend/src/integrations/MQTTConfig.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { useMQTTStore } from '../store/mqttStore';
+
+const MQTTConfig: React.FC = () => {
+  const { url, username, password, setConfig } = useMQTTStore();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setConfig({ [name]: value } as any);
+  };
+
+  return (
+    <form className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-neutral-700">Broker URL</label>
+        <input
+          name="url"
+          value={url}
+          onChange={handleChange}
+          className="w-full px-3 py-2 border border-neutral-300 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-neutral-700">Username</label>
+        <input
+          name="username"
+          value={username}
+          onChange={handleChange}
+          className="w-full px-3 py-2 border border-neutral-300 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-neutral-700">Password</label>
+        <input
+          type="password"
+          name="password"
+          value={password}
+          onChange={handleChange}
+          className="w-full px-3 py-2 border border-neutral-300 rounded-md"
+        />
+      </div>
+    </form>
+  );
+};
+
+export default MQTTConfig;

--- a/Frontend/src/store/mqttStore.ts
+++ b/Frontend/src/store/mqttStore.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface MQTTState {
+  url: string;
+  username: string;
+  password: string;
+  setConfig: (cfg: Partial<Omit<MQTTState, 'setConfig'>>) => void;
+}
+
+export const useMQTTStore = create<MQTTState>()(
+  persist(
+    (set) => ({
+      url: '',
+      username: '',
+      password: '',
+      setConfig: (cfg) =>
+        set((s) => ({
+          ...s,
+          ...cfg,
+        })),
+    }),
+    { name: 'mqtt-config' }
+  )
+);


### PR DESCRIPTION
## Summary
- add MQTT ingestion service that stores meter readings and triggers threshold notifications
- provide React config component and store for MQTT credentials
- add tests simulating MQTT messages and broker errors

## Testing
- `npm test` (backend) *(fails: vitest not found)*
- `npm test` (frontend) *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b54e41d17083238c13c4f6b693f530