### PR TITLE
Add navigate hook to DashboardStats KPIs

### DIFF
--- a/Frontend/src/components/dashboard/DashboardStats.tsx
+++ b/Frontend/src/components/dashboard/DashboardStats.tsx
@@ -32,7 +32,6 @@ interface StatCardProps {
   iconBg?: string;
   linkTo?: string;
   onRemove?: () => void;
-  linkTo?: string;
   tooltip?: string;
 }
 
@@ -85,14 +84,6 @@ const SortableStatCard: React.FC<StatCardProps> = (props) => {
     isDragging,
   } = useSortable({ id: props.id });
   const navigate = useNavigate();
-
-  const navigate = useNavigate();
-
-  const handleClick = () => {
-    if (props.linkTo) {
-      navigate(props.linkTo);
-    }
-  };
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -274,6 +265,8 @@ const DashboardStats: React.FC<DashboardStatsProps> = ({ stats }) => {
 
     setActiveId(null);
   };
+
+  const navigate = useNavigate();
 
   const allKPIs = [
     ...defaultKPIs,


### PR DESCRIPTION
## Summary
- Add useNavigate hook in DashboardStats before generating KPI list
- Clean up duplicate declarations in SortableStatCard

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5779a02208323908abe0a66b706f1