### PR TITLE
Guard service worker registration

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -29,7 +29,9 @@ mediaQuery.addEventListener('change', (e) => {
 initializeTheme();
 
 // register SW (no-op if PWA plugin is absent)
-registerSWIfAvailable({ immediate: true });
+if (import.meta.env.PROD) {
+  registerSWIfAvailable({ immediate: true });
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- Only register the service worker in production builds using `registerSWIfAvailable`
- Ensure PWA helper dynamically loads registration when the plugin is present

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b75f3bc832394e87aeb79fac217