### PR TITLE
feat(frontend): add Vite entry page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WorkPro App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+function App() {
+  return <h1>Hello WorkPro</h1>;
+}
+
+const rootElement = document.getElementById('root')!;
+createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- add `index.html` with module script for React entry
- introduce `src/main.tsx` mounting a basic React component
- configure Vite with React plugin and dev server port

## Testing
- `npm run dev` *(fails: vite not found; dependencies could not be installed due to E403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd319c7244832383dce2a02b1e2f49