### PR TITLE
chore: add workspace root package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "WORKPRO2",
+  "name": "workpro",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "workpro",
+  "private": true,
+  "workspaces": [
+    "Backend",
+    "Frontend"
+  ],
+  "scripts": {
+    "build": "npm run build -w Backend && npm run build -w Frontend"
+  }
+}


### PR DESCRIPTION
## Summary
- add root `package.json` with `Backend` and `Frontend` workspaces
- add `build` script that builds both workspaces
- update root `package-lock.json`

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fbcryptjs)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b701d2c2508323b09babc721a574fb