### PR TITLE
refactor: unify env config and stabilize notifications

### DIFF
--- a/Frontend/.env.local
+++ b/Frontend/.env.local
@@ -1,0 +1,6 @@
+VITE_API_URL=http://localhost:5010/api
+VITE_HTTP_ORIGIN=http://localhost:5010
+VITE_SOCKET_PATH=/socket.io
+# Optional: if sockets are on a different host:
+# VITE_WS_URL=ws://localhost:5010
+

--- a/Frontend/.gitignore
+++ b/Frontend/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+!.env.local
 
 # Editor directories and files
 .vscode/*

--- a/Frontend/src/utils/api.ts
+++ b/Frontend/src/utils/api.ts
@@ -15,14 +15,12 @@ import type {
   CriticalAlertResponse,
   LowStockPartResponse,
 } from "../types";
-import { endpoints } from "./env";
-
-// Base URL derived from configured HTTP origin.
-const baseURL = `${endpoints.httpOrigin}/api`;
+import { apiBaseUrl } from "./env";
 
 const api = axios.create({
-  baseURL,
+  baseURL: apiBaseUrl, // http://localhost:5010/api by default
   withCredentials: true,
+  timeout: 20000,
 });
 
 api.interceptors.request.use((cfg) => {


### PR DESCRIPTION
## Summary
- consolidate env handling for HTTP and Socket endpoints
- reconnect notifications socket with polling fallback
- centralize API base URL for axios and provide sample .env.local

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b580a3cdec83239a20ffcce32b18a9