### PR TITLE
Use dedicated NotFound page for unmatched routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import Layout from "./components/layout/Layout";
 import Dashboard from "./pages/Dashboard";
 import Departments from "./pages/Departments";
+import NotFound from "./pages/NotFound";
 
 export default function App() {
   return (
@@ -11,7 +12,7 @@ export default function App() {
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/departments" element={<Departments />} />
-          <Route path="*" element={<div className="p-6">Not Found</div>} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </Layout>
     </div>

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,42 +1,9 @@
-import React, { useEffect, useState } from 'react';
-
-const NotFound: React.FC = () => {
-  const [installEvent, setInstallEvent] = useState<any>(null);
-  const [showInstall, setShowInstall] = useState(false);
-
-  useEffect(() => {
-    const handler = (e: Event) => {
-      e.preventDefault();
-      setInstallEvent(e);
-      setShowInstall(true);
-    };
-    window.addEventListener('beforeinstallprompt', handler as EventListener);
-    return () => window.removeEventListener('beforeinstallprompt', handler as EventListener);
-  }, []);
-
-  const promptInstall = async () => {
-    if (!installEvent) return;
-    installEvent.prompt();
-    await installEvent.userChoice;
-    setInstallEvent(null);
-    setShowInstall(false);
-  };
-
+export default function NotFound() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen text-red-600 text-xl font-bold p-4">
-      {showInstall && (
-        <div className="mb-4">
-          <button
-            onClick={promptInstall}
-            className="px-4 py-2 rounded bg-blue-600 text-white"
-          >
-            Install App
-          </button>
-        </div>
-      )}
-      404 - Page Not Found
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-2">Not Found</h1>
+      <p>The page you're looking for doesn't exist.</p>
     </div>
   );
-};
+}
 
-export default NotFound;


### PR DESCRIPTION
## Summary
- replace complex NotFound page with simple message and explanation
- wire catch-all route in App to the NotFound component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite not found; `npm install` failed with 403)


------
https://chatgpt.com/codex/tasks/task_e_68bdcb8b22d88323969678ae81aeab61