### PR TITLE
Refactor work order controller types

### DIFF
--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -1,5 +1,5 @@
-import { AuthedRequest } from '../types/AuthedRequest';
-import { AuthedRequestHandler } from '../types/AuthedRequestHandler';
+import { Response, NextFunction } from 'express';
+import { AuthedRequest, AuthedRequestHandler } from '../types/http';
 import WorkOrder from '../models/WorkOrder';
 import { emitWorkOrderUpdate } from '../server';
 import { validationResult } from 'express-validator';
@@ -18,6 +18,15 @@ function toWorkOrderUpdatePayload(doc: any): WorkOrderUpdatePayload {
   } as WorkOrderUpdatePayload;
 }
 
+type SearchQuery = {
+  status?: 'open' | 'in-progress' | 'on-hold' | 'completed';
+  priority?: 'low' | 'medium' | 'high' | 'critical';
+  startDate?: string;
+  endDate?: string;
+};
+
+type IdParams = { id: string };
+
 /**
  * @openapi
  * /api/workorders:
@@ -30,9 +39,9 @@ function toWorkOrderUpdatePayload(doc: any): WorkOrderUpdatePayload {
  *         description: List of work orders
  */
 export const getAllWorkOrders: AuthedRequestHandler = async (
-  req: { tenantId: any; },
-  res: { json: (arg0: any) => void; },
-  next: (arg0: unknown) => void
+  req: AuthedRequest,
+  res: Response,
+  next: NextFunction
 ) => {
   try {
     const items = await WorkOrder.find({ tenantId: req.tenantId });
@@ -72,10 +81,10 @@ export const getAllWorkOrders: AuthedRequestHandler = async (
  *       200:
  *         description: Filtered work orders
  */
-export const searchWorkOrders: AuthedRequestHandler = async (
-  req: { query: { status: any; priority: any; startDate: any; endDate: any; }; tenantId: any; },
-  res: { json: (arg0: any) => void; },
-  next: (arg0: unknown) => void
+export const searchWorkOrders: AuthedRequestHandler<unknown, any, unknown, SearchQuery> = async (
+  req: AuthedRequest<unknown, any, unknown, SearchQuery>,
+  res: Response,
+  next: NextFunction
 ) => {
   try {
     const { status, priority, startDate, endDate } = req.query;
@@ -115,10 +124,10 @@ export const searchWorkOrders: AuthedRequestHandler = async (
  *       404:
  *         description: Work order not found
  */
-export const getWorkOrderById: AuthedRequestHandler = async (
-  req: { params: { id: any; }; tenantId: any; },
-  res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): any; new(): any; }; }; json: (arg0: any) => void; },
-  next: (arg0: unknown) => void
+export const getWorkOrderById: AuthedRequestHandler<IdParams> = async (
+  req: AuthedRequest<IdParams>,
+  res: Response,
+  next: NextFunction
 ) => {
   try {
     const item = await WorkOrder.findOne({ _id: req.params.id, tenantId: req.tenantId });
@@ -148,10 +157,10 @@ export const getWorkOrderById: AuthedRequestHandler = async (
  *       400:
  *         description: Validation error
  */
-export const createWorkOrder: AuthedRequestHandler = async (
-  req: { body: any; tenantId: any; },
-  res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { errors: any; }): void; new(): any; }; }; },
-  next: (arg0: unknown) => void
+export const createWorkOrder: AuthedRequestHandler<unknown, any, any> = async (
+  req: AuthedRequest<unknown, any, any>,
+  res: Response,
+  next: NextFunction
 ) => {
   try {
     const errors = validationResult(req);
@@ -192,10 +201,10 @@ export const createWorkOrder: AuthedRequestHandler = async (
  *       404:
  *         description: Work order not found
  */
-export const updateWorkOrder: AuthedRequestHandler = async (
-  req: { params: { id: any; }; tenantId: any; body: any; },
-  res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { errors?: any; message?: string; }): any; new(): any; }; }; json: (arg0: any) => void; },
-  next: (arg0: unknown) => void
+export const updateWorkOrder: AuthedRequestHandler<{ id: string }, any, any> = async (
+  req: AuthedRequest<{ id: string }, any, any>,
+  res: Response,
+  next: NextFunction
 ) => {
   try {
     const errors = validationResult(req);
@@ -237,10 +246,10 @@ export const updateWorkOrder: AuthedRequestHandler = async (
  *       404:
  *         description: Work order not found
  */
-export const deleteWorkOrder: AuthedRequestHandler = async (
-  req: { params: { id: any; }; tenantId: any; },
-  res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): any; new(): any; }; }; json: (arg0: { message: string; }) => void; },
-  next: (arg0: unknown) => void
+export const deleteWorkOrder: AuthedRequestHandler<{ id: string }> = async (
+  req: AuthedRequest<{ id: string }>,
+  res: Response,
+  next: NextFunction
 ) => {
   try {
       const deleted = await WorkOrder.findOneAndDelete({ _id: req.params.id, tenantId: req.tenantId });
@@ -282,10 +291,10 @@ export const deleteWorkOrder: AuthedRequestHandler = async (
  *       404:
  *         description: Work order not found
  */
-export const approveWorkOrder: AuthedRequestHandler = async (
-  req: { body: { status: any; }; params: { id: any; }; user: { _id: any; }; },
-  res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): any; new(): any; }; }; json: (arg0: any) => void; },
-  next: (arg0: unknown) => void
+export const approveWorkOrder: AuthedRequestHandler<{ id: string }, any, { status: 'pending' | 'approved' | 'rejected' }> = async (
+  req: AuthedRequest<{ id: string }, any, { status: 'pending' | 'approved' | 'rejected' }>,
+  res: Response,
+  next: NextFunction
 ) => {
   try {
     const { status } = req.body;
@@ -346,10 +355,10 @@ export const approveWorkOrder: AuthedRequestHandler = async (
  *       404:
  *         description: Work order not found
  */
-export const assistWorkOrder: AuthedRequestHandler = async (
-  req: { params: { id: any; }; tenantId: any; },
-  res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): any; new(): any; }; }; json: (arg0: AIAssistResult) => void; },
-  next: (arg0: unknown) => void
+export const assistWorkOrder: AuthedRequestHandler<{ id: string }, AIAssistResult> = async (
+  req: AuthedRequest<{ id: string }, AIAssistResult>,
+  res: Response<AIAssistResult>,
+  next: NextFunction
 ) => {
   try {
     const workOrder = await WorkOrder.findOne({

--- a/backend/types/http.ts
+++ b/backend/types/http.ts
@@ -1,0 +1,2 @@
+export { AuthedRequest } from './AuthedRequest';
+export { AuthedRequestHandler } from './AuthedRequestHandler';


### PR DESCRIPTION
## Summary
- centralize AuthedRequest and AuthedRequestHandler via new `types/http` module
- update WorkOrderController handlers to use typed AuthedRequest/Response signatures
- define explicit `SearchQuery` and `IdParams` types for better type safety

## Testing
- `npx tsc -p .` *(fails: Cannot find module 'express' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a84c4c208323b7ba520ddfdbbf78