### PR TITLE
Validate custom date range in dashboard FiltersBar

### DIFF
--- a/Frontend/src/components/dashboard/FiltersBar.test.tsx
+++ b/Frontend/src/components/dashboard/FiltersBar.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import FiltersBar from './FiltersBar';
+import { useDashboardStore } from '../../store/dashboardStore';
+import type { Department } from '../../types';
+
+const departments: Department[] = [];
+
+describe('FiltersBar', () => {
+  beforeEach(() => {
+    useDashboardStore.setState({
+      selectedTimeframe: 'custom',
+      customRange: { start: '2024-01-10', end: '2024-01-20' },
+      selectedDepartment: 'all',
+      selectedRole: 'all',
+    });
+  });
+
+  it('shows error for invalid custom range', () => {
+    const setCustomRange = vi.spyOn(useDashboardStore.getState(), 'setCustomRange');
+    render(<FiltersBar departments={departments} />);
+
+    const startInput = screen.getByDisplayValue('2024-01-10');
+    fireEvent.change(startInput, { target: { value: '2024-01-25' } });
+
+    expect(screen.getByText(/start date must be before end date/i)).toBeInTheDocument();
+    expect(setCustomRange).not.toHaveBeenCalled();
+  });
+});

--- a/Frontend/src/components/dashboard/FiltersBar.tsx
+++ b/Frontend/src/components/dashboard/FiltersBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useDashboardStore, Timeframe } from '../../store/dashboardStore';
 import type { Department } from '../../types';
 
@@ -18,8 +18,30 @@ const FiltersBar: React.FC<Props> = ({ departments }) => {
     setSelectedRole,
   } = useDashboardStore();
 
+  const [rangeError, setRangeError] = useState('');
+
   const handleTimeframeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedTimeframe(e.target.value as Timeframe);
+  };
+
+  const handleStartChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const start = e.target.value;
+    if (customRange.end && start > customRange.end) {
+      setRangeError('Start date must be before end date');
+      return;
+    }
+    setRangeError('');
+    setCustomRange({ ...customRange, start });
+  };
+
+  const handleEndChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const end = e.target.value;
+    if (customRange.start && end < customRange.start) {
+      setRangeError('End date must be after start date');
+      return;
+    }
+    setRangeError('');
+    setCustomRange({ ...customRange, end });
   };
 
   return (
@@ -40,15 +62,16 @@ const FiltersBar: React.FC<Props> = ({ departments }) => {
           <input
             type="date"
             value={customRange.start}
-            onChange={(e) => setCustomRange({ ...customRange, start: e.target.value })}
+            onChange={handleStartChange}
             className="border border-neutral-300 rounded-md px-2 py-1 text-sm"
           />
           <input
             type="date"
             value={customRange.end}
-            onChange={(e) => setCustomRange({ ...customRange, end: e.target.value })}
+            onChange={handleEndChange}
             className="border border-neutral-300 rounded-md px-2 py-1 text-sm"
           />
+          {rangeError && <p className="text-red-500 text-xs">{rangeError}</p>}
         </>
       )}
       <select


### PR DESCRIPTION
## Summary
- add custom date range validation to FiltersBar
- show error message for invalid ranges
- test invalid range handling

## Testing
- `npm test -- FiltersBar.test.tsx` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5779ff50883239d22fe6721894591