### PR TITLE
Add viewer default for OAuth login

### DIFF
--- a/Frontend/src/pages/LoginPage.tsx
+++ b/Frontend/src/pages/LoginPage.tsx
@@ -30,7 +30,13 @@ const LoginPage: React.FC = () => {
     const token = params.get('token');
     const emailFromOauth = params.get('email');
     if (token && emailFromOauth) {
-      setUser({ email: emailFromOauth, token });
+      setUser({
+        id: crypto?.randomUUID?.() ?? String(Date.now()),
+        name: emailFromOauth,
+        email: emailFromOauth,
+        role: 'viewer',
+        token,
+      });
       navigate('/dashboard');
     }
 


### PR DESCRIPTION
## Summary
- ensure OAuth logins set a full user object with default viewer role

## Testing
- `npm test -w Frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f4fab56483239b24e6168e7f033a