### PR TITLE
feat: document API with Swagger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: Backend/package-lock.json
       - run: npm ci
+      - run: npm run swagger:check
       - run: npm test -- --ci
 
   frontend:

--- a/Backend/controllers/WorkOrderController.ts
+++ b/Backend/controllers/WorkOrderController.ts
@@ -6,6 +6,17 @@ import { validationResult } from 'express-validator';
 import notifyUser from '../utils/notify';
 import { getWorkOrderAssistance } from '../services/aiCopilot';
 
+/**
+ * @openapi
+ * /api/workorders:
+ *   get:
+ *     tags:
+ *       - WorkOrders
+ *     summary: Retrieve all work orders
+ *     responses:
+ *       200:
+ *         description: List of work orders
+ */
 export const getAllWorkOrders: AuthedRequestHandler = async (
   req,
   res,
@@ -19,6 +30,36 @@ export const getAllWorkOrders: AuthedRequestHandler = async (
   }
 };
 
+/**
+ * @openapi
+ * /api/workorders/search:
+ *   get:
+ *     tags:
+ *       - WorkOrders
+ *     summary: Search work orders
+ *     parameters:
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: priority
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: startDate
+ *         schema:
+ *           type: string
+ *           format: date
+ *       - in: query
+ *         name: endDate
+ *         schema:
+ *           type: string
+ *           format: date
+ *     responses:
+ *       200:
+ *         description: Filtered work orders
+ */
 export const searchWorkOrders: AuthedRequestHandler = async (
   req,
   res,
@@ -43,6 +84,25 @@ export const searchWorkOrders: AuthedRequestHandler = async (
   }
 };
 
+/**
+ * @openapi
+ * /api/workorders/{id}:
+ *   get:
+ *     tags:
+ *       - WorkOrders
+ *     summary: Get work order by ID
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Work order found
+ *       404:
+ *         description: Work order not found
+ */
 export const getWorkOrderById: AuthedRequestHandler = async (
   req,
   res,
@@ -57,6 +117,25 @@ export const getWorkOrderById: AuthedRequestHandler = async (
   }
 };
 
+/**
+ * @openapi
+ * /api/workorders:
+ *   post:
+ *     tags:
+ *       - WorkOrders
+ *     summary: Create a work order
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *     responses:
+ *       201:
+ *         description: Work order created
+ *       400:
+ *         description: Validation error
+ */
 export const createWorkOrder: AuthedRequestHandler = async (
   req,
   res,
@@ -76,6 +155,31 @@ export const createWorkOrder: AuthedRequestHandler = async (
   }
 };
 
+/**
+ * @openapi
+ * /api/workorders/{id}:
+ *   put:
+ *     tags:
+ *       - WorkOrders
+ *     summary: Update a work order
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *     responses:
+ *       200:
+ *         description: Work order updated
+ *       404:
+ *         description: Work order not found
+ */
 export const updateWorkOrder: AuthedRequestHandler = async (
   req,
   res,
@@ -102,6 +206,25 @@ export const updateWorkOrder: AuthedRequestHandler = async (
   }
 };
 
+/**
+ * @openapi
+ * /api/workorders/{id}:
+ *   delete:
+ *     tags:
+ *       - WorkOrders
+ *     summary: Delete a work order
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Deletion successful
+ *       404:
+ *         description: Work order not found
+ */
 export const deleteWorkOrder: AuthedRequestHandler = async (
   req,
   res,
@@ -117,6 +240,36 @@ export const deleteWorkOrder: AuthedRequestHandler = async (
   }
 };
 
+/**
+ * @openapi
+ * /api/workorders/{id}/approve:
+ *   post:
+ *     tags:
+ *       - WorkOrders
+ *     summary: Approve or reject a work order
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               status:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Approval status updated
+ *       400:
+ *         description: Invalid status
+ *       404:
+ *         description: Work order not found
+ */
 export const approveWorkOrder: AuthedRequestHandler = async (
   req,
   res,
@@ -162,6 +315,25 @@ export const approveWorkOrder: AuthedRequestHandler = async (
   }
 };
 
+/**
+ * @openapi
+ * /api/workorders/{id}/assist:
+ *   get:
+ *     tags:
+ *       - WorkOrders
+ *     summary: Get AI assistance for a work order
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Assistance data
+ *       404:
+ *         description: Work order not found
+ */
 export const assistWorkOrder: AuthedRequestHandler = async (
   req,
   res,

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -13,7 +13,8 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "test": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "swagger:check": "ts-node utils/swagger.ts"
   },
   "dependencies": {
     "@types/helmet": "^0.0.48",
@@ -38,7 +39,9 @@
     "winston-daily-rotate-file": "^5.0.0",
     "zod": "^3.25.76",
     "passport": "^0.7.0",
-    "passport-openidconnect": "^0.0.2"
+    "passport-openidconnect": "^0.0.2",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.7.1"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/Backend/server.ts
+++ b/Backend/server.ts
@@ -39,6 +39,7 @@ import calendarRoutes from './routes/CalendarRoutes';
 import conditionRuleRoutes from './routes/ConditionRuleRoutes';
 
 import { startPMScheduler } from './utils/pmScheduler';
+import { setupSwagger } from './utils/swagger';
 import mongoose from 'mongoose';
 import errorHandler from './middleware/errorHandler';
 import { validateEnv } from './config/validateEnv';
@@ -86,6 +87,7 @@ app.use(cors(corsOptions));
 app.use(morgan('dev'));
 app.use(express.json({ limit: '1mb' }));
 app.use(cookieParser());
+setupSwagger(app);
 
 const dev = process.env.NODE_ENV !== 'production';
 

--- a/Backend/utils/swagger.ts
+++ b/Backend/utils/swagger.ts
@@ -1,0 +1,28 @@
+import path from 'path';
+import { Express } from 'express';
+import swaggerJsdoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+
+const swaggerDefinition = {
+  openapi: '3.0.0',
+  info: {
+    title: 'WorkPro3 API',
+    version: '1.0.0',
+  },
+};
+
+const options = {
+  definition: swaggerDefinition,
+  apis: [path.join(__dirname, '../controllers/**/*.ts')],
+};
+
+export const swaggerSpec = swaggerJsdoc(options);
+
+export const setupSwagger = (app: Express) => {
+  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+};
+
+if (require.main === module) {
+  // When run directly, output the spec for validation
+  console.log(JSON.stringify(swaggerSpec, null, 2));
+}


### PR DESCRIPTION
## Summary
- add swagger dependencies and utility to generate OpenAPI spec
- document work order endpoints with JSDoc annotations
- expose Swagger UI at `/api-docs` and validate spec in CI

## Testing
- `npm run swagger:check` *(fails: ts-node not found)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58ce45dec8323a14e3c2bfd30e816