### PR TITLE
Add speakeasy type declarations

### DIFF
--- a/backend/types/speakeasy.d.ts
+++ b/backend/types/speakeasy.d.ts
@@ -1,0 +1,22 @@
+declare module 'speakeasy' {
+  export interface GenerateSecretOptions {
+    length?: number;
+    name?: string;
+  }
+  export interface GeneratedSecret {
+    ascii?: string;
+    hex?: string;
+    base32: string;
+    otpauth_url?: string;
+  }
+  export interface TotpVerifyOptions {
+    secret: string;
+    encoding?: 'ascii' | 'hex' | 'base32';
+    token: string;
+    window?: number;
+  }
+  export function generateSecret(options?: GenerateSecretOptions): GeneratedSecret;
+  export const totp: {
+    verify(opts: TotpVerifyOptions): boolean;
+  };
+}


### PR DESCRIPTION
## Summary
- add TypeScript type declarations for `speakeasy`

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run typecheck` *(fails: tsc --noEmit)*

------
https://chatgpt.com/codex/tasks/task_e_68bb902837fc8323b275bfe65df63868