### PR TITLE
chore: align backend TypeScript dev dependency

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -69,7 +69,7 @@
     "mongoose": "^8.16.4",
     "supertest": "^7.1.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2",
+    "typescript": "^5.6.0",
     "vitest": "^3.2.4"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- set `typescript` dev dependency to `^5.6.0` and ensure `ts-node` remains at `^10.9.2`

## Testing
- `npm install --no-package-lock` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8214b86a08323b2e0ed805ce1b979