### PR TITLE
Handle offline queue persistence failures

### DIFF
--- a/Frontend/src/context/ToastContext.tsx
+++ b/Frontend/src/context/ToastContext.tsx
@@ -48,6 +48,18 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   );
 
   useEffect(() => {
+    const handler = (e: Event) => {
+      const { message, type } = (e as CustomEvent<{
+        message: string;
+        type?: 'success' | 'error';
+      }>).detail;
+      addToast(message, type);
+    };
+    window.addEventListener('toast', handler);
+    return () => window.removeEventListener('toast', handler);
+  }, [addToast]);
+
+  useEffect(() => {
     return () => {
       Object.values(timers.current).forEach(clearTimeout);
     };
@@ -71,3 +83,12 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 };
 
 export const useToast = () => useContext(ToastContext);
+
+export const emitToast = (
+  message: string,
+  type: 'success' | 'error' = 'success',
+) => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('toast', { detail: { message, type } }));
+  }
+};

--- a/Frontend/src/utils/offlineQueue.ts
+++ b/Frontend/src/utils/offlineQueue.ts
@@ -1,3 +1,5 @@
+import { emitToast } from '../context/ToastContext';
+
 export type QueuedRequest = {
   method: 'post' | 'put' | 'delete';
   url: string;
@@ -22,7 +24,12 @@ export const loadQueue = (): QueuedRequest[] => {
 };
 
 const saveQueue = (queue: QueuedRequest[]) => {
-  localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+  try {
+    localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+  } catch (err) {
+    console.error('Failed to persist offline queue', err);
+    emitToast('Failed to save offline changes; they may be lost', 'error');
+  }
 };
 
 export const addToQueue = (req: QueuedRequest) => {


### PR DESCRIPTION
## Summary
- Expose global toast emitter and listen for window "toast" events
- Guard localStorage queue persistence and notify when saving fails

## Testing
- `npm run lint -w Frontend` (fails: Cannot find package '@eslint/js')
- `npm test -w Frontend` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68b99ccdc72c8323aab22ee172e30427