### PR TITLE
Use namespace import for speakeasy

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import crypto from "crypto";
-import speakeasy from "speakeasy";
+import * as speakeasy from "speakeasy";
 import logger from "../utils/logger";
 import User from "../models/User";
 


### PR DESCRIPTION
## Summary
- use namespace import for speakeasy in auth controller so totp methods are accessible without default export

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run typecheck` *(fails: tsc --noEmit missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb902c7edc83239a4edce64005d3b7