### PR TITLE
chore: add mqtt types

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -56,6 +56,7 @@
     "@types/kafkajs": "^1.8.2",
     "@types/morgan": "^1.9.10",
     "@types/multer": "^2.0.0",
+    "@types/mqtt": "^4.2.4",
     "@types/node": "^22.17.0",
     "@types/passport": "^1.0.12",
     "@types/pdfkit": "^0.17.0",


### PR DESCRIPTION
## Summary
- add MQTT types to backend dev dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fmqtt)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b692477c048323a4c3594b33e6ca64