### PR TITLE
chore: type mqtt client callbacks

### DIFF
--- a/Backend/iot/mqttClient.ts
+++ b/Backend/iot/mqttClient.ts
@@ -23,7 +23,7 @@ export function startMQTTClient(
 
   mqttClient.on('connect', () => {
     mqttLogger.info('MQTT connected');
-    mqttClient.subscribe('tenants/+/readings', (err?: Error) => {
+    mqttClient.subscribe('tenants/+/readings', (err?: Error): void => {
       if (err) {
         mqttLogger.error('MQTT subscribe error', { error: err.message });
       } else {
@@ -34,29 +34,34 @@ export function startMQTTClient(
 
   mqttClient.on('reconnect', () => mqttLogger.warn('MQTT reconnecting'));
   mqttClient.on('close', () => mqttLogger.warn('MQTT connection closed'));
-  mqttClient.on('error', (err: Error) =>
-    mqttLogger.error('MQTT error', { error: err.message })
-  );
-
-  mqttClient.on('message', async (topic: string, payload: Buffer) => {
-    try {
-      const match = topic.match(/^tenants\/(.+?)\/readings$/);
-      if (!match) return;
-      const tenantId = match[1];
-      const data = JSON.parse(payload.toString());
-      if (!data.asset || !data.metric || typeof data.value !== 'number') return;
-
-      await SensorReading.create({
-        asset: data.asset,
-        metric: data.metric,
-        value: data.value,
-        timestamp: data.timestamp ? new Date(data.timestamp) : undefined,
-        tenantId,
-      });
-    } catch (err) {
-      mqttLogger.error('Failed to process MQTT message', { error: (err as Error).message });
-    }
+  mqttClient.on('error', (err: Error): void => {
+    mqttLogger.error('MQTT error', { error: err.message });
   });
+
+  mqttClient.on(
+    'message',
+    async (topic: string, payload: Buffer): Promise<void> => {
+      try {
+        const match = topic.match(/^tenants\/(.+?)\/readings$/);
+        if (!match) return;
+        const tenantId = match[1];
+        const data = JSON.parse(payload.toString());
+        if (!data.asset || !data.metric || typeof data.value !== 'number') return;
+
+        await SensorReading.create({
+          asset: data.asset,
+          metric: data.metric,
+          value: data.value,
+          timestamp: data.timestamp ? new Date(data.timestamp) : undefined,
+          tenantId,
+        });
+      } catch (err) {
+        mqttLogger.error('Failed to process MQTT message', {
+          error: (err as Error).message,
+        });
+      }
+    }
+  );
 
   return mqttClient;
 }


### PR DESCRIPTION
## Summary
- type the MQTT `subscribe` callback with optional error
- use explicit error and message handlers on MQTT client

## Testing
- `npm run dev` (fails: Cannot find module 'ts-node')
- `npm install --no-audit --no-fund` (fails: 403 Forbidden when fetching @types/mqtt)


------
https://chatgpt.com/codex/tasks/task_e_68b6cd3625c483239f4be53e445363f2