### PR TITLE
Remove unused lineId from DepartmentHierarchyGrid

### DIFF
--- a/frontend/src/components/departments/DepartmentHierarchyGrid.tsx
+++ b/frontend/src/components/departments/DepartmentHierarchyGrid.tsx
@@ -53,8 +53,7 @@ const DepartmentHierarchyGrid: React.FC<Props> = ({
 
   const handleStationNameChange = (
     station: StationWithAssets,
-    name: string,
-    lineId: string
+    name: string
   ) => {
     onUpdateStation({ ...station, name });
   };
@@ -139,7 +138,7 @@ const DepartmentHierarchyGrid: React.FC<Props> = ({
                         className="flex-1 mr-2 px-2 py-1 border rounded-md text-sm"
                         value={station.name}
                         onChange={(e) =>
-                          handleStationNameChange(station, e.target.value, line.id)
+                          handleStationNameChange(station, e.target.value)
                         }
                       />
                       <div className="space-x-2">


### PR DESCRIPTION
## Summary
- remove unused `lineId` param from station name change handler

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bd032b3b9c83239ca390c0130e443a