### PR TITLE
chore: remove unused Clock import

### DIFF
--- a/frontend/src/components/maintenance/MaintenanceSchedule.tsx
+++ b/frontend/src/components/maintenance/MaintenanceSchedule.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Badge from '../common/Badge';
-import { Calendar, Clock } from 'lucide-react';
+import { Calendar } from 'lucide-react';
 import type { MaintenanceSchedule } from '../../types';
 
 interface MaintenanceScheduleProps {


### PR DESCRIPTION
## Summary
- remove unused Clock icon import from maintenance schedule component

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- ❌`npm test` *(vitest: not found; registry 403 when attempting install)*

------
https://chatgpt.com/codex/tasks/task_e_68bd032e78a4832381873843aef6e5db