### PR TITLE
feat: add vendors sidebar link

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Home,
   Clipboard,
@@ -108,6 +108,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     maintenance: { path: '/maintenance', label: t('nav.maintenance'), icon: <Calendar size={20} /> },
     'pm-tasks': { path: '/pm-tasks', label: t('nav.pmTasks'), icon: <Calendar size={20} /> },
     inventory: { path: '/inventory', label: t('nav.inventory'), icon: <Package size={20} /> },
+    vendors: { path: '/vendors', label: t('nav.vendors'), icon: <Package size={20} />, requireAdmin: true },
 
     timesheets: { path: '/timesheets', label: t('nav.timesheets'), icon: <Clock size={20} /> },
 


### PR DESCRIPTION
## Summary
- add vendors link and icon to sidebar navigation
- drop unused `useState` import

## Testing
- `npx tsc -p tsconfig.app.json` (fails: Cannot find type definition file for 'node')
- `npm install --legacy-peer-deps` (fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)


------
https://chatgpt.com/codex/tasks/task_e_68bd033395648323b42513a58a1879bc