### PR TITLE
feat: add vendor portal routes and auth

### DIFF
--- a/Backend/middleware/vendorAuth.ts
+++ b/Backend/middleware/vendorAuth.ts
@@ -1,0 +1,49 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+import jwt from 'jsonwebtoken';
+import Vendor from '../models/Vendor';
+
+interface VendorTokenPayload {
+  id: string;
+}
+
+/**
+ * Middleware to authenticate vendor requests using a JWT token.
+ * The token should be provided in the `Authorization` header as
+ * a Bearer token. On success, the vendor document and `vendorId`
+ * are attached to the request object.
+ */
+export const requireVendorAuth: RequestHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+
+    const token = authHeader.substring(7);
+    const secret = process.env.VENDOR_JWT_SECRET || process.env.JWT_SECRET;
+    if (!secret) {
+      res.status(500).json({ message: 'Server configuration issue' });
+      return;
+    }
+
+    const { id } = jwt.verify(token, secret) as VendorTokenPayload;
+    const vendor = await Vendor.findById(id).lean();
+    if (!vendor) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+
+    (req as any).vendor = vendor;
+    (req as any).vendorId = vendor._id.toString();
+    next();
+  } catch (_err) {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+};
+
+export default { requireVendorAuth };

--- a/Backend/routes/vendorPortal.ts
+++ b/Backend/routes/vendorPortal.ts
@@ -1,0 +1,71 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import Vendor from '../models/Vendor';
+import PurchaseOrder from '../models/PurchaseOrder';
+import { requireVendorAuth } from '../middleware/vendorAuth';
+
+const router = express.Router();
+
+// Vendor login - issues a JWT for portal access
+router.post('/login', async (req, res) => {
+  const { vendorId, email } = req.body;
+  if (!vendorId) {
+    res.status(400).json({ message: 'vendorId required' });
+    return;
+  }
+
+  const vendor = await Vendor.findById(vendorId).lean();
+  if (!vendor || (email && vendor.email !== email)) {
+    res.status(401).json({ message: 'Invalid credentials' });
+    return;
+  }
+
+  const secret = process.env.VENDOR_JWT_SECRET || process.env.JWT_SECRET;
+  if (!secret) {
+    res.status(500).json({ message: 'Server configuration issue' });
+    return;
+  }
+
+  const token = jwt.sign({ id: vendor._id.toString() }, secret, {
+    expiresIn: '7d',
+  });
+  res.json({ token });
+});
+
+// Retrieve a purchase order for the authenticated vendor
+router.get('/purchase-orders/:id', requireVendorAuth, async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const vendorId = (req as any).vendorId;
+    const po = await PurchaseOrder.findOne({ _id: id, vendor: vendorId }).lean();
+    if (!po) {
+      res.status(404).json({ message: 'Not found' });
+      return;
+    }
+    res.json(po);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Update a purchase order for the authenticated vendor
+router.put('/purchase-orders/:id', requireVendorAuth, async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const vendorId = (req as any).vendorId;
+    const po = await PurchaseOrder.findOneAndUpdate(
+      { _id: id, vendor: vendorId },
+      req.body,
+      { new: true, runValidators: true }
+    ).lean();
+    if (!po) {
+      res.status(404).json({ message: 'Not found' });
+      return;
+    }
+    res.json(po);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/Backend/server.ts
+++ b/Backend/server.ts
@@ -31,6 +31,7 @@ import webhooksRoutes from './routes/webhooks';
 import ThemeRoutes from './routes/ThemeRoutes';
 import chatRoutes from './routes/ChatRoutes';
 import requestPortalRoutes from './routes/requestPortal';
+import vendorPortalRoutes from './routes/vendorPortal';
 
 // Keep BOTH of these:
 import calendarRoutes from './routes/CalendarRoutes';
@@ -138,6 +139,7 @@ app.use('/api/v1/analytics', analyticsRoutes);
 app.use('/api/team', teamRoutes);
 app.use('/api/theme', ThemeRoutes);
 app.use('/api/request-portal', requestPortalRoutes);
+app.use('/api/vendor-portal', vendorPortalRoutes);
 app.use('/api/chat', chatRoutes);
 app.use('/api/webhooks', webhooksRoutes);
 app.use('/api/calendar', calendarRoutes);


### PR DESCRIPTION
## Summary
- add middleware to authenticate vendor tokens
- create vendor portal routes for login and purchase order access
- wire vendor portal router into server

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types/passport)*

------
https://chatgpt.com/codex/tasks/task_e_68b55613598c83239cded12c18b4ca38