### PR TITLE
chore: add tsconfig with vitest types

### DIFF
--- a/Frontend/tsconfig.json
+++ b/Frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client", "vitest/globals", "node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript config for Frontend with vitest, vite, and node types

## Testing
- `npm test` (fails: vitest not found)
- `npm run typecheck` (fails: missing type definitions)


------
https://chatgpt.com/codex/tasks/task_e_68bd199bf088832387d6319373f3482b