### PR TITLE
feat: add customizable dashboard grid

### DIFF
--- a/Frontend/src/store/dashboardStore.ts
+++ b/Frontend/src/store/dashboardStore.ts
@@ -47,7 +47,16 @@ export const useDashboardStore = create<DashboardState>()(
       setRole: (role) => set({ role }),
       setDateRange: (dateRange) => set({ dateRange }),
       setSelectedKPIs: (selectedKPIs) => set({ selectedKPIs }),
-      setLayouts: (layouts) => set({ layouts }),
+      setLayouts: (layouts) => {
+        set({ layouts });
+        try {
+          if (typeof window !== 'undefined') {
+            localStorage.setItem('dashboardLayoutV1', JSON.stringify(layouts));
+          }
+        } catch {
+          /* ignore */
+        }
+      },
       addKPI: (id) =>
         set((state) => ({
           selectedKPIs: state.selectedKPIs.includes(id)


### PR DESCRIPTION
## Summary
- integrate ResponsiveGridLayout to arrange dashboard cards
- allow users to toggle layout customization for draggable and resizable cards
- persist dashboard layout to localStorage and restore on load

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b5615bf16c83238f46b3829536f54e