### PR TITLE
chore: type oauth provider

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -25,7 +25,7 @@ router.get('/oauth/:provider', (req, res, next) => {
 });
 
 router.get('/oauth/:provider/callback', (req, res, next) => {
-  const provider = req.params.provider;
+  const provider = req.params.provider as OAuthProvider;
   passport.authenticate(
     provider,
     { session: false },


### PR DESCRIPTION
## Summary
- type OAuth provider in callback route to better align with provider typing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb573dccfc8323b64cedabee1236cd