### PR TITLE
feat: add department dialog form

### DIFF
--- a/frontend/src/components/departments/DepartmentForm.tsx
+++ b/frontend/src/components/departments/DepartmentForm.tsx
@@ -1,60 +1,83 @@
-import React, { useState } from 'react';
-import api from '../../utils/api';
+import React, { useEffect, useRef, useState } from 'react';
 import Button from '../common/Button';
-import { useToast } from '../../context/ToastContext';
-import type { Department } from '../../types';
 
 interface Props {
-  department?: Department;
-  onSuccess?: (dep: Department) => void;
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: { name: string }) => Promise<void> | void;
+  initial?: { name: string };
 }
 
-const DepartmentForm: React.FC<Props> = ({ department, onSuccess }) => {
-  const [name, setName] = useState(department?.name || '');
+const DepartmentForm: React.FC<Props> = ({ open, onClose, onSubmit, initial }) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [name, setName] = useState(initial?.name ?? '');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const { addToast } = useToast();
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      setName(initial?.name ?? '');
+      setError(null);
+    }
+  }, [open, initial]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!name.trim()) {
+      setError('Name is required');
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
-      let res;
-      if (department) {
-        res = await api.put(`/departments/${department.id}`, { name });
-      } else {
-        res = await api.post('/departments', { name });
-      }
-      const saved = { id: res.data._id ?? res.data.id, name: res.data.name } as Department;
-      onSuccess?.(saved);
-      addToast(department ? 'Department updated' : 'Department created', 'success');
+      await onSubmit({ name: name.trim() });
+      dialogRef.current?.close();
     } catch (err: any) {
-      console.error(err);
-      setError(err.response?.data?.message || 'Failed to submit department');
+      setError(err?.message || 'Failed to submit');
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {error && <p className="text-error-500">{error}</p>}
-      <div>
-        <label className="block text-sm font-medium mb-1">Name</label>
-        <input
-          type="text"
-          className="w-full px-3 py-2 border border-neutral-300 rounded-md"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
-        />
-      </div>
-      <Button type="submit" variant="primary" loading={loading}>
-        {department ? 'Update Department' : 'Create Department'}
-      </Button>
-    </form>
+    <dialog ref={dialogRef} className="rounded-md p-0" onClose={onClose}>
+      <form onSubmit={handleSubmit} className="contents">
+        <header className="bg-sky-500 text-white px-4 py-2 rounded-t-md">
+          <h2 className="text-lg font-semibold">Department</h2>
+        </header>
+        <div className="p-4 space-y-4">
+          {error && <p className="text-error-500">{error}</p>}
+          <div>
+            <label className="block text-sm font-medium mb-1">Name</label>
+            <input
+              type="text"
+              className="w-full px-3 py-2 border border-neutral-300 rounded-md"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={() => dialogRef.current?.close()}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" loading={loading}>
+              Save
+            </Button>
+          </div>
+        </div>
+      </form>
+    </dialog>
   );
 };
 


### PR DESCRIPTION
## Summary
- replace DepartmentForm with a dialog-based component that accepts `open`, `onClose`, `onSubmit`, and optional `initial`
- handle local name state, validation, async submission, and a sky-colored header

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @dnd-kit/core)*

------
https://chatgpt.com/codex/tasks/task_e_68bbeb3aa004832396cfda28711c8463