### PR TITLE
chore: configure backend type declarations

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
+    "types": ["node"],
+    "typeRoots": ["./node_modules/@types", "./types"],
     "noImplicitAny": true
   },
   "include": [


### PR DESCRIPTION
## Summary
- add Node.js typings and custom type roots to backend tsconfig

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb902a6c7883238383dd6509c39cff