### PR TITLE
fix: resolve merge conflict in frontend package.json

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -92,17 +92,10 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-<<<<<<< HEAD
     "vite-plugin-pwa": "^0.20.5",
-    "vite": "^7.1.4"
- 
-   },
-=======
     "vite": "^7.1.4",
- 
     "vitest": "^3.2.2"
   },
->>>>>>> a678cb0e3f832e5383593a570ea65c29a7b81f90
   "overrides": {
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
## Summary
- remove merge conflict markers from frontend package.json
- keep vite-plugin-pwa and vitest dev dependencies

## Testing
- `npm install --package-lock-only`
- `npm test -w Frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf0137680832390e2dbf6ca5b0af8