### PR TITLE
docs: add environment examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 **/.env
 **/.env.*
 !Frontend/.env
+!Backend/.env.example
+!Frontend/.env.example
 
 # Dependencies
 **/node_modules/

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,0 +1,20 @@
+# Required
+JWT_SECRET=changeme
+MONGO_URI=mongodb://localhost:27017/platinum_cmms
+CORS_ORIGIN=http://localhost:5173
+
+# Optional
+# PORT=5010
+# PM_SCHEDULER_CRON=*/5 * * * *
+# PM_SCHEDULER_TASK=./tasks/pmSchedulerTask
+# NODE_ENV=development
+# RATE_LIMIT_WINDOW_MS=60000
+# RATE_LIMIT_MAX=100
+# LOG_LEVEL=info
+# LOG_DIR=./logs
+# PREDICTIVE_MODEL=arima
+# SMTP_HOST=
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASS=
+# SMTP_FROM=

--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -1,0 +1,9 @@
+VITE_API_URL=http://localhost:5010/api
+VITE_WS_URL=ws://localhost:5010
+VITE_WS_PATH=/socket.io
+CORS_ORIGIN=http://localhost:5173
+
+# Optional
+# VITE_HTTP_ORIGIN=http://localhost:5010
+# VITE_SUPABASE_URL=
+# VITE_SUPABASE_ANON_KEY=


### PR DESCRIPTION
## Summary
- add backend .env example with required and optional vars
- add frontend .env example for API and socket config
- allow committing env example files in gitignore

## Testing
- `npm test -w Backend` *(fails: vitest not found)*
- `npm test -w Frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b709fa2fec832391a957dd486e581a