### PR TITLE
chore: ignore unknown CSS at-rules in VS Code

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -16,6 +16,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,0 +1,1 @@
+{ "css.lint.unknownAtRules": "ignore" }


### PR DESCRIPTION
## Summary
- add VS Code settings to silence CSS at-rule warnings
- allow tracking settings.json in frontend gitignore

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd8bda78488323807245f1b551aae2