### PR TITLE
Include React type declarations in tsconfig

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "types": ["vite/client", "node"],
+    "types": ["vite/client", "node", "react", "react-dom"],
 
     /* Bundler mode */
     "moduleResolution": "Bundler",


### PR DESCRIPTION
## Summary
- add React and React DOM to TypeScript config to expose React.StrictMode types

## Testing
- `npm --prefix frontend run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda24940388323b1fde0d478f6d6fc