### PR TITLE
feat(frontend): proxy backend requests

### DIFF
--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -25,5 +25,15 @@ export default defineConfig({
         ]
       }
     })
-  ]
+  ],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000', // adjust if backend uses another port
+        changeOrigin: true,
+        secure: false
+      }
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- forward `/api` requests to backend through Vite dev server

## Testing
- `npm test -w Frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba01d239648323b16369c8200f33e4