### PR TITLE
refactor: clean chat sidebar imports

### DIFF
--- a/frontend/src/components/messaging/ChatSidebar.tsx
+++ b/frontend/src/components/messaging/ChatSidebar.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { Search, Plus, Hash, Users, X } from 'lucide-react';
+import { Search, Plus, Hash, X } from 'lucide-react';
 import Avatar from '../common/Avatar';
-import Button from '../common/Button';
-import type { Channel, DirectMessage } from 'src/types';
+import type { Channel, DirectMessage } from '../../types';
 
 interface ChatSidebarProps {
   channels: Channel[];
@@ -26,7 +25,6 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
   onDeleteChat,
 }) => {
   const [searchTerm, setSearchTerm] = useState('');
-  const [showNewChatModal, setShowNewChatModal] = useState(false);
 
   const filteredChannels = channels.filter(channel =>
     channel.name.toLowerCase().includes(searchTerm.toLowerCase())
@@ -36,7 +34,7 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
     dm.userName.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-  const handleDoubleClick = (userId: string, userName: string) => {
+  const handleDoubleClick = (userId: string) => {
     // Create or open direct message chat
     onDirectMessageSelect(userId);
   };
@@ -129,7 +127,7 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
                   ${activeChannelId === dm.id ? 'bg-primary-600 text-white' : 'text-neutral-300 hover:bg-neutral-700'}
                 `}
                 onClick={() => onDirectMessageSelect(dm.userId)}
-                onDoubleClick={() => handleDoubleClick(dm.userId, dm.userName)}
+                onDoubleClick={() => handleDoubleClick(dm.userId)}
               >
                 <div className="flex items-center flex-1 min-w-0">
                   <Avatar


### PR DESCRIPTION
## Summary
- fix ChatSidebar types import and remove unused imports
- simplify direct message handler

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bd0337905c832390c081abaaaf26c1