### PR TITLE
fix: move vite ignore comment into import

### DIFF
--- a/frontend/src/pwa.ts
+++ b/frontend/src/pwa.ts
@@ -6,8 +6,7 @@ export async function registerSWIfAvailable(opts?: { immediate?: boolean }) {
   try {
     // @ts-ignore - virtual module only exists when the plugin is installed
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @vite-ignore
-    const mod: any = await import(id as any);
+    const mod: any = await import(/* @vite-ignore */ id as any);
     if (mod?.registerSW) return mod.registerSW(opts);
   } catch {
     // Plugin not installed — fall back to a safe no-op.


### PR DESCRIPTION
## Summary
- embed `@vite-ignore` inside dynamic `import()` to avoid warning

## Testing
- `npm install --no-package-lock` *(fails: 403 Forbidden from registry)*
- `npm run dev` *(fails: vite: not found)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbeecf82408323a20bc57380e0c911