### PR TITLE
fix: configure Tailwind via PostCSS plugin

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -16,6 +16,10 @@
   "devDependencies": {
     "@types/node": "^20.11.30",
     "@vitejs/plugin-react": "^4.0.3",
+    "tailwindcss": "^4.0.0",
+    "@tailwindcss/postcss": "^4.0.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
     "typescript": "^5.4.0",
     "vite": "^5.2.0"
   }

--- a/Frontend/postcss.config.cjs
+++ b/Frontend/postcss.config.cjs
@@ -1,0 +1,9 @@
+/** PostCSS config for Tailwind v4+ */
+module.exports = {
+  plugins: {
+    // Tailwind’s PostCSS plugin moved here in v4
+    '@tailwindcss/postcss': {},
+    // Keep autoprefixer (safe in both v3/v4)
+    autoprefixer: {},
+  },
+};

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -1,4 +1,7 @@
-body {
-  margin: 0;
-  font-family: sans-serif;
-}
+/* Works for both Tailwind v3 and v4 builds */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* place your custom styles below if needed */
+

--- a/Frontend/tailwind.config.ts
+++ b/Frontend/tailwind.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
+  theme: { extend: {} },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
## Summary
- add Tailwind and autoprefixer PostCSS setup
- provide Tailwind configuration and base CSS
- declare Tailwind-related dev dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fpostcss)*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd28a10bd88323a6336768ea72ba0b