### PR TITLE
Make maintenance repeat configuration required

### DIFF
--- a/frontend/src/components/maintenance/MaintenanceModal.tsx
+++ b/frontend/src/components/maintenance/MaintenanceModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { X, Calendar, Clock, AlertTriangle } from 'lucide-react';
+import { X, AlertTriangle } from 'lucide-react';
 import Button from '../common/Button';
 import type { MaintenanceSchedule } from '../../types';
 import { v4 as uuidv4 } from 'uuid';
@@ -35,7 +35,7 @@ const MaintenanceModal: React.FC<MaintenanceModalProps> = ({
   schedule,
   onUpdate,
 }) => {
-  const [formData, setFormData] = useState(
+  const [formData, setFormData] = useState<MaintenanceSchedule>(
     schedule ?? createDefaultSchedule()
   );
 
@@ -70,7 +70,7 @@ const MaintenanceModal: React.FC<MaintenanceModalProps> = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    onUpdate(formData as MaintenanceSchedule);
+    onUpdate(formData);
   };
 
   const calculateNextDueDate = (date: string, frequency: string) => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -149,7 +149,7 @@ export interface MaintenanceSchedule {
   instructions?: string;
   estimatedDuration: number;
   type?: string;
-  repeatConfig?: {
+  repeatConfig: {
     interval: number;
     unit: string;
     endDate: string;


### PR DESCRIPTION
## Summary
- Require `repeatConfig` in MaintenanceSchedule type
- Type maintenance modal state and drop unused icons

## Testing
- ⚠️ `npx tsc -p tsconfig.app.json --noEmit` *(missing @types/node: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68bd0333f7cc8323b50f9124ce4279c1