### PR TITLE
Implement DepartmentDrawerForm logic

### DIFF
--- a/frontend/src/components/departments/DepartmentDrawerForm.tsx
+++ b/frontend/src/components/departments/DepartmentDrawerForm.tsx
@@ -1,13 +1,82 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { Department, DepartmentPayload, Line } from '../../api/departments';
+import Button from '../common/Button';
 
-type Props = {
+interface Props {
   initial: Department | null;
   onSubmit: (payload: DepartmentPayload, draftLines: Line[]) => Promise<void>;
   onCancel: () => void;
-};
+}
 
 export default function DepartmentDrawerForm({ initial, onSubmit, onCancel }: Props) {
   const [name, setName] = useState(initial?.name ?? '');
-  // the rest of code exactly as provided by user...
+  const [lines, setLines] = useState<Line[]>(initial?.lines ?? []);
+
+  const handleLineChange = (index: number, value: string) => {
+    setLines((prev) => prev.map((l, i) => (i === index ? { ...l, name: value } : l)));
+  };
+
+  const handleAddLine = () => {
+    setLines((prev) => [
+      ...prev,
+      { _id: Date.now().toString(), name: '', stations: [] },
+    ]);
+  };
+
+  const handleRemoveLine = (index: number) => {
+    setLines((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await onSubmit({ name: name.trim() }, lines);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium mb-1">Name</label>
+        <input
+          type="text"
+          className="w-full px-3 py-2 border border-neutral-300 rounded-md"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-2">
+        {lines.map((line, index) => (
+          <div key={line._id} className="flex gap-2">
+            <input
+              type="text"
+              className="flex-1 px-3 py-2 border border-neutral-300 rounded-md"
+              value={line.name}
+              onChange={(e) => handleLineChange(index, e.target.value)}
+            />
+            <Button
+              type="button"
+              variant="danger"
+              size="sm"
+              onClick={() => handleRemoveLine(index)}
+            >
+              Remove
+            </Button>
+          </div>
+        ))}
+        <Button type="button" variant="ghost" onClick={handleAddLine}>
+          Add Line
+        </Button>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button type="button" variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" variant="primary">
+          Save
+        </Button>
+      </div>
+    </form>
+  );
 }
+


### PR DESCRIPTION
## Summary
- remove unused useEffect import
- implement department drawer form with line management and submit/cancel actions

## Testing
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd032b1d988323931e2a650cdaac15