### PR TITLE
Refactor app routing with protected dashboard routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,23 @@
 import { Routes, Route, Navigate } from "react-router-dom";
-import Layout from "./components/layout/Layout";
-import Dashboard from "./pages/Dashboard";
-import Departments from "./pages/Departments";
+import Login from "./pages/Login";
+import NotFound from "./pages/NotFound";
+import RequireAuth from "./components/auth/RequireAuth";
+import DashboardLayout from "./pages/dashboard/DashboardLayout";
+import DashboardHome from "./pages/dashboard/DashboardHome";
+import Analytics from "./pages/dashboard/Analytics";
 
 export default function App() {
   return (
-    <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
-      <Layout>
-        <Routes>
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/departments" element={<Departments />} />
-          <Route path="*" element={<div className="p-6">Not Found</div>} />
-        </Routes>
-      </Layout>
-    </div>
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/dashboard/*" element={<RequireAuth />}>
+        <Route element={<DashboardLayout />}>
+          <Route index element={<DashboardHome />} />
+          <Route path="analytics" element={<Analytics />} />
+        </Route>
+      </Route>
+      <Route path="/" element={<Navigate to="/login" replace />} />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
   );
 }

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,6 +1,6 @@
 import { Navigate, Outlet } from 'react-router-dom';
 
-export default function ProtectedRoute() {
+export default function RequireAuth() {
   const token = localStorage.getItem('auth:token');
   return token ? <Outlet /> : <Navigate to="/login" replace />;
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,1 @@
+export { default } from "./LoginPage";

--- a/frontend/src/pages/dashboard/Analytics.tsx
+++ b/frontend/src/pages/dashboard/Analytics.tsx
@@ -1,0 +1,3 @@
+export default function Analytics() {
+  return <div>Analytics Page</div>;
+}

--- a/frontend/src/pages/dashboard/DashboardHome.tsx
+++ b/frontend/src/pages/dashboard/DashboardHome.tsx
@@ -1,0 +1,3 @@
+export default function DashboardHome() {
+  return <div>Dashboard Home</div>;
+}

--- a/frontend/src/pages/dashboard/DashboardLayout.tsx
+++ b/frontend/src/pages/dashboard/DashboardLayout.tsx
@@ -1,0 +1,5 @@
+import { Outlet } from "react-router-dom";
+
+export default function DashboardLayout() {
+  return <Outlet />;
+}


### PR DESCRIPTION
## Summary
- replace App routing with login, protected dashboard section and not-found fallback
- add RequireAuth guard and minimal dashboard layout/home/analytics pages

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb86d0c883239439418e3b7eb410