### PR TITLE
feat: add permission based authorization

### DIFF
--- a/Backend/middleware/authMiddleware.ts
+++ b/Backend/middleware/authMiddleware.ts
@@ -1,6 +1,7 @@
 
 import jwt from 'jsonwebtoken';
 import User, { UserDocument } from '../models/User';
+import Role from '../models/Role';
 import { RequestHandler } from 'express';
 import { AuthedRequest } from '../types/AuthedRequest';
 
@@ -49,8 +50,11 @@ export const requireAuth: RequestHandler = async (
       return;
     }
 
+    const role = await Role.findOne({ name: user.role }).lean();
+    const permissions = role?.permissions ?? [];
+
     const tenantId = user.tenantId.toString();
-    (req as AuthedRequest).user = { ...user, tenantId };
+    (req as AuthedRequest).user = { ...user, tenantId, permissions } as any;
     (req as AuthedRequest).tenantId = tenantId;
 
     next();

--- a/Backend/middleware/authorize.ts
+++ b/Backend/middleware/authorize.ts
@@ -1,0 +1,26 @@
+import { RequestHandler } from 'express';
+
+/**
+ * Factory for permission-based authorization middleware.
+ * Ensures the authenticated user has all required permissions
+ * before allowing the request to proceed.
+ */
+export const authorize = (...required: string[]): RequestHandler => {
+  return (req, res, next) => {
+    if (!req.user) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+
+    const userPerms = req.user.permissions || [];
+    const hasPerm = required.every((p) => userPerms.includes(p));
+    if (!hasPerm) {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
+
+    next();
+  };
+};
+
+export default authorize;

--- a/Backend/models/Role.ts
+++ b/Backend/models/Role.ts
@@ -8,7 +8,7 @@ export interface RoleDocument extends Document {
 const roleSchema = new Schema<RoleDocument>(
   {
     name: { type: String, required: true, unique: true },
-    permissions: [{ type: String }],
+    permissions: { type: [String], default: [] },
   },
   { timestamps: true }
 );

--- a/Backend/routes/WorkOrderRoutes.ts
+++ b/Backend/routes/WorkOrderRoutes.ts
@@ -12,6 +12,7 @@ import {
 } from '../controllers/WorkOrderController';
 import { requireAuth } from '../middleware/authMiddleware';
 import requireRole from '../middleware/requireRole';
+import authorize from '../middleware/authorize';
 import { validate } from '../middleware/validationMiddleware';
 import { workOrderValidators } from '../validators/workOrderValidators';
 
@@ -44,6 +45,7 @@ router.put(
 router.post(
   '/:id/approve',
   requireRole('admin', 'manager'),
+  authorize('workorders:approve'),
   approveWorkOrder
 );
 router.delete('/:id', requireRole('admin', 'manager'), deleteWorkOrder);

--- a/Backend/tests/auth/authorize.test.ts
+++ b/Backend/tests/auth/authorize.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import User from '../../models/User';
+import Role from '../../models/Role';
+import { requireAuth } from '../../middleware/authMiddleware';
+import authorize from '../../middleware/authorize';
+
+const app = express();
+app.use(express.json());
+app.get('/protected', requireAuth, authorize('perm:test'), (_req, res) => {
+  res.json({ ok: true });
+});
+
+let mongo: MongoMemoryServer;
+let tokenWith: string;
+let tokenWithout: string;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+
+  await Role.create({ name: 'with', permissions: ['perm:test'] });
+  await Role.create({ name: 'without', permissions: [] });
+
+  const userWith = await User.create({
+    name: 'With Perm',
+    email: 'with@example.com',
+    password: 'pass123',
+    role: 'with',
+    tenantId: new mongoose.Types.ObjectId(),
+  });
+  tokenWith = jwt.sign({ id: userWith._id.toString() }, process.env.JWT_SECRET!);
+
+  const userWithout = await User.create({
+    name: 'No Perm',
+    email: 'without@example.com',
+    password: 'pass123',
+    role: 'without',
+    tenantId: new mongoose.Types.ObjectId(),
+  });
+  tokenWithout = jwt.sign({ id: userWithout._id.toString() }, process.env.JWT_SECRET!);
+});
+
+describe('authorize middleware', () => {
+  it('allows access when permission is present', async () => {
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${tokenWith}`)
+      .expect(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('denies access when permission is missing', async () => {
+    await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${tokenWithout}`)
+      .expect(403);
+  });
+});

--- a/Backend/types/express/index.d.ts
+++ b/Backend/types/express/index.d.ts
@@ -3,6 +3,7 @@ import { UserDocument } from '../../models/User';
 
 export type RequestUser = Omit<LeanDocument<UserDocument>, 'tenantId'> & {
   tenantId: string;
+  permissions: string[];
 };
 
 declare global {


### PR DESCRIPTION
## Summary
- add permissions array to roles
- enforce route permissions via new authorize middleware
- apply approval permission to work order approve route
- cover permission checks with tests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58ce0acb0832399ac45a361df13cd