### PR TITLE
Add route model, calendar API, and mobile workflow

### DIFF
--- a/Backend/models/Route.ts
+++ b/Backend/models/Route.ts
@@ -1,0 +1,21 @@
+import mongoose from 'mongoose';
+
+const stationTaskSchema = new mongoose.Schema(
+  {
+    station: { type: mongoose.Schema.Types.ObjectId, ref: 'Station', required: true },
+    task: { type: String, required: true },
+    order: { type: Number, required: true }
+  },
+  { _id: false }
+);
+
+const routeSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    stationTasks: [stationTaskSchema],
+    tenantId: { type: mongoose.Schema.Types.ObjectId, required: true, index: true }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('Route', routeSchema);

--- a/Backend/routes/CalendarRoutes.ts
+++ b/Backend/routes/CalendarRoutes.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import WorkOrder from '../models/WorkOrder';
+
+const router = express.Router();
+
+router.get('/', async (_req, res) => {
+  const events = await WorkOrder.find({ dueDate: { $exists: true } }).select('title dueDate');
+  res.json(
+    events.map((e) => ({ id: e._id, title: e.title, date: e.dueDate }))
+  );
+});
+
+export default router;

--- a/Backend/server.ts
+++ b/Backend/server.ts
@@ -27,9 +27,10 @@ import notificationsRoutes from './routes/notifications';
 import TenantRoutes from './routes/TenantRoutes';
 
 import ThemeRoutes from './routes/ThemeRoutes';
- 
+
 import chatRoutes from './routes/ChatRoutes';
 import requestPortalRoutes from './routes/requestPortal';
+import calendarRoutes from './routes/CalendarRoutes';
  
   
  
@@ -138,6 +139,7 @@ app.use('/api/team', teamRoutes);
 app.use('/api/theme', ThemeRoutes);
 app.use('/api/request-portal', requestPortalRoutes);
 app.use('/api/chat', chatRoutes);
+app.use('/api/calendar', calendarRoutes);
 
 app.use('/api/summary', summaryRoutes);
 

--- a/Backend/tests/calendarRoutes.test.ts
+++ b/Backend/tests/calendarRoutes.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import calendarRoutes from '../routes/CalendarRoutes';
+import WorkOrder from '../models/WorkOrder';
+
+const app = express();
+app.use(express.json());
+app.use('/api/calendar', calendarRoutes);
+
+let mongo: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+});
+
+describe('Calendar Routes', () => {
+  it('returns events with dates', async () => {
+    await WorkOrder.create({
+      title: 'WO',
+      tenantId: new mongoose.Types.ObjectId(),
+      dueDate: new Date('2024-01-01T00:00:00Z'),
+    });
+
+    const res = await request(app).get('/api/calendar').expect(200);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].title).toBe('WO');
+    expect(new Date(res.body[0].date).toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+});

--- a/Backend/tests/routeModel.test.ts
+++ b/Backend/tests/routeModel.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import mongoose from 'mongoose';
+import Route from '../models/Route';
+
+describe('Route model', () => {
+  it('preserves task order', () => {
+    const tenantId = new mongoose.Types.ObjectId();
+    const route = new Route({
+      name: 'Route A',
+      tenantId,
+      stationTasks: [
+        { station: new mongoose.Types.ObjectId(), task: 'Inspect', order: 1 },
+        { station: new mongoose.Types.ObjectId(), task: 'Clean', order: 2 },
+      ],
+    });
+
+    expect(route.stationTasks[0].order).toBe(1);
+    expect(route.stationTasks[1].order).toBe(2);
+  });
+});

--- a/Frontend/mobile/routes/RouteWorkflow.test.tsx
+++ b/Frontend/mobile/routes/RouteWorkflow.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import RouteWorkflow from './RouteWorkflow';
+
+describe('RouteWorkflow', () => {
+  const tasks = [
+    { id: '1', title: 'A' },
+    { id: '2', title: 'B' },
+  ];
+
+  it('progresses through tasks sequentially', () => {
+    render(<RouteWorkflow tasks={tasks} />);
+    expect(screen.getByTestId('current-task').textContent).toBe('A');
+    fireEvent.click(screen.getByText('Next'));
+    expect(screen.getByTestId('current-task').textContent).toBe('B');
+    fireEvent.click(screen.getByText('Next'));
+    expect(screen.getByTestId('complete')).toBeInTheDocument();
+  });
+});

--- a/Frontend/mobile/routes/RouteWorkflow.tsx
+++ b/Frontend/mobile/routes/RouteWorkflow.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useRouteProgress, RouteTask } from './useRouteProgress';
+
+interface Props {
+  tasks: RouteTask[];
+}
+
+const RouteWorkflow: React.FC<Props> = ({ tasks }) => {
+  const { current, isComplete, next } = useRouteProgress(tasks);
+  return (
+    <div>
+      {isComplete ? (
+        <p data-testid="complete">Route Complete</p>
+      ) : (
+        <div>
+          <p data-testid="current-task">{current.title}</p>
+          <button onClick={next}>Next</button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RouteWorkflow;

--- a/Frontend/mobile/routes/useRouteProgress.ts
+++ b/Frontend/mobile/routes/useRouteProgress.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+export interface RouteTask {
+  id: string;
+  title: string;
+}
+
+export function useRouteProgress(tasks: RouteTask[]) {
+  const [index, setIndex] = useState(0);
+  const current = tasks[index];
+  const next = () => setIndex((i) => Math.min(i + 1, tasks.length));
+  return { current, index, isComplete: index >= tasks.length, next };
+}

--- a/Frontend/src/calendar/CalendarView.test.tsx
+++ b/Frontend/src/calendar/CalendarView.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import CalendarView from './CalendarView';
+import React from 'react';
+
+describe('CalendarView', () => {
+  const events = [
+    { id: '1', title: 'Test', date: '2024-01-01T12:00:00Z' },
+  ];
+
+  it('renders events', () => {
+    render(<CalendarView events={events} timeZone="UTC" />);
+    expect(screen.getByText('Test')).toBeInTheDocument();
+  });
+
+  it('formats dates in different timezones', () => {
+    const { rerender } = render(<CalendarView events={events} timeZone="UTC" />);
+    const utcTime = screen.getByTestId('event-time').textContent;
+    rerender(<CalendarView events={events} timeZone="America/New_York" />);
+    const nyTime = screen.getByTestId('event-time').textContent;
+    expect(utcTime).not.toBe(nyTime);
+  });
+});

--- a/Frontend/src/calendar/CalendarView.tsx
+++ b/Frontend/src/calendar/CalendarView.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { CalendarEvent } from './api';
+
+interface Props {
+  events: CalendarEvent[];
+  timeZone?: string;
+}
+
+const CalendarView: React.FC<Props> = ({ events, timeZone }) => {
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    timeZone,
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+
+  return (
+    <ul>
+      {events.map((evt) => (
+        <li key={evt.id} data-testid="event">
+          <span>{evt.title}</span>
+          <time data-testid="event-time" dateTime={evt.date}>
+            {formatter.format(new Date(evt.date))}
+          </time>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default CalendarView;

--- a/Frontend/src/calendar/api.ts
+++ b/Frontend/src/calendar/api.ts
@@ -1,0 +1,11 @@
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  date: string;
+}
+
+export async function fetchCalendarEvents(): Promise<CalendarEvent[]> {
+  const res = await fetch('/api/calendar');
+  if (!res.ok) throw new Error('Failed to fetch calendar');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add Route model with ordered station tasks
- expose calendar API and hook up calendar view
- create mobile route workflow with sequential task progression

## Testing
- `npm test` (backend) *(fails: vitest not found)*
- `npm install` (backend) *(fails: see logs)*
- `npm test` (frontend) *(fails: vitest not found)*
- `npm install` (frontend) *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b54e42de60832382755825c2c80ef6