### PR TITLE
feat: persist auth details after login

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -72,6 +72,9 @@ const LoginPage: React.FC = () => {
         return;
       }
       setUser({ ...data.user, token: data.token });
+      localStorage.setItem('auth:token', data.token);
+      if (data.user?.tenantId) localStorage.setItem('auth:tenantId', data.user.tenantId);
+      if (data.user?.siteId) localStorage.setItem('auth:siteId', data.user.siteId);
       navigate('/dashboard');
     } catch {
       setError(t('auth.loginFailed', 'Login failed'));
@@ -87,6 +90,9 @@ const LoginPage: React.FC = () => {
         token: code,
       });
       setUser({ ...data.user, token: data.token });
+      localStorage.setItem('auth:token', data.token);
+      if (data.user?.tenantId) localStorage.setItem('auth:tenantId', data.user.tenantId);
+      if (data.user?.siteId) localStorage.setItem('auth:siteId', data.user.siteId);
       navigate('/dashboard');
     } catch {
       setError(t('auth.invalidCode', 'Invalid code'));


### PR DESCRIPTION
## Summary
- store auth token, tenant and site IDs in localStorage after login or MFA verification

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf8172c448323aff193fa6b925c72