### PR TITLE
chore: remove unused dashboard setter

### DIFF
--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -62,7 +62,6 @@ const Dashboard: React.FC = () => {
     selectedDepartment,
     selectedTimeframe,
     customRange,
-    setSelectedDepartment,
     layouts,
     setLayouts,
   } = useDashboardStore((s) => ({
@@ -70,7 +69,6 @@ const Dashboard: React.FC = () => {
     selectedDepartment: s.selectedDepartment,
     selectedTimeframe: s.selectedTimeframe,
     customRange: s.customRange,
-    setSelectedDepartment: s.setSelectedDepartment,
     layouts: s.layouts,
     setLayouts: s.setLayouts,
   }));


### PR DESCRIPTION
## Summary
- remove unused setSelectedDepartment from dashboard page store destructuring

## Testing
- `npm test -w Frontend` *(fails: vitest not found)*
- `npm run lint -w Frontend` *(fails: Cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68ba01ccd4fc8323995e55a6208fa759