### PR TITLE
Add cost/downtime metric helpers and tests

### DIFF
--- a/Backend/controllers/ReportsController.ts
+++ b/Backend/controllers/ReportsController.ts
@@ -268,11 +268,15 @@ async function aggregateCosts(tenantId: string) {
       map.set(r.period, entry);
     });
   });
-
-  return Array.from(map.values()).map((r) => ({
-    ...r,
-    totalCost: (r.laborCost || 0) + (r.maintenanceCost || 0) + (r.materialCost || 0),
-  }));
+  return Array.from(map.values())
+    .sort((a, b) => a.period.localeCompare(b.period))
+    .map((r) => ({
+      ...r,
+      totalCost:
+        (r.laborCost || 0) +
+        (r.maintenanceCost || 0) +
+        (r.materialCost || 0),
+    }));
 }
 
 export const getCostMetrics: AuthedRequestHandler = async (req, res, next) => {

--- a/Backend/tests/reportMetrics.test.ts
+++ b/Backend/tests/reportMetrics.test.ts
@@ -68,6 +68,8 @@ describe('Reports metrics', () => {
       .get('/api/reports/costs')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].period).toBe('2023-01');
     expect(res.body[0].laborCost).toBeCloseTo(400);
     expect(res.body[0].maintenanceCost).toBeCloseTo(200);
     expect(res.body[0].materialCost).toBeCloseTo(5);
@@ -79,6 +81,8 @@ describe('Reports metrics', () => {
       .get('/api/reports/downtime')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].period).toBe('2023-01');
     expect(res.body[0].downtime).toBe(4);
   });
 });

--- a/Frontend/src/test/analyticsCharts.test.tsx
+++ b/Frontend/src/test/analyticsCharts.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../components/kpi/KpiExportButtons', () => ({ default: () => <div /> })
 vi.mock('../components/common/Button', () => ({ default: ({ children }: any) => <button>{children}</button> }));
 vi.mock('../components/common/Card', () => ({ default: ({ children, title }: any) => <div>{title}{children}</div> }));
 vi.mock('../components/common/Badge', () => ({ default: () => <span /> }));
-vi.mock('react-chartjs-2', () => ({ Line: (props: any) => <canvas {...props} /> }));
+const lineMock = vi.fn((props: any) => <canvas {...props} />);
+vi.mock('react-chartjs-2', () => ({ Line: (props: any) => lineMock(props) }));
 vi.mock('chart.js', () => ({ CategoryScale: {}, LinearScale: {}, PointElement: {}, LineElement: {}, Tooltip: {}, Legend: {}, Chart: {}, register: () => {} }));
 
 import Analytics from '../pages/Analytics';
@@ -50,5 +51,8 @@ describe('Analytics charts', () => {
     const down = await screen.findByTestId('downtime-chart');
     expect(cost).toBeInTheDocument();
     expect(down).toBeInTheDocument();
+    expect(lineMock).toHaveBeenCalledTimes(2);
+    expect(lineMock.mock.calls[0][0].data.datasets[0].data).toEqual([100]);
+    expect(lineMock.mock.calls[1][0].data.datasets[0].data).toEqual([5]);
   });
 });

--- a/Frontend/src/utils/export.ts
+++ b/Frontend/src/utils/export.ts
@@ -120,3 +120,12 @@ export const exportMetricsToPDF = (
   data: Record<string, any>[],
   filename: string,
 ) => exportToPDF(data, filename, (d) => d);
+
+export const exportMetrics = (
+  data: Record<string, any>[],
+  filename: string,
+  format: 'csv' | 'pdf',
+) =>
+  format === 'pdf'
+    ? exportMetricsToPDF(data, filename)
+    : exportMetricsToCSV(data, filename);


### PR DESCRIPTION
## Summary
- Sort monthly cost metrics in report controller and compute totals
- Add generic metric export helper for CSV/PDF
- Extend backend and frontend tests to verify cost and downtime metric aggregation and chart data

## Testing
- `npm test` (backend) *(fails: vitest not found)*
- `npm test` (frontend) *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b7e6bf308323bee6538eaebe3e53