### PR TITLE
chore: unify socket path env variable

### DIFF
--- a/Frontend/.env
+++ b/Frontend/.env
@@ -1,3 +1,3 @@
 VITE_API_URL=http://localhost:5010/api
 VITE_WS_URL=ws://localhost:5010
-VITE_WS_PATH=/socket.io
+VITE_SOCKET_PATH=/socket.io

--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -52,7 +52,7 @@ The following variables from `.env.example` configure the frontend:
 
 - `VITE_API_URL` – Base URL for API requests. Defaults to `http://localhost:5010/api`.
 - `VITE_WS_URL` – WebSocket server URL for real‑time updates. Defaults to `ws://localhost:5010`.
-- `VITE_WS_PATH` – WebSocket endpoint path. Defaults to `/socket.io`.
+- `VITE_SOCKET_PATH` – WebSocket endpoint path. Defaults to `/socket.io`.
 - `CORS_ORIGIN` – Origin allowed when using the local API server.
 
 Set `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` to the credentials from
@@ -72,7 +72,7 @@ WebSocket reconnects. The queued requests are then flushed automatically.
 node backend/server.js
 ```
 
-The server reads `MONGO_URI` and `CORS_ORIGIN` from your `.env`. Ensure `CORS_ORIGIN` matches the Vite dev server URL (e.g. `http://localhost:5173`) and update `VITE_API_URL`, `VITE_WS_URL`, and `VITE_WS_PATH` if the API runs on a different host or port.
+The server reads `MONGO_URI` and `CORS_ORIGIN` from your `.env`. Ensure `CORS_ORIGIN` matches the Vite dev server URL (e.g. `http://localhost:5173`) and update `VITE_API_URL`, `VITE_WS_URL`, and `VITE_SOCKET_PATH` if the API runs on a different host or port.
 
 ### Inventory route example
 

--- a/Frontend/src/test/setup.ts
+++ b/Frontend/src/test/setup.ts
@@ -9,7 +9,7 @@ vi.mock('../utils/env', () => ({
   config: {
     apiUrl: 'http://localhost:3000/api',
     wsUrl: null,
-    wsPath: '/socket.io',
+    socketPath: '/socket.io',
   },
   endpoints: {
     httpOrigin: 'http://localhost:3000',

--- a/Frontend/src/utils/env.ts
+++ b/Frontend/src/utils/env.ts
@@ -10,7 +10,7 @@ export const config = {
   httpOrigin: getEnvVar('VITE_HTTP_ORIGIN'),
   wsUrl: getEnvVar('VITE_WS_URL'),
   // Socket.IO path (backend default is '/socket.io')
-  wsPath: getEnvVar('VITE_SOCKET_PATH') ?? '/socket.io',
+  socketPath: getEnvVar('VITE_SOCKET_PATH') ?? '/socket.io',
 };
 
 function stripApiSuffix(url: string) {
@@ -30,7 +30,7 @@ const socketOrigin = (config.wsUrl ?? httpOrigin).replace(/^http/i, 'ws');
 export const endpoints = {
   httpOrigin,           // e.g. http://localhost:5010
   socketOrigin,         // e.g. ws://localhost:5010
-  socketPath: config.wsPath, // e.g. '/socket.io'
+  socketPath: config.socketPath, // e.g. '/socket.io'
 };
 
 export const apiBaseUrl = `${httpOrigin}/api`;

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ not committed to the repository.
 
 1. `cd Frontend`
 2. Copy `Frontend/.env.example` to `.env` and update `VITE_API_URL`,
-   `VITE_WS_URL`, `VITE_WS_PATH` and the Supabase variables (`VITE_SUPABASE_URL`,
+   `VITE_WS_URL`, `VITE_SOCKET_PATH` and the Supabase variables (`VITE_SUPABASE_URL`,
    `VITE_SUPABASE_ANON_KEY`).
 3. Install dependencies with `npm install`.
 4. Run the development server:
@@ -53,8 +53,8 @@ not committed to the repository.
 
 ### Offline mode
 
-If `VITE_WS_URL` or `VITE_WS_PATH` is empty, or the browser is offline, work order updates are
-queued in `localStorage` under `offline-queue`. Once the WebSocket defined by `VITE_WS_URL` and `VITE_WS_PATH` is restored, the queue is flushed and the requests are sent to the API.
+If `VITE_WS_URL` or `VITE_SOCKET_PATH` is empty, or the browser is offline, work order updates are
+queued in `localStorage` under `offline-queue`. Once the WebSocket defined by `VITE_WS_URL` and `VITE_SOCKET_PATH` is restored, the queue is flushed and the requests are sent to the API.
 
 ## Docker development
 
@@ -101,7 +101,7 @@ they can be merged. The testing matrix and workflow are described in
 
 The frontend stores any API requests made while offline in local storage. When
 the browser regains connectivity, the queued requests are automatically sent
-using the browser's `online` event even if the WebSocket defined by `VITE_WS_URL` and `VITE_WS_PATH` fails to reconnect.
+using the browser's `online` event even if the WebSocket defined by `VITE_WS_URL` and `VITE_SOCKET_PATH` fails to reconnect.
 
 ## License
 


### PR DESCRIPTION
## Summary
- use `VITE_SOCKET_PATH` across app and docs
- align test setup with new variable name

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden to registry)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70a00e2488323a5e6ffb1076aac7e