### PR TITLE
refactor: use React.StrictMode

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
@@ -7,8 +7,8 @@ const root = document.getElementById("root");
 if (!root) throw new Error("Root element with id 'root' not found");
 
 createRoot(root).render(
-  <StrictMode>
+  <React.StrictMode>
     <App />
-  </StrictMode>
+  </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- import React default export instead of StrictMode named import
- wrap application with `<React.StrictMode>`

## Testing
- `npm run dev` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9c3f6d34832394abdd4bc4b46518