### PR TITLE
Validate timesheet hours before submitting

### DIFF
--- a/Frontend/src/pages/TimeSheets.tsx
+++ b/Frontend/src/pages/TimeSheets.tsx
@@ -3,11 +3,13 @@ import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
 import api from '../utils/api';
 import type { Timesheet } from '../types';
+import { useToast } from '../context/ToastContext';
 
 const TimeSheets: React.FC = () => {
   const [timesheets, setTimesheets] = useState<Timesheet[]>([]);
   const [form, setForm] = useState({ date: '', hours: '', description: '' });
   const [editingId, setEditingId] = useState<string | null>(null);
+  const { addToast } = useToast();
 
   const loadTimesheets = async () => {
     try {
@@ -35,6 +37,10 @@ const TimeSheets: React.FC = () => {
       hours: Number(form.hours),
       description: form.description,
     };
+    if (!Number.isFinite(payload.hours) || payload.hours < 0) {
+      addToast('Hours must be a non-negative number', 'error');
+      return;
+    }
     try {
       if (editingId) {
         await api.put(`/timesheets/${editingId}`, payload);


### PR DESCRIPTION
## Summary
- ensure timesheet submissions only send non-negative finite hours
- show an error toast when invalid hours are entered

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b99cca35488323867dd5af5a4c5da1