### PR TITLE
refactor: type approve handler

### DIFF
--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -282,10 +282,14 @@ export const deleteWorkOrder: AuthedRequestHandler = async (
  *       404:
  *         description: Work order not found
  */
-export const approveWorkOrder: AuthedRequestHandler = async (
-  req: { body: { status: any; }; params: { id: any; }; user: { _id: any; }; },
-  res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): any; new(): any; }; }; json: (arg0: any) => void; },
-  next: (arg0: unknown) => void
+
+type IdParams = { id: string };
+type ApproveBody = { status: 'pending' | 'approved' | 'rejected' };
+
+export const approveWorkOrder: AuthedRequestHandler<IdParams, any, ApproveBody> = async (
+  req,
+  res,
+  next
 ) => {
   try {
     const { status } = req.body;
@@ -298,14 +302,14 @@ export const approveWorkOrder: AuthedRequestHandler = async (
 
     workOrder.approvalStatus = status;
 
+    const userId = req.user?._id ?? req.user?.id;
+
     if (status === 'pending') {
       // user requesting approval
-      // @ts-ignore
-      workOrder.approvalRequestedBy = req.user?._id;
+      workOrder.approvalRequestedBy = userId as any;
     } else {
       // approved or rejected
-      // @ts-ignore
-      workOrder.approvedBy = req.user?._id;
+      workOrder.approvedBy = userId as any;
     }
 
       const saved = await workOrder.save();
@@ -317,7 +321,6 @@ export const approveWorkOrder: AuthedRequestHandler = async (
         : `Work order "${workOrder.title}" was ${status}`;
 
     if (workOrder.assignedTo) {
-      // @ts-ignore
       await notifyUser(workOrder.assignedTo, message);
     }
 


### PR DESCRIPTION
## Summary
- add IdParams and ApproveBody types for work order approvals
- type approveWorkOrder handler with generics
- remove `@ts-ignore` in favor of typed user access

## Testing
- `npm test -w backend` *(fails: vitest not found)*
- `npm run typecheck -w backend` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68b859a4d36c8323906cd562049b8a14