### PR TITLE
chore: add vite-plugin-pwa types and update tsconfig

### DIFF
--- a/Frontend/src/types/vite-plugin-pwa.d.ts
+++ b/Frontend/src/types/vite-plugin-pwa.d.ts
@@ -1,0 +1,1 @@
+declare module "vite-plugin-pwa";

--- a/Frontend/tsconfig.app.json
+++ b/Frontend/tsconfig.app.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": ["node"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/Frontend/tsconfig.node.json
+++ b/Frontend/tsconfig.node.json
@@ -7,6 +7,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "types": ["node"],
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- declare vite-plugin-pwa module
- ensure Node types and bundler resolution in frontend tsconfigs

## Testing
- `npm test` (fails: vitest: not found)
- `npm run ci:install` (fails: 403 Forbidden - GET https://registry.npmjs.org/chart.js)


------
https://chatgpt.com/codex/tasks/task_e_68b6fdff76948323944b99954f07deda