### PR TITLE
fix: silence unused var warning in Documentation page

### DIFF
--- a/Frontend/src/pages/Documentation.tsx
+++ b/Frontend/src/pages/Documentation.tsx
@@ -75,7 +75,7 @@ const Documentation: React.FC = () => {
     description: '',
   });
 
-  const handleDocumentUpload = (files: File[]) => {
+  const handleDocumentUpload = (_files: File[]) => {
     setShowUploader(false);
   };
 


### PR DESCRIPTION
## Summary
- rename unused `files` parameter to `_files` in Documentation page

## Testing
- `npm test -w Frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba01d0b448832387833c5bb4251ac6