### PR TITLE
refactor: import StrictMode directly

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode } from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";


### PR DESCRIPTION
## Summary
- import StrictMode directly in frontend main entry
- render App within StrictMode wrapper

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bda24ae56c8323af2d0e809a70d9fc