### PR TITLE
chore: configure ts-node and Node types

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -58,7 +58,7 @@
     "@types/kafkajs": "^1.8.2",
     "@types/morgan": "^1.9.10",
     "@types/multer": "^2.0.0",
-    "@types/node": "^22.17.0",
+    "@types/node": "^22.0.0",
     "@types/passport": "^1.0.12",
     "@types/pdfkit": "^0.17.0",
     "cors": "^2.8.5",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,7 +8,8 @@
     "skipLibCheck": true,
     "outDir": "dist",
     "lib": ["ES2020"],
-    "types": ["node"]
+    "types": ["node"],
+    "typeRoots": ["./node_modules/@types"]
   },
   "include": ["**/*.ts"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- ensure @types/node pinned to ^22.0.0 in backend
- add typeRoots to tsconfig for Node

## Testing
- `npm i -D @types/node@^22 ts-node@^10.9.2 typescript@^5.6.2` *(fails: 403 Forbidden)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden)*
- `npm run dev` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b849f69f748323be2cda8e7b7ccf98