### PR TITLE
refactor: consolidate webhook routes

### DIFF
--- a/backend/routes/WebhookRoutes.ts
+++ b/backend/routes/WebhookRoutes.ts
@@ -1,9 +1,0 @@
-import express from 'express';
-import { handleWorkOrderHook } from '../controllers/WebhookController';
-import { requireThirdPartyAuth } from '../middleware/thirdPartyAuth';
-
-const router = express.Router();
-
-router.post('/workorder', requireThirdPartyAuth, handleWorkOrderHook);
-
-export default router;

--- a/backend/routes/webhooksRoutes.ts
+++ b/backend/routes/webhooksRoutes.ts
@@ -1,5 +1,7 @@
 import express from 'express';
 import crypto from 'crypto';
+import { handleWorkOrderHook } from '../controllers/WebhookController';
+import { requireThirdPartyAuth } from '../middleware/thirdPartyAuth';
 import Webhook from '../models/Webhook';
 import idempotency from '../middleware/idempotency';
 
@@ -15,5 +17,8 @@ router.post('/subscribe', idempotency, async (req, res) => {
   const hook = await Webhook.create({ url, event, secret });
   res.status(201).json({ id: hook._id, url: hook.url, event: hook.event, secret });
 });
+
+// Work order webhook
+router.post('/workorder', requireThirdPartyAuth, handleWorkOrderHook);
 
 export default router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -28,8 +28,7 @@ import analyticsRoutes from './routes/AnalyticsRoutes';
 import teamRoutes from './routes/TeamRoutes';
 import notificationsRoutes from './routes/notifications';
 import TenantRoutes from './routes/TenantRoutes';
-import webhooksRoutes from './routes/webhooks';
-import webhookRoutes from './routes/WebhookRoutes';
+import webhooksRoutes from './routes/webhooksRoutes';
 import ThemeRoutes from './routes/ThemeRoutes';
 import chatRoutes from './routes/ChatRoutes';
 import requestPortalRoutes from './routes/requestPortal';
@@ -168,7 +167,7 @@ app.use('/api/vendor-portal', vendorPortalRoutes);
 app.use('/api/vendor', vendorPortalRoutes);
 
 app.use('/api/chat', chatRoutes);
-app.use('/api/hooks', webhookRoutes);
+app.use('/api/hooks', webhooksRoutes);
 app.use('/api/webhooks', webhooksRoutes);
 app.use('/api/calendar', calendarRoutes);
 

--- a/backend/tests/webhookRoutes.test.ts
+++ b/backend/tests/webhookRoutes.test.ts
@@ -2,11 +2,11 @@ import { describe, it, beforeAll, expect } from "vitest";
 import request from 'supertest';
 import express from 'express';
 
-import webhookRoutes from '../routes/WebhookRoutes';
+import webhooksRoutes from '../routes/webhooksRoutes';
 
 const app = express();
 app.use(express.json());
-app.use('/api/hooks', webhookRoutes);
+app.use('/api/hooks', webhooksRoutes);
 
 beforeAll(() => {
   process.env.THIRD_PARTY_API_KEYS = 'testkey';

--- a/backend/tests/webhooks.test.ts
+++ b/backend/tests/webhooks.test.ts
@@ -5,7 +5,7 @@ import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import crypto from 'crypto';
 
-import webhooksRoutes from '../routes/webhooks';
+import webhooksRoutes from '../routes/webhooksRoutes';
 import Webhook from '../models/Webhook';
 import { dispatchEvent, RETRY_DELAY_MS } from '../utils/webhookDispatcher';
 


### PR DESCRIPTION
## Summary
- merge webhook route handlers into new `webhooksRoutes` module
- update server and tests to use unified routes for `/api/hooks` and `/api/webhooks`

## Testing
- `npm test` *(fails: Exit prior to config file resolving)*


------
https://chatgpt.com/codex/tasks/task_e_68baeca6713c83238a893a4b0a505ea1