### PR TITLE
feat(frontend): add name drawer form

### DIFF
--- a/frontend/src/components/common/NameDrawerForm.tsx
+++ b/frontend/src/components/common/NameDrawerForm.tsx
@@ -5,69 +5,73 @@ import Drawer from '../ui/Drawer';
 interface Props {
   open: boolean;
   title: string;
+  label?: string;
   initialName?: string;
-  initialAssets?: number;
-  showAssetInput?: boolean;
-  onSubmit: (values: { name: string; assets?: number }) => void;
-  onCancel: () => void;
+  confirmText?: string;
+  onClose: () => void;
+  onSubmit: (name: string) => Promise<void> | void;
 }
 
 export default function NameDrawerForm({
   open,
   title,
+  label = 'Name',
   initialName = '',
-  initialAssets = 0,
-  showAssetInput = false,
+  confirmText = 'Save',
+  onClose,
   onSubmit,
-  onCancel,
 }: Props) {
   const [name, setName] = useState(initialName);
-  const [assets, setAssets] = useState(initialAssets);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
 
   useEffect(() => {
     if (open) {
       setName(initialName);
-      setAssets(initialAssets);
+      setErr('');
+      setBusy(false);
     }
-  }, [open, initialName, initialAssets]);
+  }, [open, initialName]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim()) return;
-    onSubmit({ name: name.trim(), assets });
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setErr('Name is required');
+      return;
+    }
+    setBusy(true);
+    setErr('');
+    try {
+      await onSubmit(trimmed);
+      onClose();
+    } catch (error: any) {
+      setErr(error?.message || 'Something went wrong');
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (
-    <Drawer open={open} onClose={onCancel} title={title}>
+    <Drawer open={open} onClose={onClose} title={title}>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium mb-1">Name</label>
+          <label className="block text-sm font-medium mb-1">{label}</label>
           <input
             type="text"
             className="w-full px-3 py-2 border border-neutral-300 rounded-md"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            required
+            disabled={busy}
           />
+          {err && <p className="text-error-600 text-sm mt-1">{err}</p>}
         </div>
-        {showAssetInput && (
-          <div>
-            <label className="block text-sm font-medium mb-1">Asset Count</label>
-            <input
-              type="number"
-              className="w-full px-3 py-2 border border-neutral-300 rounded-md"
-              value={assets}
-              onChange={(e) => setAssets(Number(e.target.value))}
-              min={0}
-            />
-          </div>
-        )}
         <div className="flex justify-end gap-2 pt-2">
-          <Button type="button" variant="outline" onClick={onCancel}>
+          <Button type="button" variant="outline" onClick={onClose} disabled={busy}>
             Cancel
           </Button>
-          <Button type="submit" variant="primary">
-            Save
+          <Button type="submit" variant="primary" loading={busy}>
+            {confirmText}
           </Button>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- add reusable NameDrawerForm component with validation and busy state

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7832d15c8323bddbb4cc9b57aecd