### PR TITLE
Remove unused analytics from dashboard

### DIFF
--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -8,7 +8,6 @@ import { useDashboardStore } from '../store/dashboardStore';
 import { useSocketStore } from '../store/socketStore';
 import useDashboardData from '../hooks/useDashboardData';
 import { useSummary } from '../hooks/useSummaryData';
-import api from '../utils/api';
 import FiltersBar from '../components/dashboard/FiltersBar';
 import {
   getNotificationsSocket,
@@ -103,7 +102,6 @@ const Dashboard: React.FC = () => {
   });
   const [lowStockParts, setLowStockParts] = useState<LowStockPart[]>([]);
   const [departments, setDepartments] = useState<Department[]>([]);
-  const [analytics, setAnalytics] = useState<any | null>(null);
   const [customize, setCustomize] = useState(false);
   const dashboardRef = useRef<HTMLDivElement>(null);
 
@@ -194,19 +192,6 @@ const Dashboard: React.FC = () => {
     if (Array.isArray(departmentsData)) setDepartments(departmentsData);
   }, [departmentsData]);
 
-  // analytics (optional)
-  useEffect(() => {
-    const fetchAnalytics = async () => {
-      try {
-        const res = await api.get(`/reports/analytics${buildQuery()}`);
-        setAnalytics(res.data);
-      } catch (err) {
-        console.error('Error fetching analytics', err);
-      }
-    };
-    fetchAnalytics();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedDepartment, selectedRole, selectedTimeframe, customRange]);
 
   // socket-driven refresh with polling fallback
   useEffect(() => {

--- a/Frontend/src/test/dashboardDepartments.test.tsx
+++ b/Frontend/src/test/dashboardDepartments.test.tsx
@@ -14,28 +14,33 @@ vi.mock('../utils/notificationsSocket', () => ({
   getNotificationsSocket: () => mockSocket,
 }));
 
+const departments = [
+  { id: 'prod', name: 'Production' },
+  { id: 'pack', name: 'Packaging' },
+];
 
-vi.mock('../utils/api', () => {
-  const departments = [
-    { id: 'prod', name: 'Production' },
-    { id: 'pack', name: 'Packaging' },
-  ];
-  return {
-    fetchSummary: vi.fn().mockResolvedValue({}),
-    fetchAssetSummary: vi.fn().mockResolvedValue([]),
-    fetchWorkOrderSummary: vi.fn().mockResolvedValue([]),
-    fetchUpcomingMaintenance: vi.fn().mockResolvedValue([]),
-    fetchCriticalAlerts: vi.fn().mockResolvedValue([]),
-    fetchLowStock: vi.fn().mockResolvedValue([]),
-    fetchDepartments: vi.fn().mockResolvedValue(departments),
-    default: {
-      get: vi.fn((url: string) => {
-        if (url === '/departments') return Promise.resolve({ data: departments });
-        return Promise.resolve({ data: { laborUtilization: 0 } });
-      }),
-    },
-  };
+export const getMock = vi.fn((url: string) => {
+  if (url === '/summary/departments') {
+    return Promise.resolve({ data: departments });
+  }
+  if (url === '/summary/low-stock') {
+    return Promise.resolve({ data: [] });
+  }
+  if (url === '/summary') {
+    return Promise.resolve({ data: {} });
+  }
+  return Promise.resolve({ data: { laborUtilization: 0 } });
 });
+
+vi.mock('../utils/api', () => ({
+  fetchSummary: vi.fn().mockResolvedValue({}),
+  fetchAssetSummary: vi.fn().mockResolvedValue([]),
+  fetchWorkOrderSummary: vi.fn().mockResolvedValue([]),
+  fetchUpcomingMaintenance: vi.fn().mockResolvedValue([]),
+  fetchCriticalAlerts: vi.fn().mockResolvedValue([]),
+  fetchLowStock: vi.fn().mockResolvedValue([]),
+  default: { get: getMock },
+}));
 
 describe('Dashboard departments', () => {
   beforeEach(() => {
@@ -56,5 +61,6 @@ describe('Dashboard departments', () => {
 
     expect(await screen.findByRole('option', { name: 'Production' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Packaging' })).toBeInTheDocument();
+    expect(getMock).not.toHaveBeenCalledWith(expect.stringContaining('/reports/analytics'));
   });
 });


### PR DESCRIPTION
## Summary
- clean up Dashboard by removing unused analytics state and fetch effect
- update dashboard department test to mock summaries and assert no analytics call

## Testing
- `npm test -- --run src/test/dashboardDepartments.test.tsx` *(failed: vitest not found)*
- `npm ci` *(failed: 403 Forbidden for react-dom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68b5779b55f88323aa698b3b1ca998f1