### PR TITLE
chore: add frontend local env config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/.env
 **/.env.*
 !Frontend/.env
+!Frontend/.env.local
 !Backend/.env.example
 !Frontend/.env.example
 

--- a/Frontend/.env.local
+++ b/Frontend/.env.local
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5010/api


### PR DESCRIPTION
## Summary
- track `.env.local` in git and provide default API URL for frontend

## Testing
- `npm i -D vite @vitejs/plugin-react typescript @types/node` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2329bc848323afde530df0dfdebb