### PR TITLE
feat(frontend): add workbox and testing libs

### DIFF
--- a/frontend/mobile/routes/RouteWorkflow.test.tsx
+++ b/frontend/mobile/routes/RouteWorkflow.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import RouteWorkflow from './RouteWorkflow';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,18 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "workbox-precaching": "^7.0.0",
+    "workbox-routing": "^7.0.0",
+    "workbox-strategies": "^7.0.0",
+    "@zxing/browser": "^0.1.1",
+    "socket.io-client": "^4.8.1",
+    "file-saver": "^2.0.5",
+    "exceljs": "^4.4.0",
+    "mammoth": "^1.7.0",
+    "pdfjs-dist": "^4.0.379",
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.5.28"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "latest",
@@ -21,6 +32,12 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.13",
     "typescript": "^5.4.0",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@types/file-saver": "^2.0.7",
+    "@types/mammoth": "^1.4.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,13 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
   },
 });


### PR DESCRIPTION
## Summary
- add workbox, file utilities, zxing, socket.io-client, and PDF/Excel helpers
- install Testing Library helpers and vitest config for jest-dom matchers
- centralize jest-dom setup for typed DOM matchers

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fpostcss)*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68bd37487cd48323a7e4f00105ee3fc6