### PR TITLE
fix: configure PostCSS for Tailwind under ESM

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,7 +1,7 @@
-// frontend/postcss.config.js
+// Frontend/postcss.config.js (ESM)
+import tailwindcss from '@tailwindcss/postcss'
+import autoprefixer from 'autoprefixer'
+
 export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {}
-  }
-};
+  plugins: [tailwindcss, autoprefixer],
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,11 +1,6 @@
-/* frontend/src/index.css */
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
-:root {
-  color-scheme: light dark;
-}
-
-body {
-  /* Core utilities work in v4; use them directly (not CSS modules) */
-  @apply bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100;
-}
+:root { color-scheme: light dark; }
+body { @apply bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100; }


### PR DESCRIPTION
## Summary
- replace PostCSS config with ESM export using `@tailwindcss/postcss` and autoprefixer
- wire Tailwind directives in `src/index.css`

## Testing
- ⚠️ `npm i` (403 Forbidden from registry)
- ⚠️ `npm run dev` (vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68bd930afc388323b6397b929c27897f