### PR TITLE
feat: add OIDC typings

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -6,7 +6,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "noImplicitAny": true
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
## Summary
- define interfaces for OIDC strategy options and profile
- strongly type oidc verify handler and mock strategy
- enable `noImplicitAny` in backend tsconfig

## Testing
- `npm test -w backend` *(fails: invalid package.json in Frontend workspace)*
- `npm --prefix backend test` *(fails: vitest: not found)*
- `npm --prefix backend run typecheck` *(fails: cannot find module typings)*

------
https://chatgpt.com/codex/tasks/task_e_68baeca7205483239c2aa7e02ec5cf91