### PR TITLE
chore: add socket.io-mock type declaration

### DIFF
--- a/frontend/src/types/socket.io-mock.d.ts
+++ b/frontend/src/types/socket.io-mock.d.ts
@@ -1,0 +1,1 @@
+declare module 'socket.io-mock';


### PR DESCRIPTION
## Summary
- declare `socket.io-mock` module for TypeScript

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0327a7148323aab669e1d93d2acb