### PR TITLE
refactor: use ts-node directly in dev script

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -4,7 +4,7 @@
   "main": "server.ts",
   "type": "commonjs",
   "scripts": {
-    "dev": "node node_modules/ts-node/dist/bin.js --files server.ts",
+    "dev": "ts-node --files server.ts",
     "seed": "ts-node seed.ts",
     "seed:admin": "ts-node scripts/seedAdmin.ts",
     "seed:default-admin": "ts-node scripts/seedDefaultAdmin.ts",

--- a/Backend/tsconfig.json
+++ b/Backend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- use `ts-node --files` in backend dev script
- set backend TypeScript `module` target to CommonJS for compatibility

## Testing
- `npm test -w Backend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8214cf2b08323bb688151451ad4f3