### PR TITLE
feat: persist settings before toast

### DIFF
--- a/Frontend/src/pages/Settings.tsx
+++ b/Frontend/src/pages/Settings.tsx
@@ -37,8 +37,22 @@ const Settings: React.FC = () => {
     }
   };
 
-  const handleSaveSettings = () => {
-    addToast('Settings saved', 'success');
+  const handleSaveSettings = async () => {
+    try {
+      const settings = useSettingsStore.getState();
+      const response = await fetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(settings),
+      });
+      if (!response.ok) {
+        throw new Error('Failed to save settings');
+      }
+      addToast('Settings saved', 'success');
+    } catch (error) {
+      console.error('Error saving settings:', error);
+      addToast('Failed to save settings', 'error');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- persist settings via `/api/settings` before showing toast
- show error toast when settings persistence fails

## Testing
- `npm test -w Frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ccf55108323acd8140f70de24b0