### PR TITLE
chore: remove react-qr-reader from frontend

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -36,7 +36,6 @@
         "react-error-boundary": "^4.0.13",
         "react-grid-layout": "^1.5.2",
         "react-hook-form": "^7.51.0",
-        "react-qr-reader": "^3.0.0",
         "react-router-dom": "^6.22.2",
         "react-signature-canvas": "^1.0.6",
         "socket.io-client": "^4.8.1",
@@ -8947,63 +8946,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
-    },
-    "node_modules/react-qr-reader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-qr-reader/-/react-qr-reader-3.0.0.tgz",
-      "integrity": "sha512-PLACEHOLDER-react-qr-reader",
-      "license": "MIT",
-      "dependencies": {
-        "@zxing/browser": "0.0.7",
-        "@zxing/library": "^0.18.3",
-        "rollup": "^2.67.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/react-qr-reader/node_modules/@zxing/browser": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.0.7.tgz",
-      "integrity": "sha512-AepzMgDnD6EjxewqmXpHJsi4S3Gw9ilZJLIbTf6fWuWySEcHBodnGu3p7FWlgq1Sd5QyfPhTum5z3CBkkhMVng==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "@zxing/text-encoding": "^0.9.0"
-      },
-      "peerDependencies": {
-        "@zxing/library": "^0.18.3"
-      }
-    },
-    "node_modules/react-qr-reader/node_modules/@zxing/library": {
-      "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.18.6.tgz",
-      "integrity": "sha512-bulZ9JHoLFd9W36pi+7e7DnEYNJhljYjZ1UTsKPOoLMU3qtC+REHITeCRNx40zTRJZx18W5TBRXt5pq2Uopjsw==",
-      "license": "MIT",
-      "dependencies": {
-        "ts-custom-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.4.0"
-      },
-      "optionalDependencies": {
-        "@zxing/text-encoding": "~0.9.0"
-      }
-    },
-    "node_modules/react-qr-reader/node_modules/rollup": {
-      "version": "2.79.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -46,7 +46,6 @@
     "react-i18next": "^13.5.0",
     "react-grid-layout": "^1.5.2",
     "react-hook-form": "^7.51.0",
-    "react-qr-reader": "^3.0.0",
     "react-router-dom": "^6.22.2",
     "react-signature-canvas": "^1.0.6",
     "socket.io-client": "^4.8.1",


### PR DESCRIPTION
## Summary
- remove unused react-qr-reader dependency from frontend package.json
- prune react-qr-reader from package-lock

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/chart.js)*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e295d33483239111d583a6b0b7d9