### PR TITLE
feat: add confirm dialog component

### DIFF
--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useRef } from "react";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title?: string;
+  message: string;
+  confirmText: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  title,
+  message,
+  confirmText,
+  onClose,
+  onConfirm,
+}) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  const handleConfirm = () => {
+    onConfirm();
+    dialogRef.current?.close();
+  };
+
+  const handleCancel = () => {
+    dialogRef.current?.close();
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="rounded-md p-6 bg-white text-slate-900 shadow-lg dark:bg-slate-800 dark:text-slate-100"
+      onClose={onClose}
+    >
+      {title && <h2 className="text-lg font-semibold mb-4">{title}</h2>}
+      <p className="mb-6 text-slate-700 dark:text-slate-300">{message}</p>
+      <div className="flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={handleCancel}
+          className="px-4 py-2 rounded-md bg-slate-200 text-slate-800 hover:bg-slate-300 dark:bg-slate-700 dark:text-slate-200 dark:hover:bg-slate-600"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleConfirm}
+          className="px-4 py-2 rounded-md bg-rose-600 text-white hover:bg-rose-700"
+        >
+          {confirmText}
+        </button>
+      </div>
+    </dialog>
+  );
+};
+
+export default ConfirmDialog;
+


### PR DESCRIPTION
## Summary
- add modal-like ConfirmDialog component with slate and rose styling

## Testing
- `npm test -- --run` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching @dnd-kit/core)*

------
https://chatgpt.com/codex/tasks/task_e_68bbeb3b69ac8323893729067110e322