### PR TITLE
feat: add export options on dashboard

### DIFF
--- a/Frontend/src/utils/exportCsv.ts
+++ b/Frontend/src/utils/exportCsv.ts
@@ -1,0 +1,37 @@
+import { saveAs } from 'file-saver';
+
+export type CSVInput = Record<string, any>[] | Record<string, any>;
+
+/**
+ * Generates a CSV file from an array of objects or a single object and triggers a download.
+ * - Arrays of objects use their keys as headers.
+ * - Plain objects are converted to a two-column key/value table.
+ */
+const exportCsv = (data: CSVInput, filename = 'data') => {
+  let rows: Record<string, any>[] = [];
+
+  if (Array.isArray(data)) {
+    rows = data;
+  } else if (data && typeof data === 'object') {
+    rows = Object.entries(data).map(([key, value]) => ({ key, value }));
+  }
+
+  if (!rows.length) return;
+
+  const headers = Array.from(
+    rows.reduce((set, row) => {
+      Object.keys(row).forEach((k) => set.add(k));
+      return set;
+    }, new Set<string>())
+  );
+
+  const csv = [
+    headers.join(','),
+    ...rows.map((row) => headers.map((h) => JSON.stringify(row[h] ?? '')).join(',')),
+  ].join('\n');
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  saveAs(blob, `${filename}.csv`);
+};
+
+export default exportCsv;


### PR DESCRIPTION
## Summary
- add utility to build and download CSV files from arrays or objects
- add Export CSV and Export PDF buttons to dashboard
- generate dashboard summary PDF via lazy-loaded html2canvas and jsPDF

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5615db4ac8323b55e4e19de6a8416