### PR TITLE
refactor: use flexible asset status map

### DIFF
--- a/Frontend/src/components/dashboard/AssetsStatusChart.tsx
+++ b/Frontend/src/components/dashboard/AssetsStatusChart.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import Card from '../common/Card';
+import type { AssetStatusMap } from '../../types';
 
 interface AssetsStatusChartProps {
-  data?: Record<string, number>;
+  data?: AssetStatusMap;
 }
 
 const AssetsStatusChart: React.FC<AssetsStatusChartProps> = ({ data }) => {

--- a/Frontend/src/hooks/useDashboardData.ts
+++ b/Frontend/src/hooks/useDashboardData.ts
@@ -6,6 +6,7 @@ import type {
   CriticalAlertResponse,
   UpcomingMaintenanceItem,
   CriticalAlertItem,
+  AssetStatusMap,
 } from '../types';
 import type { DateRange, Timeframe } from '../store/dashboardStore';
 
@@ -30,17 +31,7 @@ const defaultWOStatus: WorkOrderStatusMap = {
   completed: 0,
 };
 
-interface AssetStatusMap {
-  Active: number;
-  Offline: number;
-  'In Repair': number;
-}
-
-const defaultAssetStatus: AssetStatusMap = {
-  Active: 0,
-  Offline: 0,
-  'In Repair': 0,
-};
+const defaultAssetStatus: AssetStatusMap = {};
 
 // simple debounce helper
 function debounce<F extends (...args: any[]) => void>(fn: F, delay: number) {
@@ -105,12 +96,10 @@ export default function useDashboardData(
       setWorkOrdersByStatus(woCounts);
 
       // Assets
-      const assetCounts: AssetStatusMap = { ...defaultAssetStatus };
+      const assetCounts: AssetStatusMap = {};
       if (Array.isArray(assetRes.data)) {
         assetRes.data.forEach(({ _id, count }) => {
-          if (_id in assetCounts) {
-            assetCounts[_id as keyof AssetStatusMap] = count;
-          }
+          assetCounts[_id as string] = count;
         });
       }
       setAssetsByStatus(assetCounts);

--- a/Frontend/src/types/index.ts
+++ b/Frontend/src/types/index.ts
@@ -25,6 +25,8 @@ export interface Asset {
   updatedAt?: string;
 }
 
+export type AssetStatusMap = Record<string, number>;
+
 export interface Department {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- export reusable `AssetStatusMap` type
- dynamically populate asset status counts in dashboard hook
- update AssetsStatusChart to accept AssetStatusMap props

## Testing
- `npm run lint -w Frontend` (fails: Cannot find package '@eslint/js')
- `npm test -w Frontend` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba01ca05bc83238117fd64c8f7491d