### PR TITLE
chore: assert purchase order state

### DIFF
--- a/frontend/src/vendor/POList.tsx
+++ b/frontend/src/vendor/POList.tsx
@@ -8,7 +8,7 @@ interface PurchaseOrder {
 }
 
 export default function VendorPOList() {
-  const [pos, setPos] = useState<PurchaseOrder[]>([]);
+  const [pos, setPos] = useState([] as PurchaseOrder[]);
   const navigate = useNavigate();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- assert vendor PO list state without generics

## Testing
- `npm ls @types/react`
- `npm install @types/react@18.2.0` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd886881e083238a325dfd22863872