### PR TITLE
chore: silence tailwind at-rule warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "css.lint.unknownAtRules": "ignore"
+}


### PR DESCRIPTION
## Summary
- silence VSCode unknown at-rule warnings for Tailwind CSS

## Testing
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd88677a5c8323bebdf7099e994dc3