### PR TITLE
refactor: require auth wrapper

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,15 +2,20 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import Layout from "./components/layout/Layout";
 import Dashboard from "./pages/Dashboard";
 import Departments from "./pages/Departments";
+import LoginPage from "./pages/LoginPage";
+import RequireAuth from "./components/auth/RequireAuth";
 
 export default function App() {
   return (
     <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
       <Layout>
         <Routes>
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/departments" element={<Departments />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route element={<RequireAuth />}>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/departments" element={<Departments />} />
+          </Route>
           <Route path="*" element={<div className="p-6">Not Found</div>} />
         </Routes>
       </Layout>

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,7 +1,0 @@
-import { Navigate, Outlet } from 'react-router-dom';
-
-export default function ProtectedRoute() {
-  const token = localStorage.getItem('auth:token');
-  return token ? <Outlet /> : <Navigate to="/login" replace />;
-}
-

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,13 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+export default function RequireAuth() {
+  const token = localStorage.getItem('auth:token');
+  const user = localStorage.getItem('auth:user');
+  const location = useLocation();
+
+  if (!token || !user) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return <Outlet />;
+}


### PR DESCRIPTION
## Summary
- rename ProtectedRoute to RequireAuth with location-aware redirect
- secure routes by wrapping them in new RequireAuth component

## Testing
- `npm test` (fails: Missing script "test")
- `npx vitest run` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68bdcb87fa888323b42420a0e807470e