### PR TITLE
feat: add confirm dialog component

### DIFF
--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,48 +1,52 @@
-import React from 'react';
-import Modal from '../modals/Modal';
-import Button from './Button';
+import { useEffect, useRef } from 'react';
 
-
-interface ConfirmDialogProps {
+type Props = {
   open: boolean;
   title?: string;
-  message: string;
-   confirmText?: string;
-  cancelText?: string;
-  loading?: boolean;
-  error?: string | null;
-  onConfirm: () => void;
-  onCancel: () => void;
- 
-}
-
-const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
-  open,
-   title = 'Confirm',
-  message,
-  confirmText = 'Confirm',
-  cancelText = 'Cancel',
-  loading = false,
-  error,
-  onConfirm,
-  onCancel,
-}) => {
-  return (
-    <Modal isOpen={open} onClose={onCancel} title={title}>
-      {error && <p className="text-error-600 mb-2">{error}</p>}
-      <p>{message}</p>
-      <div className="flex justify-end space-x-2 mt-6">
-        <Button variant="outline" onClick={onCancel} disabled={loading}>
-          {cancelText}
-        </Button>
-        <Button variant="danger" onClick={onConfirm} loading={loading}>
-          {confirmText}
-        </Button>
-      </div>
-    </Modal>
- 
-  );
+  message?: string;
+  confirmText?: string;
+  onClose: () => void;
+  onConfirm: () => Promise<void> | void;
 };
 
-export default ConfirmDialog;
- 
+export default function ConfirmDialog({
+  open,
+  title = 'Are you sure?',
+  message = 'This action cannot be undone.',
+  confirmText = 'Delete',
+  onClose,
+  onConfirm,
+}: Props) {
+  const ref = useRef<HTMLDialogElement>(null);
+  useEffect(() => {
+    open ? ref.current?.showModal() : ref.current?.close();
+  }, [open]);
+  return (
+    <dialog
+      ref={ref}
+      className="rounded-xl w-[480px] max-w-[95vw] p-0 backdrop:bg-black/30"
+    >
+      <div className="p-5 space-y-3">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <p className="text-sm text-slate-600">{message}</p>
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            onClick={onClose}
+            className="rounded px-3 py-2 border hover:bg-slate-100"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={async () => {
+              await onConfirm();
+              onClose();
+            }}
+            className="rounded px-3 py-2 bg-rose-600 text-white hover:bg-rose-700"
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/src/pages/Departments.tsx
+++ b/frontend/src/pages/Departments.tsx
@@ -23,8 +23,7 @@ export default function Departments() {
   const [editing, setEditing] = useState<Dept | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<Dept | null>(null);
-  const [confirmError, setConfirmError] = useState<string | null>(null);
-  const [confirmLoading, setConfirmLoading] = useState(false);
+  // Confirm dialog no longer displays inline errors or loading state
 
   const load = async () => {
     setLoading(true);
@@ -65,25 +64,24 @@ export default function Departments() {
 
   const openDelete = (dep: Dept) => {
     setPendingDelete(dep);
-    setConfirmError(null);
     setConfirmOpen(true);
   };
 
   const handleDelete = async () => {
     if (!pendingDelete) return;
-    setConfirmLoading(true);
-    setConfirmError(null);
     try {
       await api.delete(`/departments/${pendingDelete.id}`);
       setItems((prev) => prev.filter((d) => d.id !== pendingDelete.id));
       addToast('Department deleted', 'success');
-      setConfirmOpen(false);
-      setPendingDelete(null);
     } catch (err: any) {
       console.error(err);
-      setConfirmError(err.response?.data?.message || 'Failed to delete department');
+      addToast(
+        err.response?.data?.message || 'Failed to delete department',
+        'error'
+      );
     } finally {
-      setConfirmLoading(false);
+      setConfirmOpen(false);
+      setPendingDelete(null);
     }
   };
 
@@ -149,9 +147,8 @@ export default function Departments() {
           title="Delete Department"
           message={`Are you sure you want to delete "${pendingDelete?.name}"?`}
           onConfirm={handleDelete}
-          onCancel={() => setConfirmOpen(false)}
-          loading={confirmLoading}
-          error={confirmError}
+          onClose={() => setConfirmOpen(false)}
+          confirmText="Delete"
         />
         <Modal
           isOpen={modalOpen}


### PR DESCRIPTION
## Summary
- replace existing ConfirmDialog with dialog-based component
- integrate new ConfirmDialog into Departments page and streamline delete logic

## Testing
- `npm test` (fails: vitest not found)
- `npm install --legacy-peer-deps` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68bc32da49a88323bc6816b6ce631c1d