### PR TITLE
feat(frontend): add PWA support

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -92,7 +92,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite-plugin-pwa": "^0.20.5",
+    "vite-plugin-pwa": "^0.21.0",
     "vite": "^7.1.4",
     "vitest": "^3.2.2"
   },

--- a/Frontend/src/vite-env.d.ts
+++ b/Frontend/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />

--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -1,9 +1,23 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
   plugins: [
-    react()
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['favicon.svg', 'robots.txt'],
+      manifest: {
+        name: 'WorkPro3',
+        short_name: 'WorkPro3',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#ffffff',
+        theme_color: '#0ea5e9',
+        icons: []
+      }
+    })
   ],
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary
- install Vite PWA plugin
- configure Vite to enable PWA with auto update and manifest
- add PWA client types

## Testing
- `npm i --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite-plugin-pwa)*
- `npm run dev` *(fails: vite: not found)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4d011db08323b0d5284b1204bd77