### PR TITLE
test: include jest-dom import for workflow test

### DIFF
--- a/frontend/mobile/routes/RouteWorkflow.test.tsx
+++ b/frontend/mobile/routes/RouteWorkflow.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import RouteWorkflow from './RouteWorkflow';


### PR DESCRIPTION
## Summary
- add `@testing-library/jest-dom` import in RouteWorkflow test so `toBeInTheDocument` is typed

## Testing
- `npm test mobile/routes/RouteWorkflow.test.tsx` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npx tsc mobile/routes/RouteWorkflow.test.tsx` *(fails: Cannot find module '@testing-library/react', missing types)*


------
https://chatgpt.com/codex/tasks/task_e_68bd033289508323864640d884a022a6