### PR TITLE
chore: downgrade jspdf

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "@zxing/browser": "^0.1.5",
     "exceljs": "^4.4.0",
     "file-saver": "^2.0.5",
-    "jspdf": "^3.0.2",
+    "jspdf": "^2.5.1",
     "jspdf-autotable": "^3.5.28",
     "mammoth": "^1.10.0",
     "pdfjs-dist": "^5.4.149",


### PR DESCRIPTION
## Summary
- downgrade jspdf to v2.5.1 for compatibility with jspdf-autotable

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9c3d36bc83239327ccb923f96702