### PR TITLE
refactor: clean up document uploader

### DIFF
--- a/frontend/src/components/documentation/DocumentUploader.tsx
+++ b/frontend/src/components/documentation/DocumentUploader.tsx
@@ -1,22 +1,12 @@
 import React, { useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
-import { Upload, File, X } from 'lucide-react';
-import Button from '../common/Button';
-import type { DocumentMetadata } from '../../utils/documentation';
+import { Upload } from 'lucide-react';
 
 interface DocumentUploaderProps {
   onUpload: (files: File[]) => void;
-  acceptedTypes?: string[];
 }
 
-const DocumentUploader: React.FC<DocumentUploaderProps> = ({
-  onUpload,
-  acceptedTypes = [
-    'application/pdf',
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-  ]
-}) => {
+const DocumentUploader: React.FC<DocumentUploaderProps> = ({ onUpload }) => {
   const onDrop = useCallback((acceptedFiles: File[]) => {
     onUpload(acceptedFiles);
   }, [onUpload]);


### PR DESCRIPTION
## Summary
- remove unused imports from DocumentUploader component
- drop unused acceptedTypes prop

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68bd032d4b488323bde9259ad75b4a26