### PR TITLE
feat: replace api module with http

### DIFF
--- a/frontend/src/api/channels.ts
+++ b/frontend/src/api/channels.ts
@@ -1,27 +1,27 @@
-import api from '../lib/api';
+import http from '../lib/http';
 import type { Channel, Member, Message } from '../types';
 
 export const getChannelMembers = (channelId: string) =>
-  api.get<Member[]>(`/channels/${channelId}/members`).then((res) => res.data);
+  http.get<Member[]>(`/channels/${channelId}/members`).then((res) => res.data);
 
 export const addMembers = (channelId: string, members: string[]) =>
-  api
+  http
     .post<Channel>(`/channels/${channelId}/members`, { members })
     .then((res) => res.data);
 
 export const removeMember = (channelId: string, memberId: string) =>
-  api
+  http
     .delete<Channel>(`/channels/${channelId}/members/${memberId}`)
     .then((res) => res.data);
 
 export const togglePin = (id: string) =>
-  api.post<Channel>(`/channels/${id}/pin`).then((res) => res.data);
+  http.post<Channel>(`/channels/${id}/pin`).then((res) => res.data);
 
 export const toggleMute = (id: string) =>
-  api.post<Channel>(`/channels/${id}/mute`).then((res) => res.data);
+  http.post<Channel>(`/channels/${id}/mute`).then((res) => res.data);
 
 export const searchMessages = (channelId: string, q: string) =>
-  api
+  http
     .get<Message[]>(`/channels/${channelId}/messages/search`, { params: { q } })
     .then((res) => res.data);
 

--- a/frontend/src/api/departments.ts
+++ b/frontend/src/api/departments.ts
@@ -1,4 +1,4 @@
-import api from '../lib/api';
+import http from '../lib/http';
 
 export interface Station {
   _id: string;
@@ -32,14 +32,14 @@ export type DepartmentPayload = Pick<Department, 'name' | 'description'>;
 
 // ---- Department helpers ----
 export async function listDepartments(): Promise<Department[]> {
-  const { data } = await api.get<Department[]>('/departments');
+  const { data } = await http.get<Department[]>('/departments');
   return data;
 }
 
 export async function createDepartment(
   payload: DepartmentPayload,
 ): Promise<Department> {
-  const { data } = await api.post<Department>('/departments', payload);
+  const { data } = await http.post<Department>('/departments', payload);
   return data;
 }
 
@@ -48,18 +48,18 @@ export async function updateDepartment(
    payload: DepartmentPayload,
  
 ): Promise<Department> {
-  const { data } = await api.put<Department>(`/departments/${id}`, payload);
+  const { data } = await http.put<Department>(`/departments/${id}`, payload);
   return data;
 }
  
 export async function deleteDepartment(id: string): Promise<{ message: string }> {
-  const { data } = await api.delete<{ message: string }>(`/departments/${id}`);
+  const { data } = await http.delete<{ message: string }>(`/departments/${id}`);
   return data;
 }
 
 // ---- Line helpers ----
 export async function listLines(departmentId: string): Promise<Line[]> {
-  const { data } = await api.get<Line[]>(`/departments/${departmentId}/lines`);
+  const { data } = await http.get<Line[]>(`/departments/${departmentId}/lines`);
   return data;
 }
 
@@ -67,7 +67,7 @@ export async function createLine(
   departmentId: string,
   payload: LinePayload,
 ): Promise<Line> {
-  const { data } = await api.post<Line>(
+  const { data } = await http.post<Line>(
     `/departments/${departmentId}/lines`,
     payload,
   );
@@ -79,7 +79,7 @@ export async function updateLine(
   lineId: string,
   payload: LinePayload,
 ): Promise<Line> {
-  const { data } = await api.put<Line>(
+  const { data } = await http.put<Line>(
     `/departments/${departmentId}/lines/${lineId}`,
     payload,
   );
@@ -90,7 +90,7 @@ export async function deleteLine(
   departmentId: string,
   lineId: string,
 ): Promise<{ message: string }> {
-  const { data } = await api.delete<{ message: string }>(
+  const { data } = await http.delete<{ message: string }>(
     `/departments/${departmentId}/lines/${lineId}`,
   );
   return data;
@@ -101,7 +101,7 @@ export async function listStations(
   departmentId: string,
   lineId: string,
 ): Promise<Station[]> {
-  const { data } = await api.get<Station[]>(
+  const { data } = await http.get<Station[]>(
     `/departments/${departmentId}/lines/${lineId}/stations`,
   );
   return data;
@@ -112,7 +112,7 @@ export async function createStation(
   lineId: string,
   payload: StationPayload,
 ): Promise<Station> {
-  const { data } = await api.post<Station>(
+  const { data } = await http.post<Station>(
     `/departments/${departmentId}/lines/${lineId}/stations`,
     payload,
   );
@@ -125,7 +125,7 @@ export async function updateStation(
   stationId: string,
   payload: StationPayload,
 ): Promise<Station> {
-  const { data } = await api.put<Station>(
+  const { data } = await http.put<Station>(
     `/departments/${departmentId}/lines/${lineId}/stations/${stationId}`,
     payload,
   );
@@ -137,7 +137,7 @@ export async function deleteStation(
   lineId: string,
   stationId: string,
 ): Promise<{ message: string }> {
-  const { data } = await api.delete<{ message: string }>(
+  const { data } = await http.delete<{ message: string }>(
     `/departments/${departmentId}/lines/${lineId}/stations/${stationId}`,
   );
   return data;

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -1,9 +1,9 @@
-import api from '../lib/api';
+import http from '../lib/http';
 import type { NotificationType } from '../types';
 
 export const fetchNotifications = (params?: Record<string, unknown>) =>
-  api.get<NotificationType[]>('/notifications', { params }).then((res) => res.data);
+  http.get<NotificationType[]>('/notifications', { params }).then((res) => res.data);
 
 export const markNotificationRead = (id: string) =>
-  api.patch<NotificationType>(`/notifications/${id}/read`).then((res) => res.data);
+  http.patch<NotificationType>(`/notifications/${id}/read`).then((res) => res.data);
 

--- a/frontend/src/api/purchasing.ts
+++ b/frontend/src/api/purchasing.ts
@@ -1,8 +1,8 @@
-import api from '../lib/api';
+import http from '../lib/http';
 
 export const createPurchaseOrder = (payload: any) =>
-  api.post('/purchase-orders', payload).then((res) => res.data);
+  http.post('/purchase-orders', payload).then((res) => res.data);
 
 export const createGoodsReceipt = (payload: any) =>
-  api.post('/goods-receipts', payload).then((res) => res.data);
+  http.post('/goods-receipts', payload).then((res) => res.data);
 

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -1,5 +1,5 @@
-import api from '../lib/api';
+import http from '../lib/http';
 
 export const searchAssets = (q: string) =>
-  api.get('/assets/search', { params: { q } }).then((res) => res.data);
+  http.get('/assets/search', { params: { q } }).then((res) => res.data);
 

--- a/frontend/src/api/summary.ts
+++ b/frontend/src/api/summary.ts
@@ -1,4 +1,4 @@
-import api from '../lib/api';
+import http from '../lib/http';
 import type {
   DashboardSummary,
   StatusCountResponse,
@@ -8,28 +8,28 @@ import type {
 } from '../types';
 
 export const fetchSummary = (params?: Record<string, unknown>) =>
-  api.get<DashboardSummary>('/summary', { params }).then((res) => res.data);
+  http.get<DashboardSummary>('/summary', { params }).then((res) => res.data);
 
 export const fetchAssetSummary = (params?: Record<string, unknown>) =>
-  api.get<StatusCountResponse[]>('/summary/assets', { params }).then((res) => res.data);
+  http.get<StatusCountResponse[]>('/summary/assets', { params }).then((res) => res.data);
 
 export const fetchWorkOrderSummary = (params?: Record<string, unknown>) =>
-  api
+  http
     .get<StatusCountResponse[]>('/summary/workorders', { params })
     .then((res) => res.data);
 
 export const fetchUpcomingMaintenance = (params?: Record<string, unknown>) =>
-  api
+  http
     .get<UpcomingMaintenanceResponse[]>('/summary/upcoming-maintenance', { params })
     .then((res) => res.data);
 
 export const fetchCriticalAlerts = (params?: Record<string, unknown>) =>
-  api
+  http
     .get<CriticalAlertResponse[]>('/summary/critical-alerts', { params })
     .then((res) => res.data);
 
 export const fetchLowStock = (params?: Record<string, unknown>) =>
-  api
+  http
     .get<LowStockPartResponse[]>('/summary/low-stock', { params })
     .then((res) => res.data);
 

--- a/frontend/src/api/vendorPurchaseOrders.ts
+++ b/frontend/src/api/vendorPurchaseOrders.ts
@@ -1,12 +1,12 @@
-import api from '../lib/api';
+import http from '../lib/http';
 
 export const listVendorPurchaseOrders = (token: string) =>
-  api
+  http
     .get('/purchase-orders', { headers: { Authorization: `Bearer ${token}` } })
     .then((res) => res.data);
 
 export const getVendorPurchaseOrder = (id: string, token: string) =>
-  api
+  http
     .get(`/purchase-orders/${id}`, { headers: { Authorization: `Bearer ${token}` } })
     .then((res) => res.data);
 
@@ -15,7 +15,7 @@ export const updateVendorPurchaseOrder = (
   payload: any,
   token: string,
 ) =>
-  api
+  http
     .put(`/purchase-orders/${id}`, payload, {
       headers: { Authorization: `Bearer ${token}` },
     })

--- a/frontend/src/components/assets/AssetModal.tsx
+++ b/frontend/src/components/assets/AssetModal.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { useDropzone } from "react-dropzone";
 import { X, Upload, Download } from "lucide-react";
 import Button from "../common/Button";
-import api from "../../lib/api";
+import http from "../../lib/http";
 import { useToast } from "../../context/ToastContext";
 import { useDepartmentStore } from "../../store/departmentStore";
 import { useAuthStore } from "../../store/authStore";
@@ -128,11 +128,11 @@ const AssetModal: React.FC<AssetModalProps> = ({
           }
         });
         files.forEach((f) => fd.append("files", f));
-        res = await api.post("/assets", fd, {
+        res = await http.post("/assets", fd, {
           headers: { "Content-Type": "multipart/form-data" },
         });
       } else {
-        res = await api.post("/assets", payload);
+        res = await http.post("/assets", payload);
       }
 
       onUpdate({ ...(res.data as any), id: res.data._id } as Asset);

--- a/frontend/src/components/assets/HierarchyView.tsx
+++ b/frontend/src/components/assets/HierarchyView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import api from '../../lib/api';
+import http from '../../lib/http';
 import type { DepartmentHierarchy } from '../../types';
 import { useDepartmentStore } from '../../store/departmentStore';
 
@@ -12,7 +12,7 @@ const HierarchyView: React.FC = () => {
     const departments = useDepartmentStore.getState().departments;
     const detailed = await Promise.all(
       departments.map(async (dep) => {
-        const hRes = await api.get(`/departments/${dep.id}/hierarchy`);
+        const hRes = await http.get(`/departments/${dep.id}/hierarchy`);
         return hRes.data as DepartmentHierarchy;
       })
     );

--- a/frontend/src/components/maintenance/PmTaskForm.tsx
+++ b/frontend/src/components/maintenance/PmTaskForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import api from '../../lib/api';
+import http from '../../lib/http';
 import Button from '../common/Button';
 import { useToast } from '../../context/ToastContext';
 import type { PMTask } from '../../types';
@@ -43,9 +43,9 @@ const PmTaskForm: React.FC<Props> = ({ task, onSuccess }) => {
       };
       let res;
       if (task) {
-        res = await api.put(`/pm-tasks/${task.id}`, payload);
+        res = await http.put(`/pm-tasks/${task.id}`, payload);
       } else {
-        res = await api.post('/pm-tasks', payload);
+        res = await http.post('/pm-tasks', payload);
       }
       const saved = { ...(res.data as any), id: res.data._id ?? res.data.id } as PMTask;
       onSuccess?.(saved);

--- a/frontend/src/components/work-orders/WorkOrderForm.tsx
+++ b/frontend/src/components/work-orders/WorkOrderForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import api from '../../lib/api';
+import http from '../../lib/http';
 import { useDepartmentStore } from '../../store/departmentStore';
 import Button from '../common/Button';
 import { useToast } from '../../context/ToastContext';
@@ -46,13 +46,13 @@ const WorkOrderForm: React.FC<WorkOrderFormProps> = ({ workOrder, onSuccess }) =
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const assetRes = await api.get('/assets');
+        const assetRes = await http.get('/assets');
         setAssets((assetRes.data as any[]).map(a => ({ ...a, id: a._id ?? a.id })) as Asset[]);
       } catch (err) {
         console.error('Failed to load assets', err);
       }
       try {
-        const userRes = await api.get('/users');
+        const userRes = await http.get('/users');
         setTechs((userRes.data as any[])
           .filter((u) => u.role === 'technician')
           .map(u => ({ ...u, id: u._id ?? u.id })) as User[]);
@@ -109,9 +109,9 @@ const WorkOrderForm: React.FC<WorkOrderFormProps> = ({ workOrder, onSuccess }) =
     try {
       let res;
       if (workOrder) {
-        res = await api.put(`/workorders/${workOrder.id}`, payload);
+        res = await http.put(`/workorders/${workOrder.id}`, payload);
       } else {
-        res = await api.post('/workorders', payload);
+        res = await http.post('/workorders', payload);
       }
       const data = res.data as WorkOrderUpdatePayload;
       if (onSuccess) onSuccess({ ...(data as Partial<WorkOrder>), id: data._id } as WorkOrder);

--- a/frontend/src/components/work-orders/WorkOrderModal.tsx
+++ b/frontend/src/components/work-orders/WorkOrderModal.tsx
@@ -7,7 +7,7 @@ import { X, Upload, Download, Camera } from "lucide-react";
 import Button from "../common/Button";
 import AutoCompleteInput from "../common/AutoCompleteInput";
 import type { WorkOrder, Department } from "../../types";
-import api from "../../lib/api";
+import http from "../../lib/http";
 import { searchAssets } from "../../api/search";
 import { useDepartmentStore } from "../../store/departmentStore";
    

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 import { useAuthStore } from '../store/authStore';
 import type { AuthUser } from '../types';
-import api from '../lib/api';
+import http from '../lib/http';
 
 interface AuthContextType {
   user: AuthUser | null;
@@ -61,7 +61,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const login = useCallback(
     async (email: string, password: string) => {
-      const { data } = await api.post('/auth/login', { email, password });
+      const { data } = await http.post('/auth/login', { email, password });
  
       handleSetUser({ ...data.user, token: data.token });
  

--- a/frontend/src/hooks/useDashboardData.ts
+++ b/frontend/src/hooks/useDashboardData.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import api from '../lib/api';
+import http from '../lib/http';
 import type {
   StatusCountResponse,
   UpcomingMaintenanceResponse,
@@ -81,10 +81,10 @@ export default function useDashboardData(
       const query = params.toString() ? `?${params.toString()}` : '';
 
       const [woRes, assetRes, upcomingRes, alertRes] = await Promise.all([
-        api.get<StatusCountResponse[]>(`/summary/workorders${query}`),
-        api.get<StatusCountResponse[]>(`/summary/assets${query}`),
-        api.get<UpcomingMaintenanceResponse[]>(`/summary/upcoming-maintenance${query}`),
-        api.get<CriticalAlertResponse[]>(`/summary/critical-alerts${query}`),
+        http.get<StatusCountResponse[]>(`/summary/workorders${query}`),
+        http.get<StatusCountResponse[]>(`/summary/assets${query}`),
+        http.get<UpcomingMaintenanceResponse[]>(`/summary/upcoming-maintenance${query}`),
+        http.get<CriticalAlertResponse[]>(`/summary/critical-alerts${query}`),
       ]);
 
       // Work orders

--- a/frontend/src/hooks/useSummaryData.ts
+++ b/frontend/src/hooks/useSummaryData.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import api from '../lib/api';
+import http from '../lib/http';
 
 type CacheEntry<T> = { promise?: Promise<T>; data?: T; ts?: number };
 const cache: Record<string, CacheEntry<unknown>> = {};
@@ -25,7 +25,7 @@ export function useSummary<T = unknown>(
     const controller = new AbortController();
     abortRef.current = controller;
 
-    const p = api
+    const p = http
       .get<T>(path, { signal: controller.signal })
       .then((res) => {
         if (!mountedRef.current) return c.data as T | undefined;

--- a/frontend/src/inventory/transfers/TransferApproval.tsx
+++ b/frontend/src/inventory/transfers/TransferApproval.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from '../../components/common/Button';
-import api from '../../lib/api';
+import http from '../../lib/http';
 
 interface Props {
   orderId: string;
@@ -9,7 +9,7 @@ interface Props {
 
 const TransferApproval: React.FC<Props> = ({ orderId, onApproved }) => {
   const approve = async () => {
-    await api.post(`/transfers/${orderId}/approve`);
+    await http.post(`/transfers/${orderId}/approve`);
     onApproved?.();
   };
   return (

--- a/frontend/src/inventory/transfers/TransferReceive.tsx
+++ b/frontend/src/inventory/transfers/TransferReceive.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from '../../components/common/Button';
-import api from '../../lib/api';
+import http from '../../lib/http';
 
 interface Props {
   orderId: string;
@@ -9,7 +9,7 @@ interface Props {
 
 const TransferReceive: React.FC<Props> = ({ orderId, onReceived }) => {
   const receive = async () => {
-    await api.post(`/transfers/${orderId}/receive`);
+    await http.post(`/transfers/${orderId}/receive`);
     onReceived?.();
   };
   return (

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+const base = (import.meta.env.VITE_API_URL || 'http://localhost:5010/api').replace(/\/+$/, '');
+
+export const http = axios.create({
+  baseURL: base,
+  withCredentials: true,
+});
+
+export default http;

--- a/frontend/src/pages/AdminTenants.tsx
+++ b/frontend/src/pages/AdminTenants.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
-import api from '../lib/api';
+import http from '../lib/http';
 import { useToast } from '../context/ToastContext';
 
 interface Tenant {
@@ -17,7 +17,7 @@ const AdminTenants = () => {
 
   const load = async () => {
     try {
-      const res = await api.get('/tenants');
+      const res = await http.get('/tenants');
       setTenants(res.data.map((t: any) => ({ id: t._id ?? t.id, name: t.name })));
     } catch (err) {
       console.error(err);
@@ -33,11 +33,11 @@ const AdminTenants = () => {
     e.preventDefault();
     try {
       if (editing) {
-        const res = await api.put(`/tenants/${editing}`, { name });
+        const res = await http.put(`/tenants/${editing}`, { name });
         setTenants((ts) => ts.map((t) => (t.id === editing ? { id: res.data._id, name: res.data.name } : t)));
         addToast('Tenant updated', 'success');
       } else {
-        const res = await api.post('/tenants', { name });
+        const res = await http.post('/tenants', { name });
         setTenants((ts) => [...ts, { id: res.data._id, name: res.data.name }]);
         addToast('Tenant created', 'success');
       }
@@ -56,7 +56,7 @@ const AdminTenants = () => {
 
   const handleDelete = async (id: string) => {
     try {
-      await api.delete(`/tenants/${id}`);
+      await http.delete(`/tenants/${id}`);
       setTenants((ts) => ts.filter((t) => t.id !== id));
       addToast('Tenant deleted', 'success');
     } catch (err) {

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -4,7 +4,7 @@ import { Download, Calendar, Filter } from 'lucide-react';
 import Button from '../components/common/Button';
 import Card from '../components/common/Card';
 import Badge from '../components/common/Badge';
-import api from '../lib/api';
+import http from '../lib/http';
 import { useDashboardStore } from '../store/dashboardStore';
  // import { useAuth } from '../context/AuthContext';
  
@@ -55,13 +55,13 @@ const Analytics: React.FC = () => {
   const fetchData = async () => {
     setLoading(true);
     try {
-      const res = await api.get('/reports/analytics', { params: { role } });
+      const res = await http.get('/reports/analytics', { params: { role } });
       setData(res.data);
-      const kpiRes = await api.get('/v1/analytics/kpis');
+      const kpiRes = await http.get('/v1/analytics/kpis');
       setKpis(kpiRes.data);
-      const costRes = await api.get('/reports/costs');
+      const costRes = await http.get('/reports/costs');
       setCosts(costRes.data);
-      const downtimeRes = await api.get('/reports/downtime');
+      const downtimeRes = await http.get('/reports/downtime');
       setDowntime(downtimeRes.data);
       setError(null);
     } catch (err) {

--- a/frontend/src/pages/AssetsPage.tsx
+++ b/frontend/src/pages/AssetsPage.tsx
@@ -4,7 +4,7 @@ import AssetTable from '../components/assets/AssetTable';
 import AssetModal from '../components/assets/AssetModal';
 import WorkOrderModal from '../components/work-orders/WorkOrderModal';
 import Button from '../components/common/Button';
-import api from '../lib/api';
+import http from '../lib/http';
 import { enqueueAssetRequest } from '../utils/offlineQueue';
 import { useAssetStore } from '../store/assetStore';
 import type { Asset } from '../types';
@@ -48,7 +48,7 @@ const AssetsPage = () => {
     }
 
     try {
-      const res = await api.get('/assets');
+      const res = await http.get('/assets');
       const data = (res.data as any[]).map((a) => ({
         ...a,
         id: a._id ?? a.id,
@@ -83,7 +83,7 @@ const AssetsPage = () => {
       addAsset({ ...clone, id: Date.now().toString() });
       return;
     }
-    const res = await api.post('/assets', clone);
+    const res = await http.post('/assets', clone);
     addAsset({ ...res.data, id: res.data._id });
   };
 
@@ -93,7 +93,7 @@ const AssetsPage = () => {
       removeAsset(id);
       return;
     }
-    await api.delete(`/assets/${id}`);
+    await http.delete(`/assets/${id}`);
     removeAsset(id);
   };
 
@@ -139,11 +139,11 @@ const AssetsPage = () => {
           onUpdate={async (payload) => {
             try {
               if (payload instanceof FormData) {
-                await api.post('/workorders', payload, {
+                await http.post('/workorders', payload, {
                   headers: { 'Content-Type': 'multipart/form-data' },
                 });
               } else {
-                await api.post('/workorders', payload);
+                await http.post('/workorders', payload);
               }
             } catch (err) {
               console.error(err);

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import api from '../lib/api';
+import http from '../lib/http';
 
 const ForgotPasswordPage: React.FC = () => {
   const { t } = useTranslation();
@@ -32,7 +32,7 @@ const ForgotPasswordPage: React.FC = () => {
     e.preventDefault();
     setMessage('');
     try {
-      await api.post('/auth/password/reset', { email });
+      await http.post('/auth/password/reset', { email });
       setMessage(t('auth.resetLinkSent'));
     } catch (err) {
       console.error(err);

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -7,7 +7,7 @@ import InventoryModal from '../components/inventory/InventoryModal';
 import InventoryMetrics from '../components/inventory/InventoryMetrics';
 import InventoryScanModal from '../components/inventory/InventoryScanModal';
 import { exportToExcel, exportToPDF } from '../utils/export';
-import api from '../lib/api';
+import http from '../lib/http';
 import { useAuth } from '../context/AuthContext';
 import type { Part } from '../types';
 
@@ -24,7 +24,7 @@ const Inventory: React.FC = () => {
 
   const fetchParts = async () => {
     try {
-      const res = await api.get('/inventory');
+      const res = await http.get('/inventory');
       setParts(res.data as Part[]);
     } catch (err) {
       console.error('Error fetching inventory:', err);
@@ -153,11 +153,11 @@ const Inventory: React.FC = () => {
           onUpdate={async (data: FormData) => {
             try {
               if (selectedPart) {
-                await api.put(`/inventory/${selectedPart.id}`, data, {
+                await http.put(`/inventory/${selectedPart.id}`, data, {
                   headers: { 'Content-Type': 'multipart/form-data' },
                 });
               } else {
-                await api.post('/inventory', data, {
+                await http.post('/inventory', data, {
                   headers: { 'Content-Type': 'multipart/form-data' },
                 });
               }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
-import api from '../lib/api';
+import http from '../lib/http';
 
 type BeforeInstallPromptEvent = Event & {
   prompt: () => Promise<void>;
@@ -66,7 +66,7 @@ const LoginPage: React.FC = () => {
     e.preventDefault();
     setError('');
     try {
-      const { data } = await api.post('/auth/login', { email, password });
+      const { data } = await http.post('/auth/login', { email, password });
       if (data.mfaRequired) {
         setMfaUser(data.userId);
         return;
@@ -82,7 +82,7 @@ const LoginPage: React.FC = () => {
     e.preventDefault();
     if (!mfaUser) return;
     try {
-      const { data } = await api.post('/auth/mfa/verify', {
+      const { data } = await http.post('/auth/mfa/verify', {
         userId: mfaUser,
         token: code,
       });

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
-import api from '../lib/api';
+import http from '../lib/http';
 import type { NotificationType } from '../types';
 
 type Notification = NotificationType & { assetId?: string };
@@ -17,7 +17,7 @@ const Notifications = () => {
   const fetchNotifications = async (pageNum: number) => {
     try {
       setLoading(true);
-      const res = await api.get('/notifications', { params: { page: pageNum, limit } });
+      const res = await http.get('/notifications', { params: { page: pageNum, limit } });
       const data = Array.isArray(res.data) ? res.data : res.data.items || [];
       type ApiNotification = Partial<Notification> & {
         _id?: string;
@@ -47,7 +47,7 @@ const Notifications = () => {
 
   const markAsRead = async (id: string) => {
     try {
-      await api.put(`/notifications/${id}`, { read: true });
+      await http.put(`/notifications/${id}`, { read: true });
     } catch (err) {
       console.error('Failed to mark notification as read', err);
     }
@@ -56,7 +56,7 @@ const Notifications = () => {
 
   const dismiss = async (id: string) => {
     try {
-      await api.delete(`/notifications/${id}`);
+      await http.delete(`/notifications/${id}`);
     } catch (err) {
       console.error('Failed to delete notification', err);
     }

--- a/frontend/src/pages/PMTasksPage.tsx
+++ b/frontend/src/pages/PMTasksPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
 import PmTaskForm from '../components/maintenance/PmTaskForm';
-import api from '../lib/api';
+import http from '../lib/http';
 import type { PMTask } from '../types';
 
 const PMTasksPage: React.FC = () => {
@@ -13,7 +13,7 @@ const PMTasksPage: React.FC = () => {
 
   const loadTasks = async () => {
     try {
-      const res = await api.get('/pm-tasks', { withCredentials: true });
+      const res = await http.get('/pm-tasks', { withCredentials: true });
       setTasks((res.data as any[]).map(t => ({ ...t, id: t._id ?? t.id })) as PMTask[]);
     } catch (err: any) {
       console.error(err);

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import api from '../lib/api';
+import http from '../lib/http';
 
 type BeforeInstallPromptEvent = Event & {
   prompt: () => Promise<void>;
@@ -49,7 +49,7 @@ const RegisterPage: React.FC = () => {
     e.preventDefault();
     setError('');
     try {
-      await api.post('/auth/register', form);
+      await http.post('/auth/register', form);
       navigate('/login');
     } catch (err) {
       console.error(err);

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -16,7 +16,7 @@ import { useThemeStore } from '../store/themeStore';
 import { useSettingsStore } from '../store/settingsStore';
 import type { ThemeSettings } from '../store/settingsStore';
 import { useToast } from '../context/ToastContext';
-import api from '../lib/api';
+import http from '../lib/http';
 
 const Settings: React.FC = () => {
   const { theme, setTheme, updateTheme } = useThemeStore();
@@ -68,7 +68,7 @@ const Settings: React.FC = () => {
   const handleSaveSettings = async () => {
     try {
       const settings = useSettingsStore.getState();
-      await api.post('/settings', settings);
+      await http.post('/settings', settings);
       addToast('Settings saved', 'success');
     } catch (error: any) {
       console.error('Error saving settings:', error);

--- a/frontend/src/pages/TimeSheets.tsx
+++ b/frontend/src/pages/TimeSheets.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
-import api from '../lib/api';
+import http from '../lib/http';
 import type { Timesheet } from '../types';
 import { useToast } from '../context/ToastContext';
 
@@ -13,7 +13,7 @@ const TimeSheets: React.FC = () => {
 
   const loadTimesheets = async () => {
     try {
-      const res = await api.get('/timesheets');
+      const res = await http.get('/timesheets');
       const data = (res.data as any[]).map((t) => ({
         id: t._id ?? t.id,
         date: t.date,
@@ -43,12 +43,12 @@ const TimeSheets: React.FC = () => {
     }
     try {
       if (editingId) {
-        await api.put(`/timesheets/${editingId}`, payload);
+        await http.put(`/timesheets/${editingId}`, payload);
         setTimesheets((prev) =>
           prev.map((t) => (t.id === editingId ? { id: editingId, ...payload } : t)),
         );
       } else {
-        const res = await api.post('/timesheets', payload);
+        const res = await http.post('/timesheets', payload);
         setTimesheets((prev) => [
           ...prev,
           { id: res.data._id ?? res.data.id, ...payload },
@@ -72,7 +72,7 @@ const TimeSheets: React.FC = () => {
 
   const handleDelete = async (id: string) => {
     try {
-      await api.delete(`/timesheets/${id}`);
+      await http.delete(`/timesheets/${id}`);
       setTimesheets((prev) => prev.filter((t) => t.id !== id));
       if (editingId === id) {
         setEditingId(null);

--- a/frontend/src/pages/VendorsPage.tsx
+++ b/frontend/src/pages/VendorsPage.tsx
@@ -3,7 +3,7 @@ import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
 import DataTable from '../components/common/DataTable';
 import VendorModal from '../components/vendors/VendorModal';
-import api from '../lib/api';
+import http from '../lib/http';
 import type { Vendor } from '../types';
 import { useToast } from '../context/ToastContext';
 
@@ -17,7 +17,7 @@ const VendorsPage = () => {
   const fetchVendors = async () => {
     setLoading(true);
     try {
-      const res = await api.get('/vendors');
+      const res = await http.get('/vendors');
       setVendors(res.data as Vendor[]);
     } catch (err) {
       console.error('Failed to load vendors', err);
@@ -34,10 +34,10 @@ const VendorsPage = () => {
   const handleSave = async (data: { name: string; contact: string }) => {
     try {
       if (editing) {
-        const res = await api.put(`/vendors/${editing.id}`, data);
+        const res = await http.put(`/vendors/${editing.id}`, data);
         setVendors((prev) => prev.map((v) => (v.id === editing.id ? res.data : v)));
       } else {
-        const res = await api.post('/vendors', data);
+        const res = await http.post('/vendors', data);
         setVendors((prev) => [...prev, res.data]);
       }
       setModalOpen(false);
@@ -49,7 +49,7 @@ const VendorsPage = () => {
 
   const handleDelete = async (id: string) => {
     try {
-      await api.delete(`/vendors/${id}`);
+      await http.delete(`/vendors/${id}`);
       setVendors((prev) => prev.filter((v) => v.id !== id));
     } catch (err) {
       console.error('Failed to delete vendor', err);

--- a/frontend/src/pages/WorkOrders.tsx
+++ b/frontend/src/pages/WorkOrders.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import Layout from '../components/layout/Layout';
-import api from '../lib/api';
+import http from '../lib/http';
 import { addToQueue } from '../utils/offlineQueue';
 import DataTable from '../components/common/DataTable';
 import Badge from '../components/common/Badge';
@@ -48,7 +48,7 @@ export default function WorkOrders() {
       const url = params.toString()
         ? `/workorders/search?${params.toString()}`
         : '/workorders';
-      const res = await api.get(url);
+      const res = await http.get(url);
       const data = (res.data as any[]).map((w) => ({ ...w, id: w._id ?? w.id })) as WorkOrder[];
       setWorkOrders(data);
       localStorage.setItem(LOCAL_KEY, JSON.stringify(data));
@@ -79,7 +79,7 @@ export default function WorkOrders() {
       return;
     }
     try {
-      await api.put(`/workorders/${id}`, update);
+      await http.put(`/workorders/${id}`, update);
       fetchWorkOrders();
     } catch {
       addToQueue({ method: 'put', url: `/workorders/${id}`, data: update });
@@ -88,7 +88,7 @@ export default function WorkOrders() {
 
   const openReview = async (order: WorkOrder) => {
     try {
-      const res = await api.get(`/workorders/${order.id}`);
+      const res = await http.get(`/workorders/${order.id}`);
       const data = { ...res.data, id: res.data._id ?? res.data.id } as WorkOrder;
       setSelectedOrder(data);
       setShowReviewModal(true);
@@ -109,11 +109,11 @@ export default function WorkOrders() {
     }
     try {
       if (payload instanceof FormData) {
-        await api.post('/workorders', payload, {
+        await http.post('/workorders', payload, {
           headers: { 'Content-Type': 'multipart/form-data' },
         });
       } else {
-        await api.post('/workorders', payload);
+        await http.post('/workorders', payload);
       }
       fetchWorkOrders();
     } catch (err) {

--- a/frontend/src/pm/ConditionRules.tsx
+++ b/frontend/src/pm/ConditionRules.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
-import api from '../lib/api';
+import http from '../lib/http';
 
 interface ConditionRule {
   _id?: string;
@@ -31,7 +31,7 @@ const ConditionRules: React.FC = () => {
 
   const loadRules = async () => {
     try {
-      const res = await api.get('/condition-rules', { withCredentials: true });
+      const res = await http.get('/condition-rules', { withCredentials: true });
       setRules(res.data as ConditionRule[]);
     } catch (err) {
       console.error(err);
@@ -46,9 +46,9 @@ const ConditionRules: React.FC = () => {
     if (!form) return;
     try {
       if (form._id) {
-        await api.put(`/condition-rules/${form._id}`, form, { withCredentials: true });
+        await http.put(`/condition-rules/${form._id}`, form, { withCredentials: true });
       } else {
-        await api.post('/condition-rules', form, { withCredentials: true });
+        await http.post('/condition-rules', form, { withCredentials: true });
       }
       setForm(null);
       await loadRules();

--- a/frontend/src/store/dataStore.ts
+++ b/frontend/src/store/dataStore.ts
@@ -22,7 +22,7 @@ export const useDataStore = create<DataState>()(
 // IndexedDB cache + offline queue
 // -----------------------------
 
-import api from '../lib/api';
+import http from '../lib/http';
 
 // Basic key/value store in IndexedDB. For test environments where
 // `indexedDB` isn't available (e.g. jsdom), we fall back to an in-memory
@@ -145,7 +145,7 @@ export const enqueueRequest = async (req: QueuedRequest) => {
 export const clearQueue = async () => deleteItem(KEYS.queue);
 
 export const flushQueue = async (
-  apiFn: typeof api = api,
+  apiFn: typeof http = http,
   useBackoff = true
 ) => {
   const queue = await loadQueue();

--- a/frontend/src/store/themeStore.ts
+++ b/frontend/src/store/themeStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import api from '../lib/api';
+import http from '../lib/http';
 import { useAuthStore } from './authStore';
 
 interface ThemeState {
@@ -24,7 +24,7 @@ export const useThemeStore = create<ThemeState>()(
       },
       fetchTheme: async () => {
         try {
-          const res = await api.get('/theme');
+          const res = await http.get('/theme');
           set({ theme: res.data.theme, colorScheme: res.data.colorScheme });
         } catch (err) {
           console.error(err);
@@ -33,7 +33,7 @@ export const useThemeStore = create<ThemeState>()(
       updateTheme: async (data) => {
         set(data as any);
         try {
-          await api.put('/theme', { ...get(), ...data });
+          await http.put('/theme', { ...get(), ...data });
         } catch (err) {
           console.error(err);
  

--- a/frontend/src/store/useTeamMembers.ts
+++ b/frontend/src/store/useTeamMembers.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import api from '../lib/api';
+import http from '../lib/http';
 import type { TeamMember, TeamMemberResponse } from '../types';
 
 interface TeamMemberState {
@@ -14,7 +14,7 @@ export const useTeamMembers = create<TeamMemberState>((set) => ({
   members: [],
 
   fetchMembers: async () => {
-    const res = await api.get<TeamMemberResponse[]>('/team');
+    const res = await http.get<TeamMemberResponse[]>('/team');
     const members = (res.data ?? []).map(mapMember);
     set({ members });
     return members;
@@ -22,7 +22,7 @@ export const useTeamMembers = create<TeamMemberState>((set) => ({
 
   addMember: async (data) => {
     const isForm = data instanceof FormData;
-    const res = await api.post<TeamMemberResponse>('/team', data as any, {
+    const res = await http.post<TeamMemberResponse>('/team', data as any, {
       headers: isForm ? { 'Content-Type': 'multipart/form-data' } : undefined,
     });
     const member = mapMember(res.data);
@@ -32,7 +32,7 @@ export const useTeamMembers = create<TeamMemberState>((set) => ({
 
   updateMember: async (id, data) => {
     const isForm = data instanceof FormData;
-    const res = await api.put<TeamMemberResponse>(`/team/${id}`, data as any, {
+    const res = await http.put<TeamMemberResponse>(`/team/${id}`, data as any, {
       headers: isForm ? { 'Content-Type': 'multipart/form-data' } : undefined,
     });
     const member = mapMember(res.data);
@@ -43,7 +43,7 @@ export const useTeamMembers = create<TeamMemberState>((set) => ({
   },
 
   deleteMember: async (id) => {
-    await api.delete<void>(`/team/${id}`);
+    await http.delete<void>(`/team/${id}`);
     set((state) => ({ members: state.members.filter((m) => m.id !== id) }));
   },
 }));

--- a/frontend/src/test/analyticsCharts.test.tsx
+++ b/frontend/src/test/analyticsCharts.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
-import api from '../lib/api';
+import http from '../lib/http';
 
-vi.mock('../lib/api');
+vi.mock('../lib/http');
 vi.mock('../components/layout/Layout', () => ({ default: ({ children }: any) => <div>{children}</div> }));
 vi.mock('../components/kpi/KpiWidget', () => ({ default: () => <div /> }));
 vi.mock('../components/kpi/KpiExportButtons', () => ({ default: () => <div /> }));
@@ -16,7 +16,7 @@ vi.mock('chart.js', () => ({ CategoryScale: {}, LinearScale: {}, PointElement: {
 
 import Analytics from '../pages/Analytics';
 
-const mockedGet = api.get as unknown as vi.Mock;
+const mockedGet = http.get as unknown as vi.Mock;
 
 mockedGet.mockImplementation((url: string) => {
   if (url === '/reports/analytics') {

--- a/frontend/src/test/dashboardDepartments.test.tsx
+++ b/frontend/src/test/dashboardDepartments.test.tsx
@@ -41,7 +41,7 @@ vi.mock('../api/summary', () => ({
   fetchLowStock: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock('../lib/api', () => ({
+vi.mock('../lib/http', () => ({
   default: { get: getMock },
 }));
 

--- a/frontend/src/test/mobileScanner.test.ts
+++ b/frontend/src/test/mobileScanner.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { scanQRCode } from '../utils/qr';
-import api from '../lib/api';
+import http from '../lib/http';
 
-vi.mock('../lib/api', () => ({
+vi.mock('../lib/http', () => ({
   default: vi.fn(),
 }));
 
@@ -18,10 +18,10 @@ vi.mock('@zxing/browser', () => {
 describe('mobile scanner', () => {
   it('looks up asset by scanned code', async () => {
     const video = document.createElement('video');
-    const apiMock = api as unknown as ReturnType<typeof vi.fn>;
+    const apiMock = http as unknown as ReturnType<typeof vi.fn>;
     (apiMock as any).mockResolvedValue({});
     const code = await scanQRCode(video);
-    await api({ method: 'get', url: `/assets/${code}` });
+    await http({ method: 'get', url: `/assets/${code}` });
     expect(apiMock).toHaveBeenCalledWith({ method: 'get', url: '/assets/asset-123' });
   });
 

--- a/frontend/src/test/offlineQueue.test.ts
+++ b/frontend/src/test/offlineQueue.test.ts
@@ -6,9 +6,9 @@ import {
   enqueueAssetRequest,
   enqueueDepartmentRequest,
 } from '../utils/offlineQueue';
-import api from '../lib/api';
+import http from '../lib/http';
 
-vi.mock('../lib/api', () => ({
+vi.mock('../lib/http', () => ({
   default: vi.fn(),
 }));
 
@@ -69,7 +69,7 @@ describe('offline queue helpers', () => {
   });
 
   it('flushes the queue and clears storage', async () => {
-    const apiMock = api as unknown as ReturnType<typeof vi.fn>;
+    const apiMock = http as unknown as ReturnType<typeof vi.fn>;
     (apiMock as any).mockResolvedValue({});
     const queue = [
       { method: 'post' as const, url: '/a', data: { a: 1 } },
@@ -101,7 +101,7 @@ describe('offline queue helpers', () => {
   });
 
   it('continues flushing when a request fails', async () => {
-    const apiMock = api as unknown as ReturnType<typeof vi.fn>;
+    const apiMock = http as unknown as ReturnType<typeof vi.fn>;
     (apiMock as any).mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('fail'));
     const queue = [
       { method: 'post' as const, url: '/a', data: { a: 1 } },
@@ -121,7 +121,7 @@ describe('offline queue helpers', () => {
   });
 
   it('skips requests whose nextAttempt is in the future', async () => {
-    const apiMock = api as unknown as ReturnType<typeof vi.fn>;
+    const apiMock = http as unknown as ReturnType<typeof vi.fn>;
     (apiMock as any).mockResolvedValue({});
     const future = Date.now() + 100000;
     const queue = [
@@ -137,7 +137,7 @@ describe('offline queue helpers', () => {
   });
 
   it('drops requests that conflict on the server', async () => {
-    const apiMock = api as unknown as ReturnType<typeof vi.fn>;
+    const apiMock = http as unknown as ReturnType<typeof vi.fn>;
     (apiMock as any).mockRejectedValue({ response: { status: 409 } });
     const queue = [
       { method: 'post' as const, url: '/conflict', data: { id: 1 } },
@@ -151,7 +151,7 @@ describe('offline queue helpers', () => {
   });
 
   it('processes 1k queued records within 5s', async () => {
-    const apiMock = api as unknown as ReturnType<typeof vi.fn>;
+    const apiMock = http as unknown as ReturnType<typeof vi.fn>;
     (apiMock as any).mockResolvedValue({});
     const queue = Array.from({ length: 1000 }, (_, i) => ({
       method: 'post' as const,
@@ -167,7 +167,7 @@ describe('offline queue helpers', () => {
   });
 
   it('handles queued screenshot uploads', async () => {
-    const apiMock = api as unknown as ReturnType<typeof vi.fn>;
+    const apiMock = http as unknown as ReturnType<typeof vi.fn>;
     (apiMock as any).mockResolvedValue({});
     const req = { method: 'post' as const, url: '/uploads/screenshot', data: { img: 'dataurl' } };
     localStorageMock.store['offline-queue'] = JSON.stringify([req]);
@@ -179,7 +179,7 @@ describe('offline queue helpers', () => {
   });
 
   it('handles queued signature uploads', async () => {
-    const apiMock = api as unknown as ReturnType<typeof vi.fn>;
+    const apiMock = http as unknown as ReturnType<typeof vi.fn>;
     (apiMock as any).mockResolvedValue({});
     const req = { method: 'post' as const, url: '/uploads/signature', data: { sig: 'dataurl' } };
     localStorageMock.store['offline-queue'] = JSON.stringify([req]);

--- a/frontend/src/test/offlineSync.test.ts
+++ b/frontend/src/test/offlineSync.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, beforeEach, expect, vi } from 'vitest';
 import { addToQueue, flushQueue } from '../utils/offlineQueue';
-import api from '../lib/api';
+import http from '../lib/http';
 
-vi.mock('../lib/api', () => ({
+vi.mock('../lib/http', () => ({
   default: vi.fn(),
 }));
 
@@ -31,7 +31,7 @@ beforeEach(() => {
 
 describe('offline sync', () => {
   it('flushes seeded requests', async () => {
-    const apiMock = api as unknown as ReturnType<typeof vi.fn>;
+    const apiMock = http as unknown as ReturnType<typeof vi.fn>;
     (apiMock as any).mockResolvedValue({});
     addToQueue({ method: 'post', url: '/assets', data: { name: 'Seeded' } });
     await flushQueue();

--- a/frontend/src/test/settings.test.tsx
+++ b/frontend/src/test/settings.test.tsx
@@ -19,29 +19,29 @@ vi.mock('../context/ToastContext', () => ({
   useToast: () => ({ addToast: mockAddToast }),
 }));
 
-vi.mock('../lib/api', () => ({
+vi.mock('../lib/http', () => ({
   default: { post: vi.fn() },
 }));
 
-import api from '../lib/api';
+import http from '../lib/http';
 import Settings from '../pages/Settings';
 
 describe('Settings page', () => {
   beforeEach(() => {
-    (api.post as any).mockReset();
+    (http.post as any).mockReset();
     mockAddToast.mockReset();
   });
 
   it('saves settings successfully', async () => {
-    (api.post as any).mockResolvedValueOnce({ data: {} });
+    (http.post as any).mockResolvedValueOnce({ data: {} });
     render(<Settings />);
     await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
-    expect(api.post).toHaveBeenCalledWith('/settings', expect.any(Object));
+    expect(http.post).toHaveBeenCalledWith('/settings', expect.any(Object));
     expect(mockAddToast).toHaveBeenCalledWith('Settings saved', 'success');
   });
 
   it('handles unauthorized errors', async () => {
-    (api.post as any).mockRejectedValueOnce({ response: { status: 401 } });
+    (http.post as any).mockRejectedValueOnce({ response: { status: 401 } });
     render(<Settings />);
     await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
     expect(mockAddToast).toHaveBeenCalledWith('Unauthorized', 'error');

--- a/frontend/src/test/vendorsPage.test.tsx
+++ b/frontend/src/test/vendorsPage.test.tsx
@@ -6,33 +6,33 @@ vi.mock('../components/layout/Layout', () => ({
   default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
-vi.mock('../lib/api', () => ({
+vi.mock('../lib/http', () => ({
   default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
 }));
 
-import api from '../lib/api';
+import http from '../lib/http';
 import VendorsPage from '../pages/VendorsPage';
 
 describe('VendorsPage', () => {
   beforeEach(() => {
-    (api.get as any).mockReset();
-    (api.post as any).mockReset();
-    (api.put as any).mockReset();
-    (api.delete as any).mockReset();
+    (http.get as any).mockReset();
+    (http.post as any).mockReset();
+    (http.put as any).mockReset();
+    (http.delete as any).mockReset();
   });
 
   it('loads and displays vendors', async () => {
-    (api.get as any).mockResolvedValueOnce({ data: [{ id: '1', name: 'Vendor A', contact: 'c' }] });
+    (http.get as any).mockResolvedValueOnce({ data: [{ id: '1', name: 'Vendor A', contact: 'c' }] });
     render(<VendorsPage />);
     expect(await screen.findByText('Vendor A')).toBeInTheDocument();
   });
 
   it('deletes vendor', async () => {
-    (api.get as any).mockResolvedValueOnce({ data: [{ id: '1', name: 'Vendor A', contact: 'c' }] });
-    (api.delete as any).mockResolvedValueOnce({});
+    (http.get as any).mockResolvedValueOnce({ data: [{ id: '1', name: 'Vendor A', contact: 'c' }] });
+    (http.delete as any).mockResolvedValueOnce({});
     render(<VendorsPage />);
     await screen.findByText('Vendor A');
     await userEvent.click(screen.getByRole('button', { name: /delete/i }));
-    expect(api.delete).toHaveBeenCalledWith('/vendors/1');
+    expect(http.delete).toHaveBeenCalledWith('/vendors/1');
   });
 });

--- a/frontend/src/utils/offlineQueue.ts
+++ b/frontend/src/utils/offlineQueue.ts
@@ -59,7 +59,7 @@ export const enqueueDepartmentRequest = (
 
 export const clearQueue = () => localStorage.removeItem(QUEUE_KEY);
 
-import api from '../lib/api';
+import http from '../lib/http';
 
 export const flushQueue = async (useBackoff = true) => {
   const queue = loadQueue();
@@ -74,7 +74,7 @@ export const flushQueue = async (useBackoff = true) => {
       continue;
     }
     try {
-      await api({ method: req.method, url: req.url, data: req.data });
+      await http({ method: req.method, url: req.url, data: req.data });
     } catch (err: any) {
       if (err?.response?.status === 409) {
         console.warn('Dropping conflicted request', err);

--- a/frontend/src/workorders/AICopilot.tsx
+++ b/frontend/src/workorders/AICopilot.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import Button from '../components/common/Button';
-import api from '../lib/api';
+import http from '../lib/http';
 
 interface Props {
   workOrderId: string;
@@ -16,7 +16,7 @@ const AICopilot: React.FC<Props> = ({ workOrderId }) => {
     setLoading(true);
     setError('');
     try {
-      const res = await api.get(`/workorders/${workOrderId}/assist`);
+      const res = await http.get(`/workorders/${workOrderId}/assist`);
       setSummary(res.data.summary);
       setRisk(res.data.riskScore);
     } catch (_err) {


### PR DESCRIPTION
## Summary
- add new http axios client
- swap api imports for http and adjust calls

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for package @dnd-kit/core)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf8167a2883239d189da74896082c