### PR TITLE
feat: add maintenance type union

### DIFF
--- a/Frontend/src/components/dashboard/UpcomingMaintenance.tsx
+++ b/Frontend/src/components/dashboard/UpcomingMaintenance.tsx
@@ -3,13 +3,14 @@ import { Calendar, Clock, PenTool as Tool } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import Card from '../common/Card';
 import Badge from '../common/Badge';
+import type { MaintenanceType } from '../../types';
 
 interface MaintenanceItem {
   id: string;
   assetName: string;
   assetId: string;
   date: string;
-  type: 'preventive' | 'corrective' | 'inspection';
+  type: MaintenanceType;
   assignedTo?: string;
   estimatedDuration: number;
 }

--- a/Frontend/src/hooks/useDashboardData.ts
+++ b/Frontend/src/hooks/useDashboardData.ts
@@ -6,6 +6,7 @@ import type {
   CriticalAlertResponse,
   UpcomingMaintenanceItem,
   CriticalAlertItem,
+  MaintenanceType,
 } from '../types';
 import type { DateRange, Timeframe } from '../store/dashboardStore';
 
@@ -122,7 +123,7 @@ export default function useDashboardData(
             assetName: u.asset?.name ?? 'Unknown',
             assetId: u.asset?._id ?? (u as any).asset?.id ?? '',
             date: u.nextDue,
-            type: u.type ?? '',
+            type: (u.type ?? 'preventive') as MaintenanceType,
             assignedTo: u.assignedTo ?? '',
             estimatedDuration: u.estimatedDuration ?? 0,
           }))

--- a/Frontend/src/types/index.ts
+++ b/Frontend/src/types/index.ts
@@ -1,3 +1,5 @@
+export type MaintenanceType = 'preventive' | 'corrective' | 'inspection';
+
 export interface Asset {
   id: string;
   name: string;
@@ -329,7 +331,7 @@ export interface UpcomingMaintenanceResponse {
   id?: string;
   asset?: { _id?: string; name?: string };
   nextDue: string;
-  type?: string;
+  type?: MaintenanceType;
   assignedTo?: string;
   estimatedDuration?: number;
 }
@@ -340,7 +342,7 @@ export interface UpcomingMaintenanceItem {
   assetName: string;
   assetId: string;
   date: string;
-  type: string;
+  type: MaintenanceType;
   assignedTo: string;
   estimatedDuration: number;
 }


### PR DESCRIPTION
## Summary
- add `MaintenanceType` union for maintenance categories
- use `MaintenanceType` in upcoming maintenance types and hook
- update dashboard component to leverage shared `MaintenanceType`

## Testing
- `npm test -w Frontend` *(fails: vitest not found)*
- `npm run lint -w Frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ba01c8d3cc8323a23b2db93288eb6f