### PR TITLE
refactor: rely on store to persist dashboard layouts

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -111,6 +111,6 @@ curl -X POST "$VITE_API_URL/inventory" \
 
 The dashboard uses a small zustand store with the `persist` middleware. Your
 selected timeframe, department filter, date range and any custom KPIs are saved
-to `localStorage` under the key `dashboard-storage`. When you return to the
+to `localStorage` under the key `dashboard-layouts`. When you return to the
 dashboard, these preferences are automatically loaded so your layout and filters
 remain the same across sessions.

--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -152,19 +152,6 @@ const Dashboard: React.FC = () => {
     { ttlMs: 60_000 },
   );
 
-  // restore saved layout (once)
-  useEffect(() => {
-    try {
-      const stored = typeof window !== 'undefined' ? localStorage.getItem('dashboardLayoutV1') : null;
-      if (stored) {
-        setLayouts(JSON.parse(stored));
-      } else {
-        setLayouts(defaultLayouts);
-      }
-    } catch {
-      setLayouts(defaultLayouts);
-    }
-  }, [setLayouts]);
 
   // map summaries to local state
   useEffect(() => {
@@ -282,11 +269,6 @@ const Dashboard: React.FC = () => {
 
   const handleLayoutChange = (_: any, allLayouts: Layouts) => {
     setLayouts(allLayouts);
-    try {
-      localStorage.setItem('dashboardLayoutV1', JSON.stringify(allLayouts));
-    } catch {
-      // ignore persistence errors
-    }
   };
 
   const handleExportCSV = async () => {

--- a/Frontend/src/store/dashboardStore.ts
+++ b/Frontend/src/store/dashboardStore.ts
@@ -49,13 +49,6 @@ export const useDashboardStore = create<DashboardState>()(
       setSelectedKPIs: (selectedKPIs) => set({ selectedKPIs }),
       setLayouts: (layouts) => {
         set({ layouts });
-        try {
-          if (typeof window !== 'undefined') {
-            localStorage.setItem('dashboardLayoutV1', JSON.stringify(layouts));
-          }
-        } catch {
-          /* ignore */
-        }
       },
       addKPI: (id) =>
         set((state) => ({
@@ -69,7 +62,7 @@ export const useDashboardStore = create<DashboardState>()(
         })),
     }),
     {
-      name: 'dashboard-storage',
+      name: 'dashboard-layouts',
     }
   )
 );


### PR DESCRIPTION
## Summary
- remove manual dashboard layout localStorage handling
- persist layouts via zustand store only
- document new dashboard layout storage key

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5779c9fcc832398590d85f329c5b5