### PR TITLE
Apply rate limiting to department routes

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -12,6 +12,7 @@ npm run dev
 ```
 
 Incoming JSON request bodies are limited to **1 MB**. Adjust the limit by editing the `express.json` configuration in `server.ts` if your application requires larger payloads.
+Requests to `/api` are protected by a general rate limiter. The department endpoints now fall under this limiter.
 The server connects to MongoDB using the `MONGO_URI` environment variable. This variable is used consistently across the codebase and example configuration files. The server also starts a Socket.IO server on the same HTTP port. Clients can listen for real-time updates using the following events:
 
 - `workOrderUpdated`

--- a/Backend/server.ts
+++ b/Backend/server.ts
@@ -121,11 +121,10 @@ app.get('/', (_req: Request, res: Response) => {
 // --- Routes (order matters for the limiter) ---
 app.use('/api/auth', authRoutes);
 app.use('/api/notifications', burstFriendly, notificationsRoutes);
-app.use('/api/departments', departmentRoutes);
-
 // Apply limiter to the rest of /api
 app.use('/api', generalLimiter);
 
+app.use('/api/departments', departmentRoutes);
 app.use('/api/workorders', workOrdersRoutes);
 app.use('/api/assets', assetsRoutes);
 app.use('/api/condition-rules', conditionRuleRoutes);


### PR DESCRIPTION
## Summary
- ensure `/api/departments` is covered by the general API rate limiter
- document that department endpoints now share the `/api` rate limit

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @types/passport)*

------
https://chatgpt.com/codex/tasks/task_e_68b57bed494083239bb1f74252d0ccaf