### PR TITLE
feat(auth): add permission middleware

### DIFF
--- a/Backend/middleware/authorize.ts
+++ b/Backend/middleware/authorize.ts
@@ -13,9 +13,12 @@ export const authorize = (...required: string[]): RequestHandler => {
     }
 
     const userPerms = req.user.permissions || [];
-    const hasPerm = required.every((p) => userPerms.includes(p));
-    if (!hasPerm) {
-      res.status(403).json({ message: 'Forbidden' });
+    // Determine which permissions from `required` are not present on the
+    // authenticated user. Using a list allows callers or tests to inspect
+    // which permissions were missing when access is denied.
+    const missing = required.filter((p) => !userPerms.includes(p));
+    if (missing.length > 0) {
+      res.status(403).json({ message: 'Forbidden', missing });
       return;
     }
 

--- a/Backend/models/Role.ts
+++ b/Backend/models/Role.ts
@@ -2,13 +2,20 @@ import mongoose, { Schema, Document, Model } from 'mongoose';
 
 export interface RoleDocument extends Document {
   name: string;
+  /**
+   * List of permission strings granted to the role. Each permission
+   * follows the `resource:action` convention (e.g. `workorders:approve`).
+   */
   permissions: string[];
 }
 
 const roleSchema = new Schema<RoleDocument>(
   {
     name: { type: String, required: true, unique: true },
-    permissions: { type: [String], default: [] },
+    // Explicit array of permissions. Even though an empty array is a
+    // sensible default, mark the field as required so that it is always
+    // present on documents and in TypeScript typings.
+    permissions: { type: [String], required: true, default: [] },
   },
   { timestamps: true }
 );

--- a/Backend/routes/WorkOrderRoutes.ts
+++ b/Backend/routes/WorkOrderRoutes.ts
@@ -45,6 +45,9 @@ router.put(
 router.post(
   '/:id/approve',
   requireRole('admin', 'manager'),
+  // Fine-grained permission check for approving a work order. The user's
+  // role alone isn't enough; they must explicitly hold the
+  // `workorders:approve` permission.
   authorize('workorders:approve'),
   approveWorkOrder
 );

--- a/Backend/tests/auth/authorize.test.ts
+++ b/Backend/tests/auth/authorize.test.ts
@@ -65,9 +65,14 @@ describe('authorize middleware', () => {
   });
 
   it('denies access when permission is missing', async () => {
-    await request(app)
+    const res = await request(app)
       .get('/protected')
       .set('Authorization', `Bearer ${tokenWithout}`)
       .expect(403);
+    expect(res.body.missing).toEqual(['perm:test']);
+  });
+
+  it('returns 401 when no authentication is provided', async () => {
+    await request(app).get('/protected').expect(401);
   });
 });


### PR DESCRIPTION
## Summary
- require roles to define explicit permission strings
- enhance authorization middleware to report missing permissions
- document permission check in work order approval route
- extend authorization tests with missing-permission and unauthenticated cases

## Testing
- `npm test tests/auth/authorize.test.ts` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @types/mqtt)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b7d795048323a7ed1f37345fb0cf