### PR TITLE
test: use vitest expect directly

### DIFF
--- a/frontend/src/test/vendorModal.test.tsx
+++ b/frontend/src/test/vendorModal.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, Mock, vi } from 'vitest';
+import { describe, it, expect, Mock, vi } from 'vitest';
 import VendorModal from '../components/vendors/VendorModal';
 
 describe('VendorModal', () => {
@@ -28,7 +28,4 @@ describe('VendorModal', () => {
     expect(screen.getByDisplayValue('c1')).toBeInTheDocument();
   });
 });
-function expect(handleSave: Mock<(...args: any[]) => any>) {
-  throw new Error('Function not implemented.');
-}
 


### PR DESCRIPTION
## Summary
- import Vitest's built-in `expect` in vendor modal test
- drop custom `expect` stub from test

## Testing
- `npx vitest run src/test/vendorModal.test.tsx --environment jsdom` *(fails: 403 Forbidden accessing https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68bd374e2e0c8323a44a7b617f14c92a