### PR TITLE
Consolidate MaintenanceType definition

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Defines the allowed maintenance categories for upcoming maintenance tasks.
+ */
 export type MaintenanceType = 'preventive' | 'corrective' | 'inspection';
 
 export interface Asset {
@@ -337,11 +340,6 @@ export interface LowStockPart {
   quantity: number;
   reorderPoint: number;
 }
-
-/**
- * Defines the allowed maintenance categories for upcoming maintenance tasks.
- */
-export type MaintenanceType = 'preventive' | 'corrective' | 'inspection';
 
 /** Response shape for upcoming maintenance tasks */
 export interface UpcomingMaintenanceResponse {


### PR DESCRIPTION
## Summary
- remove duplicate `MaintenanceType` type and retain a single shared definition with documentation

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bd3748df748323a6a0cf438e4cf751