### PR TITLE
Allow Response returns in handlers

### DIFF
--- a/backend/types/http.ts
+++ b/backend/types/http.ts
@@ -1,2 +1,27 @@
- export type { RequestUser, AuthedRequest, AuthedRequestHandler } from '../../types/http';
+import { Request, Response, NextFunction } from 'express';
+
+export type RequestUser = {
+  id?: string;
+  _id?: string;
+  email?: string;
+  role?: string;
+};
+
+export type AuthedRequest<P = any, ResBody = any, ReqBody = any, ReqQuery = any> =
+  Request<P, ResBody, ReqBody, ReqQuery> & {
+    user?: RequestUser;
+    tenantId?: string;
+  };
+
+/**
+ * Allow common Express patterns like:
+ *   return res.json(...), return res.status(...).json(...), or just res.json(...)
+ */
+export type AuthedRequestHandler<P = any, ResBody = any, ReqBody = any, ReqQuery = any> =
+  (
+    req: AuthedRequest<P, ResBody, ReqBody, ReqQuery>,
+    res: Response<ResBody>,
+    next: NextFunction
+  ) => void | Response<any> | Promise<void | Response<any>>;
+
  


### PR DESCRIPTION
## Summary
- expand AuthedRequestHandler to accept returning Express responses
- clean WorkOrderController imports and use ObjectId for approval fields
- return responses from assistWorkOrder

## Testing
- `npx tsc -p .` (fails: Cannot find module 'passport' or its types, etc.)
- `npm run dev` (fails: ts-node not found)


------
https://chatgpt.com/codex/tasks/task_e_68b8b8949e4c8323a95ac0008f65896f