### PR TITLE
refactor: add maintenance type alias

### DIFF
--- a/Frontend/src/components/dashboard/UpcomingMaintenance.tsx
+++ b/Frontend/src/components/dashboard/UpcomingMaintenance.tsx
@@ -3,13 +3,15 @@ import { Calendar, Clock, PenTool as Tool } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import Card from '../common/Card';
 import Badge from '../common/Badge';
+import type { MaintenanceType } from '../../types';
+export type { MaintenanceType };
 
 interface MaintenanceItem {
   id: string;
   assetName: string;
   assetId: string;
   date: string;
-  type: 'preventive' | 'corrective' | 'inspection';
+  type: MaintenanceType;
   assignedTo?: string;
   estimatedDuration: number;
 }

--- a/Frontend/src/hooks/useDashboardData.ts
+++ b/Frontend/src/hooks/useDashboardData.ts
@@ -6,6 +6,7 @@ import type {
   CriticalAlertResponse,
   UpcomingMaintenanceItem,
   CriticalAlertItem,
+  MaintenanceType,
 } from '../types';
 import type { DateRange, Timeframe } from '../store/dashboardStore';
 
@@ -122,7 +123,7 @@ export default function useDashboardData(
             assetName: u.asset?.name ?? 'Unknown',
             assetId: u.asset?._id ?? (u as any).asset?.id ?? '',
             date: u.nextDue,
-            type: u.type ?? '',
+            type: (u.type ?? 'inspection') as MaintenanceType,
             assignedTo: u.assignedTo ?? '',
             estimatedDuration: u.estimatedDuration ?? 0,
           }))

--- a/Frontend/src/types/index.ts
+++ b/Frontend/src/types/index.ts
@@ -323,13 +323,18 @@ export interface LowStockPart {
   reorderPoint: number;
 }
 
+/**
+ * Defines the allowed maintenance categories for upcoming maintenance tasks.
+ */
+export type MaintenanceType = 'preventive' | 'corrective' | 'inspection';
+
 /** Response shape for upcoming maintenance tasks */
 export interface UpcomingMaintenanceResponse {
   _id?: string;
   id?: string;
   asset?: { _id?: string; name?: string };
   nextDue: string;
-  type?: string;
+  type?: MaintenanceType;
   assignedTo?: string;
   estimatedDuration?: number;
 }
@@ -340,7 +345,7 @@ export interface UpcomingMaintenanceItem {
   assetName: string;
   assetId: string;
   date: string;
-  type: string;
+  type: MaintenanceType;
   assignedTo: string;
   estimatedDuration: number;
 }


### PR DESCRIPTION
## Summary
- add `MaintenanceType` union type for upcoming maintenance
- use `MaintenanceType` for upcoming maintenance item props and dashboard hook

## Testing
- `npm test -w Frontend` *(fails: vitest not found)*
- `npm run lint -w Frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b9f4f8e62c832382beddf109c92938