### PR TITLE
feat: add PWA with offline capabilities

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -90,7 +90,8 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
     "vite": "^6.3.5",
-    "vitest": "^3.2.2"
+    "vitest": "^3.2.2",
+    "vite-plugin-pwa": "^0.20.0"
   },
   "overrides": {
     "react": "18.2.0",

--- a/Frontend/src/components/layout/Layout.tsx
+++ b/Frontend/src/components/layout/Layout.tsx
@@ -11,6 +11,8 @@ interface LayoutProps {
 
 const Layout: React.FC<LayoutProps> = ({ children, title }) => {
   const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
+  const [installEvent, setInstallEvent] = useState<any>(null);
+  const [showInstall, setShowInstall] = useState(false);
   const { theme } = useThemeStore();
   const {
     theme: themeSettings,
@@ -35,6 +37,24 @@ const Layout: React.FC<LayoutProps> = ({ children, title }) => {
 
   const toggleMobileSidebar = () => {
     setSidebarMobileOpen(!sidebarMobileOpen);
+  };
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setInstallEvent(e);
+      setShowInstall(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler as EventListener);
+    return () => window.removeEventListener('beforeinstallprompt', handler as EventListener);
+  }, []);
+
+  const promptInstall = async () => {
+    if (!installEvent) return;
+    installEvent.prompt();
+    await installEvent.userChoice;
+    setInstallEvent(null);
+    setShowInstall(false);
   };
 
   return (
@@ -70,8 +90,20 @@ const Layout: React.FC<LayoutProps> = ({ children, title }) => {
           title={title}
         />
         
-        <main className="flex-1 p-2 sm:p-4 md:p-6 overflow-y-auto dark:bg-neutral-900 dark:text-white">
-          {children}
+        <main className="flex-1 overflow-y-auto dark:bg-neutral-900 dark:text-white">
+          <div className="p-2 sm:p-4 md:p-6 max-w-screen-xl mx-auto w-full">
+            {showInstall && (
+              <div className="mb-4 flex justify-center">
+                <button
+                  onClick={promptInstall}
+                  className="px-4 py-2 rounded bg-blue-600 text-white"
+                >
+                  Install App
+                </button>
+              </div>
+            )}
+            {children}
+          </div>
         </main>
       </div>
     </div>

--- a/Frontend/src/hooks/useOfflineQueue.ts
+++ b/Frontend/src/hooks/useOfflineQueue.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+
+interface QueueItem {
+  url: string;
+  options?: RequestInit;
+}
+
+/**
+ * useOfflineQueue queues network requests made while offline and
+ * retries them when connectivity is restored.
+ */
+export function useOfflineQueue() {
+  const queue = useRef<QueueItem[]>([]);
+
+  const processQueue = async () => {
+    while (queue.current.length > 0 && navigator.onLine) {
+      const { url, options } = queue.current[0];
+      try {
+        await fetch(url, options);
+        queue.current.shift();
+      } catch {
+        break; // stop processing if a request fails
+      }
+    }
+    localStorage.setItem('offline-queue', JSON.stringify(queue.current));
+  };
+
+  const enqueue = (url: string, options?: RequestInit) => {
+    if (navigator.onLine) {
+      fetch(url, options).catch(() => {
+        queue.current.push({ url, options });
+        localStorage.setItem('offline-queue', JSON.stringify(queue.current));
+      });
+    } else {
+      queue.current.push({ url, options });
+      localStorage.setItem('offline-queue', JSON.stringify(queue.current));
+    }
+  };
+
+  useEffect(() => {
+    const stored = localStorage.getItem('offline-queue');
+    if (stored) {
+      queue.current = JSON.parse(stored);
+      processQueue();
+    }
+    window.addEventListener('online', processQueue);
+    return () => window.removeEventListener('online', processQueue);
+  }, []);
+
+  return { enqueue };
+}

--- a/Frontend/src/main.tsx
+++ b/Frontend/src/main.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from './context/AuthContext';
 import { ToastProvider } from './context/ToastContext';
 import { useThemeStore } from './store/themeStore';
 import './index.css';
+import { registerSW } from 'virtual:pwa-register';
 
 // Initialize theme on app load
 const initializeTheme = () => {
@@ -31,6 +32,9 @@ mediaQuery.addEventListener('change', (e) => {
 
 // Initialize theme
 initializeTheme();
+
+// register service worker for PWA
+registerSW({ immediate: true });
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/Frontend/src/pages/ForgotPasswordPage.tsx
+++ b/Frontend/src/pages/ForgotPasswordPage.tsx
@@ -1,10 +1,30 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import api from '../utils/api';
 
 const ForgotPasswordPage: React.FC = () => {
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
+  const [installEvent, setInstallEvent] = useState<any>(null);
+  const [showInstall, setShowInstall] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setInstallEvent(e);
+      setShowInstall(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler as EventListener);
+    return () => window.removeEventListener('beforeinstallprompt', handler as EventListener);
+  }, []);
+
+  const promptInstall = async () => {
+    if (!installEvent) return;
+    installEvent.prompt();
+    await installEvent.userChoice;
+    setInstallEvent(null);
+    setShowInstall(false);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -19,8 +39,19 @@ const ForgotPasswordPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
       <form onSubmit={handleSubmit} className="max-w-md w-full space-y-4">
+        {showInstall && (
+          <div className="flex justify-center">
+            <button
+              onClick={promptInstall}
+              type="button"
+              className="mb-4 px-4 py-2 rounded bg-blue-600 text-white"
+            >
+              Install App
+            </button>
+          </div>
+        )}
         <h2 className="text-xl font-bold">Reset Password</h2>
         <input
           type="email"

--- a/Frontend/src/pages/LoginPage.tsx
+++ b/Frontend/src/pages/LoginPage.tsx
@@ -1,17 +1,50 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import LoginForm from '../components/auth/LoginForm';
 
-const LoginPage: React.FC = () => (
-  <div className="min-h-screen flex items-center justify-center bg-gray-100">
-    <div className="space-y-4">
-      <LoginForm />
-      <div className="flex justify-between text-sm">
-        <Link to="/register" className="text-blue-600">Register</Link>
-        <Link to="/forgot-password" className="text-blue-600">Forgot Password?</Link>
+const LoginPage: React.FC = () => {
+  const [installEvent, setInstallEvent] = useState<any>(null);
+  const [showInstall, setShowInstall] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setInstallEvent(e);
+      setShowInstall(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler as EventListener);
+    return () => window.removeEventListener('beforeinstallprompt', handler as EventListener);
+  }, []);
+
+  const promptInstall = async () => {
+    if (!installEvent) return;
+    installEvent.prompt();
+    await installEvent.userChoice;
+    setInstallEvent(null);
+    setShowInstall(false);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <div className="space-y-4 w-full max-w-md">
+        {showInstall && (
+          <div className="flex justify-center">
+            <button
+              onClick={promptInstall}
+              className="mb-4 px-4 py-2 rounded bg-blue-600 text-white"
+            >
+              Install App
+            </button>
+          </div>
+        )}
+        <LoginForm />
+        <div className="flex justify-between text-sm">
+          <Link to="/register" className="text-blue-600">Register</Link>
+          <Link to="/forgot-password" className="text-blue-600">Forgot Password?</Link>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default LoginPage;

--- a/Frontend/src/pages/NotFound.tsx
+++ b/Frontend/src/pages/NotFound.tsx
@@ -1,8 +1,39 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 const NotFound: React.FC = () => {
+  const [installEvent, setInstallEvent] = useState<any>(null);
+  const [showInstall, setShowInstall] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setInstallEvent(e);
+      setShowInstall(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler as EventListener);
+    return () => window.removeEventListener('beforeinstallprompt', handler as EventListener);
+  }, []);
+
+  const promptInstall = async () => {
+    if (!installEvent) return;
+    installEvent.prompt();
+    await installEvent.userChoice;
+    setInstallEvent(null);
+    setShowInstall(false);
+  };
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen text-red-600 text-xl font-bold">
+    <div className="flex flex-col items-center justify-center min-h-screen text-red-600 text-xl font-bold p-4">
+      {showInstall && (
+        <div className="mb-4">
+          <button
+            onClick={promptInstall}
+            className="px-4 py-2 rounded bg-blue-600 text-white"
+          >
+            Install App
+          </button>
+        </div>
+      )}
       404 - Page Not Found
     </div>
   );

--- a/Frontend/src/pages/RegisterPage.tsx
+++ b/Frontend/src/pages/RegisterPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import api from '../utils/api';
 
@@ -12,6 +12,26 @@ const RegisterPage: React.FC = () => {
     employeeId: '',
   });
   const [error, setError] = useState('');
+  const [installEvent, setInstallEvent] = useState<any>(null);
+  const [showInstall, setShowInstall] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setInstallEvent(e);
+      setShowInstall(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler as EventListener);
+    return () => window.removeEventListener('beforeinstallprompt', handler as EventListener);
+  }, []);
+
+  const promptInstall = async () => {
+    if (!installEvent) return;
+    installEvent.prompt();
+    await installEvent.userChoice;
+    setInstallEvent(null);
+    setShowInstall(false);
+  };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -30,8 +50,19 @@ const RegisterPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
       <form onSubmit={handleSubmit} className="max-w-md w-full space-y-4">
+        {showInstall && (
+          <div className="flex justify-center">
+            <button
+              onClick={promptInstall}
+              type="button"
+              className="mb-4 px-4 py-2 rounded bg-blue-600 text-white"
+            >
+              Install App
+            </button>
+          </div>
+        )}
         <h2 className="text-xl font-bold">Register</h2>
         <input
           type="text"

--- a/Frontend/src/sw.ts
+++ b/Frontend/src/sw.ts
@@ -1,0 +1,33 @@
+/// <reference lib="webworker" />
+
+import { precacheAndRoute } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+import { CacheFirst, NetworkFirst, StaleWhileRevalidate } from 'workbox-strategies';
+
+declare let self: ServiceWorkerGlobalScope & { __WB_MANIFEST: any };
+
+precacheAndRoute(self.__WB_MANIFEST);
+
+// Cache page navigations (html) with a Network First strategy
+registerRoute(
+  ({ request }) => request.mode === 'navigate',
+  new NetworkFirst({ cacheName: 'pages' })
+);
+
+// Cache CSS, JS, and worker requests with a Stale While Revalidate strategy
+registerRoute(
+  ({ request }) => ['style', 'script', 'worker'].includes(request.destination),
+  new StaleWhileRevalidate({ cacheName: 'assets' })
+);
+
+// Cache images with a Cache First strategy
+registerRoute(
+  ({ request }) => request.destination === 'image',
+  new CacheFirst({ cacheName: 'images' })
+);
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -1,12 +1,29 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
   return {
-    plugins: [react()],
+    plugins: [
+      react(),
+      VitePWA({
+        registerType: 'autoUpdate',
+        strategies: 'injectManifest',
+        srcDir: 'src',
+        filename: 'sw.ts',
+        manifest: {
+          name: 'WorkPro3',
+          short_name: 'WorkPro3',
+          start_url: '/',
+          display: 'standalone',
+          background_color: '#ffffff',
+          theme_color: '#ffffff',
+        },
+      }),
+    ],
     optimizeDeps: {
       exclude: ['lucide-react'],
     },


### PR DESCRIPTION
## Summary
- integrate `vite-plugin-pwa` and register service worker
- add caching strategies and offline queue utilities
- show install prompts with responsive layout across pages

## Testing
- `npm install --ignore-scripts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite-plugin-pwa)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58ce120ac832387ed1e6b84d1d2ae