### PR TITLE
Add minimal passport-openidconnect type declaration

### DIFF
--- a/Backend/types/passport-openidconnect.d.ts
+++ b/Backend/types/passport-openidconnect.d.ts
@@ -1,0 +1,29 @@
+declare module 'passport-openidconnect' {
+  import { Strategy as PassportStrategy } from 'passport';
+
+  export interface StrategyOptions {
+    issuer: string;
+    clientID: string;
+    clientSecret: string;
+    callbackURL: string;
+  }
+
+  export interface VerifyCallback {
+    (
+      issuer: string,
+      sub: string,
+      profile: any,
+      jwtClaims: any,
+      accessToken: string,
+      refreshToken: string,
+      params: any,
+      done: (err: any, user?: any) => void,
+    ): void;
+  }
+
+  export class Strategy extends PassportStrategy {
+    constructor(options: StrategyOptions, verify: VerifyCallback);
+  }
+
+  export default Strategy;
+}


### PR DESCRIPTION
## Summary
- declare minimal `passport-openidconnect` module with Strategy and VerifyCallback types so backend TypeScript recognizes the OIDC strategy

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm ci` *(fails: 403 Forbidden for @types/passport)*

------
https://chatgpt.com/codex/tasks/task_e_68b58418acd4832394e2bbc2f33e66aa