### PR TITLE
feat: enable PWA support in Vite

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -92,7 +92,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite-plugin-pwa": "^0.20.5",
+    "vite-plugin-pwa": "^0.21.0",
     "vite": "^7.1.4",
     "vitest": "^3.2.2"
   },

--- a/Frontend/src/vite-env.d.ts
+++ b/Frontend/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />

--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -1,9 +1,23 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
   plugins: [
-    react()
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['favicon.svg', 'robots.txt'],
+      manifest: {
+        name: 'WorkPro3',
+        short_name: 'WorkPro3',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#ffffff',
+        theme_color: '#0ea5e9',
+        icons: []
+      }
+    })
   ],
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary
- add VitePWA plugin configuration to enable PWA functionality
- reference PWA client types
- update vite-plugin-pwa dependency to latest v0.21

## Testing
- `npm install vite-plugin-pwa@0.21.0 --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite-plugin-pwa)*
- `npm test` *(fails: vitest not found)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4d01276c8323a18d64c479c13108