### PR TITLE
chore(frontend): add react type definitions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,9 @@
   "devDependencies": {
     "@tailwindcss/postcss": "latest",
     "@types/node": "^20.11.30",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.0.3",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "types": ["vite/client", "vitest/globals", "node"],
+    "types": ["vite/client", "vitest/globals", "node", "react", "react-dom"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- add React-related @types packages as dev dependencies
- include react and react-dom in TypeScript config types

## Testing
- `npm install` *(fails: 403 Forbidden on @tailwindcss/postcss)*
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd3747091c83238f76c02769ca9fee