### PR TITLE
refactor: unify asset status types

### DIFF
--- a/Frontend/src/components/dashboard/AssetsStatusChart.tsx
+++ b/Frontend/src/components/dashboard/AssetsStatusChart.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import Card from '../common/Card';
+import type { AssetStatusMap } from '../../hooks/useDashboardData';
 
 interface AssetsStatusChartProps {
-  data?: Record<string, number>;
+  data?: AssetStatusMap;
 }
 
 const AssetsStatusChart: React.FC<AssetsStatusChartProps> = ({ data }) => {

--- a/Frontend/src/hooks/useDashboardData.ts
+++ b/Frontend/src/hooks/useDashboardData.ts
@@ -30,11 +30,7 @@ const defaultWOStatus: WorkOrderStatusMap = {
   completed: 0,
 };
 
-interface AssetStatusMap {
-  Active: number;
-  Offline: number;
-  'In Repair': number;
-}
+export type AssetStatusMap = Record<string, number>;
 
 const defaultAssetStatus: AssetStatusMap = {
   Active: 0,


### PR DESCRIPTION
## Summary
- export reusable AssetStatusMap alias and use it across dashboard components
- update AssetsStatusChart to rely on AssetStatusMap instead of inline Record

## Testing
- `npm test -w Frontend` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f4fa739883238bd319e758fe875d