### PR TITLE
feat: add notification interface and card padding option

### DIFF
--- a/frontend/src/components/common/Card.tsx
+++ b/frontend/src/components/common/Card.tsx
@@ -8,6 +8,7 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   icon?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
+  noPadding?: boolean;
 }
 
 const Card: React.FC<CardProps> = ({
@@ -17,10 +18,14 @@ const Card: React.FC<CardProps> = ({
   icon,
   children,
   className = '',
+  noPadding = false,
   ...rest
 }) => {
   return (
-    <div {...rest} className={`bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-lg shadow-sm p-6 ${className}`}>
+    <div
+      {...rest}
+      className={`bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-lg shadow-sm ${noPadding ? 'p-0' : 'p-6'} ${className}`}
+    >
       {(title || subtitle || headerActions || icon) && (
         <div className="flex justify-between items-start mb-4">
           <div className="flex items-start">

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@
  
 import React, { useEffect, useState, useRef } from 'react';
  
-import { Search, Bell, HelpCircle, Menu, Book, Video, MessageCircle, FileText, ExternalLink, Sun, Moon, Monitor, Database } from 'lucide-react';
+import { Search, Bell, HelpCircle, Menu, Book, Video, MessageCircle, FileText, ExternalLink, Database } from 'lucide-react';
  
 import ThemeToggle from '../common/ThemeToggle';
 import Avatar from '../common/Avatar';
@@ -18,15 +18,6 @@ import { useTranslation } from 'react-i18next';
  
 
 import type { Notification } from '../../types';
-  
-
-interface Member {
-  id: string;
-  name: string;
-  avatar?: string;
-  status: 'online' | 'away' | 'offline';
-  role?: string;
-}
 
 interface HeaderProps {
   onToggleSidebar: () => void;
@@ -37,7 +28,6 @@ type HeaderNotification = Notification & { link?: string };
 
 const Header: React.FC<HeaderProps> = ({ onToggleSidebar, title }) => {
   const { t, i18n } = useTranslation();
-  const headerTitle = title ?? t('nav.dashboard');
   const user = useAuthStore((s) => s.user);
   const isAdmin = useAuthStore(selectIsAdmin);
   const isManager = useAuthStore(selectIsManager);
@@ -209,7 +199,7 @@ const Header: React.FC<HeaderProps> = ({ onToggleSidebar, title }) => {
         >
           <Menu size={20} className="dark:text-white" />
         </button>
-        <h1 className="text-xl font-semibold text-neutral-900 dark:text-white ml-2 lg:ml-0">{title}</h1>
+        <h1 className="text-xl font-semibold text-neutral-900 dark:text-white ml-2 lg:ml-0">{title ?? t('nav.dashboard')}</h1>
         <button
           onClick={() => setShowMobileSearch(!showMobileSearch)} aria-label="Search"
           className="md:hidden ml-2 p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-700 focus:outline-none"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -275,6 +275,15 @@ export interface Member {
   role?: string;
 }
 
+export interface Notification {
+  id: string;
+  title: string;
+  message: string;
+  type: 'critical' | 'warning' | 'info';
+  read: boolean;
+  createdAt: string;
+}
+
 export interface NotificationType {
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
- add Notification interface to shared types
- update Header to use Notification and support optional link
- allow Card to render without padding

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd03325b288323802ddac20103d8b7