### PR TITLE
feat: add live dashboard notifications with polling fallback

### DIFF
--- a/Frontend/src/utils/notificationsSocket.ts
+++ b/Frontend/src/utils/notificationsSocket.ts
@@ -1,0 +1,40 @@
+import { io, type Socket } from 'socket.io-client';
+import { useSocketStore } from '../store/socketStore';
+
+let socket: Socket | null = null;
+let poll: ReturnType<typeof setInterval> | null = null;
+
+export function getNotificationsSocket(): Socket {
+  if (socket) return socket;
+  const base =
+    import.meta.env.VITE_WS_NOTIFICATIONS_URL ?? 'ws://localhost:5055';
+  socket = io(base, {
+    path: '/ws/notifications',
+    transports: ['websocket'],
+    autoConnect: true,
+  });
+  const { setConnected } = useSocketStore.getState();
+  socket.on('connect', () => setConnected(true));
+  socket.on('disconnect', () => setConnected(false));
+  socket.on('connect_error', () => setConnected(false));
+  return socket;
+}
+
+export function closeNotificationsSocket() {
+  if (socket) {
+    socket.close();
+    socket = null;
+  }
+}
+
+export function startNotificationsPoll(fn: () => void, interval = 10_000) {
+  if (poll) return;
+  poll = setInterval(fn, interval);
+}
+
+export function stopNotificationsPoll() {
+  if (poll) {
+    clearInterval(poll);
+    poll = null;
+  }
+}


### PR DESCRIPTION
## Summary
- enable live dashboard updates via notifications socket with polling fallback and toggle
- guard dashboard stats with defaults and use summary endpoints

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for react-dom)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b56158b2bc83239922e418e3aa40a9