### PR TITLE
docs: add dashboard acceptance tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,13 @@ using the browser's `online` event even if the WebSocket fails to reconnect.
 
 This project is licensed under the [MIT License](LICENSE).
 
+
+## Dashboard Acceptance Tests
+
+- Real numbers load with API running.
+- Live Data ON updates KPIs within 5 s on backend changes.
+- Socket outage triggers polling within 10 s.
+- Live Data OFF disables socket and polling.
+- CSV/PDF export produces correct files.
+- Layout customization persists after reload.
+- Drill-through links apply correct filters.


### PR DESCRIPTION
## Summary
- document dashboard acceptance tests in README to outline key functional expectations

## Testing
- `cd Backend && npm test` *(fails: sh: 1: vitest: not found)*
- `cd Frontend && npm test` *(fails: sh: 1: vitest: not found)*
- `cd Frontend && npm run test:e2e` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b561630dfc8323b934e84554230559