### PR TITLE
fix: pin arima dependency to v0.2.5

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -46,7 +46,7 @@
     "winston": "^3.17.0",
     "winston-daily-rotate-file": "^5.0.0",
     "zod": "^3.25.76",
-    "arima": "^0.2.7"
+    "arima": "0.2.5"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",


### PR DESCRIPTION
## Summary
- specify arima dependency version 0.2.5 to align with project requirements

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fbcryptjs)*

------
https://chatgpt.com/codex/tasks/task_e_68b8214a9f9083238d7bf931a3081987