### PR TITLE
Use shared API helper for settings and test unauthorized errors

### DIFF
--- a/Frontend/src/pages/Settings.tsx
+++ b/Frontend/src/pages/Settings.tsx
@@ -15,6 +15,7 @@ import { parseDocument } from '../utils/documentation';
 import { useThemeStore } from '../store/themeStore';
 import { useSettingsStore } from '../store/settingsStore';
 import { useToast } from '../context/ToastContext';
+import api from '../utils/api';
 
 const Settings: React.FC = () => {
   const { theme, setTheme, updateTheme } = useThemeStore();
@@ -40,18 +41,15 @@ const Settings: React.FC = () => {
   const handleSaveSettings = async () => {
     try {
       const settings = useSettingsStore.getState();
-      const response = await fetch('/api/settings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(settings),
-      });
-      if (!response.ok) {
-        throw new Error('Failed to save settings');
-      }
+      await api.post('/settings', settings);
       addToast('Settings saved', 'success');
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error saving settings:', error);
-      addToast('Failed to save settings', 'error');
+      if (error.response?.status === 401) {
+        addToast('Unauthorized', 'error');
+      } else {
+        addToast('Failed to save settings', 'error');
+      }
     }
   };
 

--- a/Frontend/src/test/settings.test.tsx
+++ b/Frontend/src/test/settings.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../components/layout/Layout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../components/documentation/DocumentUploader', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../components/documentation/DocumentViewer', () => ({
+  default: () => <div />,
+}));
+
+const mockAddToast = vi.fn();
+vi.mock('../context/ToastContext', () => ({
+  useToast: () => ({ addToast: mockAddToast }),
+}));
+
+vi.mock('../utils/api', () => ({
+  default: { post: vi.fn() },
+}));
+
+import api from '../utils/api';
+import Settings from '../pages/Settings';
+
+describe('Settings page', () => {
+  beforeEach(() => {
+    (api.post as any).mockReset();
+    mockAddToast.mockReset();
+  });
+
+  it('saves settings successfully', async () => {
+    (api.post as any).mockResolvedValueOnce({ data: {} });
+    render(<Settings />);
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+    expect(api.post).toHaveBeenCalledWith('/settings', expect.any(Object));
+    expect(mockAddToast).toHaveBeenCalledWith('Settings saved', 'success');
+  });
+
+  it('handles unauthorized errors', async () => {
+    (api.post as any).mockRejectedValueOnce({ response: { status: 401 } });
+    render(<Settings />);
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+    expect(mockAddToast).toHaveBeenCalledWith('Unauthorized', 'error');
+  });
+});


### PR DESCRIPTION
## Summary
- Use shared axios API helper in Settings page instead of fetch
- Improve Settings save error handling with explicit unauthorized branch
- Add Settings page tests including unauthorized failure path

## Testing
- `npm test` *(fails: Exit prior to config file resolving)*
- `npx vitest --run` *(fails: Exit prior to config file resolving)*

------
https://chatgpt.com/codex/tasks/task_e_68baeca80a60832386559bc4b0dfe664