### PR TITLE
feat(backend): add typecheck script

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -14,6 +14,7 @@
     "start": "node dist/server.js",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
     "swagger:check": "ts-node utils/swagger.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add typecheck npm script for backend

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68b701d6290c83238b86e2fedb62a261