### PR TITLE
refactor: update PostCSS config to ESM style

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,7 +1,6 @@
-export default {
-  plugins: [
-    require('@tailwindcss/postcss'),
-    require('autoprefixer'),
-  ],
-};
+import tailwindcss from '@tailwindcss/postcss';
+import autoprefixer from 'autoprefixer';
 
+export default {
+  plugins: [tailwindcss, autoprefixer],
+};


### PR DESCRIPTION
## Summary
- rewrite PostCSS config to use ESM `import` syntax and plugin instances

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fpostcss)*
- `npm run dev` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2f2ba64883239bcf50c28c10c11d