### PR TITLE
Add loading state to TeamModal submission

### DIFF
--- a/Frontend/src/components/teams/TeamModal.tsx
+++ b/Frontend/src/components/teams/TeamModal.tsx
@@ -28,6 +28,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ isOpen, onClose, member }) => {
   const { fetchDepartments } = useDepartmentStore();
   const { addToast } = useToast();
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const {
     register,
@@ -72,6 +73,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ isOpen, onClose, member }) => {
   };
 
   const onSubmit = handleSubmit(async (data) => {
+    setLoading(true);
     try {
       const payload: any = { ...data };
       if (!payload.managerId) delete payload.managerId;
@@ -92,6 +94,8 @@ const TeamModal: React.FC<TeamModalProps> = ({ isOpen, onClose, member }) => {
     } catch (e: any) {
       const msg = e.response?.data?.message || 'Failed to save team member';
       addToast(msg, 'error');
+    } finally {
+      setLoading(false);
     }
   });
 
@@ -229,7 +233,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ isOpen, onClose, member }) => {
             <Button type="button" variant="outline" onClick={onClose}>
               Cancel
             </Button>
-            <Button type="submit" variant="primary">
+            <Button type="submit" variant="primary" loading={loading}>
               {member ? 'Update Member' : 'Add Member'}
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- track loading state in TeamModal and toggle around async submit
- disable submit button with spinner during form submission

## Testing
- `npm test -w Frontend` *(fails: vitest not found)*
- `npm run lint -w Frontend` *(fails: Cannot find package '/workspace/WorkPro3/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b99ccc1f048323ad4f2589c2843633