### PR TITLE
Fix standard deviation calculation in predictive service

### DIFF
--- a/backend/utils/predictiveService.ts
+++ b/backend/utils/predictiveService.ts
@@ -69,9 +69,11 @@ function arimaForecast(values: number[]): number {
 }
 
 function computeStdDev(values: number[]): number {
+  if (values.length <= 1) return 0;
   const mean = values.reduce((a, b) => a + b, 0) / values.length;
   const variance =
-    values.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / values.length;
+    values.reduce((a, b) => a + Math.pow(b - mean, 2), 0) /
+    (values.length - 1);
   return Math.sqrt(variance);
 }
 


### PR DESCRIPTION
## Summary
- Correct sample standard deviation in predictiveService utility to avoid underestimating variance

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2b215d708323958438af41127903