### PR TITLE
refactor: refine MQTT callback typings

### DIFF
--- a/Backend/iot/mqttClient.ts
+++ b/Backend/iot/mqttClient.ts
@@ -23,7 +23,7 @@ export function startMQTTClient(
 
   mqttClient.on('connect', () => {
     mqttLogger.info('MQTT connected');
-    mqttClient.subscribe('tenants/+/readings', (err: { message: any; }) => {
+    mqttClient.subscribe('tenants/+/readings', (err?: Error) => {
       if (err) {
         mqttLogger.error('MQTT subscribe error', { error: err.message });
       } else {
@@ -34,9 +34,11 @@ export function startMQTTClient(
 
   mqttClient.on('reconnect', () => mqttLogger.warn('MQTT reconnecting'));
   mqttClient.on('close', () => mqttLogger.warn('MQTT connection closed'));
-  mqttClient.on('error', (err: { message: any; }) => mqttLogger.error('MQTT error', { error: err.message }));
+  mqttClient.on('error', (err: Error) =>
+    mqttLogger.error('MQTT error', { error: err.message })
+  );
 
-  mqttClient.on('message', async (topic: string, payload: { toString: () => string; }) => {
+  mqttClient.on('message', async (topic: string, payload: Buffer) => {
     try {
       const match = topic.match(/^tenants\/(.+?)\/readings$/);
       if (!match) return;


### PR DESCRIPTION
## Summary
- tighten mqtt subscribe callback typing to use optional Error
- use Error typing for MQTT error handler
- accept Buffer payload in MQTT message handler

## Testing
- `npm run dev` *(fails: Cannot find module 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_68b69247f53083238390b8bd9aebe1fa