### PR TITLE
Setup Vitest testing for Frontend

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vite-react-typescript-starter",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "vitest",
+    "test:watch": "vitest --watch"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.4",
+    "@types/node": "^20.11.7",
+    "typescript": "^5.4.0",
+    "vitest": "^1.5.0"
+  }
+}

--- a/Frontend/src/smoke.test.ts
+++ b/Frontend/src/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('smoke test', () => {
+  it('passes', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/Frontend/src/test/setup.ts
+++ b/Frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/Frontend/vitest.config.ts
+++ b/Frontend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['src/test/setup.ts'],
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- add Frontend package.json with TypeScript and Vitest scripts and dev deps
- configure Vitest to use jsdom and project test setup
- add jest-dom setup and a simple smoke test

## Testing
- `npm install vitest @testing-library/jest-dom typescript @types/node --no-save --no-package-lock` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd09a1f848832387be00629ac77d21