### PR TITLE
chore: rename login page component

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -9,7 +9,7 @@ type BeforeInstallPromptEvent = Event & {
   userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
 };
 
-const LoginPage: React.FC = () => {
+const Login: React.FC = () => {
   const { t } = useTranslation();
 
   // Auth & MFA state
@@ -182,4 +182,4 @@ const LoginPage: React.FC = () => {
   );
 };
 
-export default LoginPage;
+export default Login;

--- a/frontend/src/test/i18n.test.tsx
+++ b/frontend/src/test/i18n.test.tsx
@@ -2,17 +2,17 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
-import LoginPage from '../pages/LoginPage';
+import Login from '../pages/Login';
 import ForgotPasswordPage from '../pages/ForgotPasswordPage';
 import ErrorFallback from '../components/common/ErrorFallback';
 import i18n from '../i18n';
 
 describe('i18n integration', () => {
-  it('switches languages for LoginPage links', async () => {
+  it('switches languages for Login links', async () => {
     render(
       <I18nextProvider i18n={i18n}>
         <MemoryRouter>
-          <LoginPage />
+          <Login />
         </MemoryRouter>
       </I18nextProvider>
     );


### PR DESCRIPTION
## Summary
- rename LoginPage.tsx to Login.tsx and update default export
- fix i18n test imports for Login component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb8cdc108323a0487ea102b012d8