### PR TITLE
Add npm registry configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 fund=false
 audit=false


### PR DESCRIPTION
## Summary
- configure root `.npmrc` to use the public npm registry and support token-based authentication

## Testing
- `npm install` *(fails: Could not read package.json)*
- `cd Backend && npm install --ignore-scripts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fmqtt)*
- `cd Frontend && npm install --ignore-scripts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/chart.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b701db13e4832384350cf88bc6b903