### PR TITLE
feat: add dashboard layout with sidebar navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,9 @@
 import { Routes, Route, Navigate } from "react-router-dom";
 import Layout from "./components/layout/Layout";
 import Dashboard from "./pages/Dashboard";
+import Analytics from "./pages/Analytics";
 import Departments from "./pages/Departments";
+import DashboardLayout from "./pages/dashboard/DashboardLayout";
 
 export default function App() {
   return (
@@ -9,7 +11,10 @@ export default function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/dashboard" element={<DashboardLayout />}>
+            <Route index element={<Dashboard />} />
+            <Route path="analytics" element={<Analytics />} />
+          </Route>
           <Route path="/departments" element={<Departments />} />
           <Route path="*" element={<div className="p-6">Not Found</div>} />
         </Routes>

--- a/frontend/src/pages/dashboard/DashboardLayout.tsx
+++ b/frontend/src/pages/dashboard/DashboardLayout.tsx
@@ -1,0 +1,41 @@
+import { NavLink, Outlet } from 'react-router-dom';
+
+export default function DashboardLayout() {
+  return (
+    <div className="flex min-h-screen">
+      <aside className="w-64 bg-neutral-100 dark:bg-neutral-900 p-4">
+        <nav className="space-y-2">
+          <NavLink
+            to="/dashboard"
+            end
+            className={({ isActive }) =>
+              `block px-3 py-2 rounded ${
+                isActive
+                  ? 'bg-neutral-200 dark:bg-neutral-800'
+                  : 'hover:bg-neutral-200 dark:hover:bg-neutral-800'
+              }`
+            }
+          >
+            Home
+          </NavLink>
+          <NavLink
+            to="/dashboard/analytics"
+            className={({ isActive }) =>
+              `block px-3 py-2 rounded ${
+                isActive
+                  ? 'bg-neutral-200 dark:bg-neutral-800'
+                  : 'hover:bg-neutral-200 dark:hover:bg-neutral-800'
+              }`
+            }
+          >
+            Analytics
+          </NavLink>
+        </nav>
+      </aside>
+      <main className="flex-1 p-4">
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add dashboard layout with sidebar navigation and outlet
- wire up dashboard routes for home and analytics

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite not found)

------
https://chatgpt.com/codex/tasks/task_e_68bdcb89ac90832394f7992d459bdfaf