### PR TITLE
chore: use vite 5

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -93,7 +93,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^6.3.5",
+    "vite": "^5.0.0",
     "vitest": "^3.2.2",
     "vite-plugin-pwa": "^0.20.0"
   },


### PR DESCRIPTION
## Summary
- downgrade Vite to ^5 in frontend to match current vite-plugin-pwa compatibility

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/chart.js)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d9dfc12483238f1ad0e12f3ab545