### PR TITLE
fix: ensure duplicated work order matches WorkOrder type

### DIFF
--- a/frontend/src/utils/duplicate.ts
+++ b/frontend/src/utils/duplicate.ts
@@ -16,7 +16,7 @@ export const duplicateAsset = (asset: Asset): Asset => {
 };
 
 export const duplicateWorkOrder = (workOrder: WorkOrder): WorkOrder => {
-  const newWorkOrder = {
+  const newWorkOrder: WorkOrder = {
     ...workOrder,
     id: `${workOrder.id}-copy`,
     title: `${workOrder.title} (Copy)`,


### PR DESCRIPTION
## Summary
- type new work order as `WorkOrder` when duplicating to satisfy expected status type

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68bd374baa2c832390d38519a13c5ff0