### PR TITLE
Use single router and initialize i18n early

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,19 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import AppShell from "./components/layout/AppShell";
+import { Routes, Route, Navigate } from "react-router-dom";
+import Layout from "./components/layout/Layout";
 import Dashboard from "./pages/Dashboard";
 import Departments from "./pages/Departments";
 
 export default function App() {
   return (
     <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
-      <BrowserRouter>
-        <AppShell>
-          <Routes>
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/departments" element={<Departments />} />
-            <Route path="*" element={<div className="p-6">Not Found</div>} />
-          </Routes>
-        </AppShell>
-      </BrowserRouter>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<Navigate to="/dashboard" replace />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/departments" element={<Departments />} />
+          <Route path="*" element={<div className="p-6">Not Found</div>} />
+        </Routes>
+      </Layout>
     </div>
   );
 }

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -148,12 +148,18 @@ export const resources = {
   },
 } as const;
 
-i18n.use(initReactI18next).init({
-  resources,
-  lng: 'en',
-  fallbackLng: 'en',
-  interpolation: { escapeValue: false },
-});
+if (!i18n.isInitialized) {
+  i18n
+    .use(initReactI18next)
+    .init({
+      resources,
+      lng: 'en',
+      fallbackLng: 'en',
+      interpolation: { escapeValue: false },
+      react: { useSuspense: false },
+    })
+    .catch(console.error);
+}
 
 export default i18n;
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,14 +1,18 @@
-// src/main.tsx
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+import "./i18n";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("Root element with id 'root' not found");
 
 createRoot(rootEl).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );
+


### PR DESCRIPTION
## Summary
- Refactor entry to wrap the app in a single `<BrowserRouter>` and load i18n before rendering
- Remove nested router from `App` and render routes inside layout only
- Add resilient i18n setup with guard against re‑init and `useSuspense` disabled

## Testing
- `npm run build` *(fails: sh: 1: vite: not found)*
- `npm run dev` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaed9ae5483238c6b7e72b2112a6b