### PR TITLE
Include full user data on OAuth login

### DIFF
--- a/Frontend/src/pages/LoginPage.tsx
+++ b/Frontend/src/pages/LoginPage.tsx
@@ -30,7 +30,17 @@ const LoginPage: React.FC = () => {
     const token = params.get('token');
     const emailFromOauth = params.get('email');
     if (token && emailFromOauth) {
-      setUser({ email: emailFromOauth, token });
+      const id =
+        typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+          ? crypto.randomUUID()
+          : `${Date.now()}`;
+      setUser({
+        id,
+        name: emailFromOauth.split('@')[0],
+        role: 'viewer',
+        email: emailFromOauth,
+        token,
+      });
       navigate('/dashboard');
     }
 


### PR DESCRIPTION
## Summary
- ensure OAuth login sets full user object (id, name, role, email, token)
- confirm other setUser usages already supply complete user info

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba01cae604832393047df1ddea3842