### PR TITLE
Safeguard timer hooks for SSR environments

### DIFF
--- a/Frontend/src/hooks/useDashboardData.ts
+++ b/Frontend/src/hooks/useDashboardData.ts
@@ -47,7 +47,9 @@ function debounce<F extends (...args: any[]) => void>(fn: F, delay: number) {
   let timer: ReturnType<typeof setTimeout> | null = null;
   const debounced = (...args: Parameters<F>) => {
     if (timer) clearTimeout(timer);
-    timer = window.setTimeout(() => fn(...args), delay);
+    if (typeof window !== 'undefined') {
+      timer = setTimeout(() => fn(...args), delay);
+    }
   };
   (debounced as any).cancel = () => {
     if (timer) {

--- a/Frontend/src/hooks/useSummaryData.ts
+++ b/Frontend/src/hooks/useSummaryData.ts
@@ -57,8 +57,10 @@ export function useSummary<T = unknown>(
     mountedRef.current = true;
     if (auto) fetcher().catch(() => {});
 
-    let timer: number | undefined;
-    if (poll) timer = window.setInterval(() => fetcher().catch(() => {}), 60_000);
+    let timer: ReturnType<typeof setInterval> | undefined;
+    if (poll && typeof window !== 'undefined') {
+      timer = setInterval(() => fetcher().catch(() => {}), 60_000);
+    }
 
     return () => {
       mountedRef.current = false;


### PR DESCRIPTION
## Summary
- replace browser-specific window timers with generic timers in dashboard and summary hooks
- guard timers with `typeof window !== 'undefined'` to avoid SSR issues

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - react-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68b5779f47a48323bcbfd4809ed1feb0