### PR TITLE
Add optional category field to Asset type

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,6 +6,7 @@ export interface Asset {
   type?: 'Electrical' | 'Mechanical' | 'Tooling' | 'Interface';
   location?: string;
   department?: string;
+  category?: string;
   status?: 'Active' | 'Offline' | 'In Repair';
   description?: string;
   image?: string;


### PR DESCRIPTION
## Summary
- extend `Asset` interface with an optional `category` field

## Testing
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find type definition file for 'node')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fpostcss)*

------
https://chatgpt.com/codex/tasks/task_e_68bd374a7f7883238233f63de26cee01