### PR TITLE
docs: remove unused env var references

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -55,9 +55,6 @@ The following variables from `.env.example` configure the frontend:
 - `VITE_WS_PATH` – WebSocket endpoint path. Defaults to `/socket.io`.
 - `CORS_ORIGIN` – Origin allowed when using the local API server.
 
-Set `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` to the credentials from
-your Supabase project dashboard.
-
 ### Offline mode
 
 If `VITE_WS_URL` is omitted or the browser goes offline, API requests made

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ not committed to the repository.
    ```bash
    cp .env.example .env
    ```
-   Update the required environment variables such as `MONGO_URI` and
-   `TENANT_NAME` along with `JWT_SECRET` and `CORS_ORIGIN`. The example
-   connection string uses `mongodb://localhost:27017/platinum_cmms`.
+   Update the required environment variables such as `MONGO_URI`, `JWT_SECRET`,
+   and `CORS_ORIGIN`. The example connection string uses
+   `mongodb://localhost:27017/platinum_cmms`.
 3. Seed the database with a tenant and admin account:
    ```bash
    npm run seed:admin
@@ -42,8 +42,7 @@ not committed to the repository.
 
 1. `cd Frontend`
 2. Copy `Frontend/.env.example` to `.env` and update `VITE_API_URL`,
-   `VITE_WS_URL`, `VITE_WS_PATH` and the Supabase variables (`VITE_SUPABASE_URL`,
-   `VITE_SUPABASE_ANON_KEY`).
+   `VITE_WS_URL`, and `VITE_WS_PATH`.
 3. Install dependencies with `npm install`.
 4. Run the development server:
    ```bash


### PR DESCRIPTION
## Summary
- clarify Backend setup env vars and drop unused `TENANT_NAME`
- remove Supabase variable references from Frontend docs

## Testing
- `cd Backend && npm test` *(fails: vitest not found)*
- `npm install` in Backend *(fails: 403 Forbidden from registry)*
- `cd Frontend && npm test` *(fails: vitest not found)*
- `npm install` in Frontend *(fails: 403 Forbidden from registry)*
- `npm run test:e2e` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70a04a86483238f3101a2f7882219