### PR TITLE
feat: typed team member update handler

### DIFF
--- a/backend/controllers/TeamMemberController.ts
+++ b/backend/controllers/TeamMemberController.ts
@@ -1,6 +1,14 @@
 import TeamMember, { ITeamMember } from '../models/TeamMember';
 import { AuthedRequestHandler } from '../types/AuthedRequestHandler';
 
+type IdParams = { id: string };
+
+interface UpdateTeamMemberBody {
+  role?: ITeamMember['role'];
+  managerId?: string | null;
+  [key: string]: any;
+}
+
 const roleHierarchy: Record<ITeamMember['role'], ITeamMember['role'][] | null> = {
   admin: null,
   manager: null,
@@ -80,7 +88,11 @@ export const createTeamMember: AuthedRequestHandler = async (req, res, next) => 
   }
 };
 
-export const updateTeamMember: AuthedRequestHandler = async (req, res, next) => {
+export const updateTeamMember: AuthedRequestHandler<
+  IdParams,
+  any,
+  UpdateTeamMemberBody
+> = async (req, res, next) => {
   try {
     const role = req.body.role;
     if (['admin', 'manager', 'department_leader'].includes(role)) {
@@ -103,8 +115,8 @@ export const updateTeamMember: AuthedRequestHandler = async (req, res, next) => 
     );
     if (!updated) return res.status(404).json({ message: 'Not found' });
     res.json(updated);
-  } catch (err) {
-    next(err);
+  } catch (err: any) {
+    res.status(400).json({ errors: err.errors ?? err });
   }
 };
 


### PR DESCRIPTION
## Summary
- type team member update params/body generics
- return validation errors for failed update

## Testing
- `npm test -w backend` *(fails: vitest not found)*
- `npm run typecheck -w backend` *(fails: tsc --noEmit)*

------
https://chatgpt.com/codex/tasks/task_e_68b859a395348323ba26d2a0541ffdb8