### PR TITLE
refactor: initialize chat socket using env endpoints

### DIFF
--- a/Frontend/src/utils/chatSocket.ts
+++ b/Frontend/src/utils/chatSocket.ts
@@ -1,18 +1,16 @@
 import { io, type Socket } from 'socket.io-client';
 import { useSocketStore } from '../store/socketStore';
+import { endpoints } from './env';
 
 let socket: Socket | null = null;
 
 export function getChatSocket(): Socket {
   if (socket) return socket;
 
-  const base =
-    import.meta.env.VITE_WS_NOTIFICATIONS_URL ?? 'ws://localhost:5055';
-
-  socket = io(base, {
-    path: '/ws/notifications',
-    transports: ['websocket'],
-    autoConnect: true,
+  socket = io(endpoints.httpOrigin, {
+    path: endpoints.socketPath,
+    transports: ['websocket', 'polling'],
+    withCredentials: true,
   });
 
   const { setConnected } = useSocketStore.getState();

--- a/Frontend/src/utils/env.ts
+++ b/Frontend/src/utils/env.ts
@@ -6,3 +6,8 @@ export const getEnvVar = (key: string): string | undefined => {
 export const config = {
   apiUrl: getEnvVar('VITE_API_URL'),
 };
+
+export const endpoints = {
+  httpOrigin: getEnvVar('VITE_HTTP_ORIGIN') ?? '',
+  socketPath: getEnvVar('VITE_SOCKET_PATH') ?? '/ws/notifications',
+};


### PR DESCRIPTION
## Summary
- use environment-provided endpoints for chat socket connection
- expose http origin and socket path via `endpoints` helper

## Testing
- `npm test` *(fails: vitest not found; npm ci 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b5615832d083239e3b3ab61483d81e