### PR TITLE
chore: remove PWA plugin

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -87,7 +87,6 @@
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
         "vite": "^7.1.4",
-        "vite-plugin-pwa": "^0.20.5",
         "vitest": "^3.2.2"
       }
     },
@@ -13781,37 +13780,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-plugin-pwa": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-0.20.5.tgz",
-      "integrity": "sha512-aweuI/6G6n4C5Inn0vwHumElU/UEpNuO+9iZzwPZGTCH87TeZ6YFMrEY6ZUBQdIHHlhTsbMDryFARcSuOdsz9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.6",
-        "pretty-bytes": "^6.1.1",
-        "tinyglobby": "^0.2.0",
-        "workbox-build": "^7.1.0",
-        "workbox-window": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vite-pwa/assets-generator": "^0.2.6",
-        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0",
-        "workbox-build": "^7.1.0",
-        "workbox-window": "^7.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@vite-pwa/assets-generator": {
-          "optional": true
-        }
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -93,7 +93,6 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
     "vite": "^7.1.4",
-    "vite-plugin-pwa": "^0.20.5",
     "vitest": "^3.2.2"
   },
   "overrides": {

--- a/Frontend/src/types/vite-plugin-pwa.d.ts
+++ b/Frontend/src/types/vite-plugin-pwa.d.ts
@@ -1,1 +1,0 @@
-declare module "vite-plugin-pwa";

--- a/Frontend/src/vite-env.d.ts
+++ b/Frontend/src/vite-env.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-pwa/client" />

--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -1,30 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
   plugins: [
-    react(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      devOptions: { enabled: true }, // allow SW in dev
-      strategies: 'injectManifest',
-      srcDir: 'src',
-      filename: 'sw.ts',
-      manifest: {
-        name: 'MaintainPro',
-        short_name: 'MaintainPro',
-        start_url: '/',
-        display: 'standalone',
-        background_color: '#ffffff',
-        theme_color: '#0ea5e9',
-        icons: [
-          // add real icons if available:
-          // { src: '/pwa-192x192.png', sizes: '192x192', type: 'image/png' },
-          // { src: '/pwa-512x512.png', sizes: '512x512', type: 'image/png' }
-        ]
-      }
-    })
+    react()
   ],
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary
- remove Vite PWA plugin dependency and configuration from frontend
- drop PWA-specific types

## Testing
- `npm run dev` *(fails: sh: 1: vite: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bae34937888323b840b883a65d64a5