### PR TITLE
refactor: use chat socket in chat input

### DIFF
--- a/frontend/src/components/messaging/ChatInput.tsx
+++ b/frontend/src/components/messaging/ChatInput.tsx
@@ -3,7 +3,7 @@ import { Smile, Paperclip, Send, Image, AtSign, Hash } from 'lucide-react';
 import data from '@emoji-mart/data';
  
 import Picker from '@emoji-mart/react';
-import { getNotificationsSocket } from '../../utils/notificationsSocket';
+import { getChatSocket } from '../../utils/chatSocket';
  
 
 interface ChatInputProps {
@@ -29,12 +29,12 @@ const ChatInput: React.FC<ChatInputProps> = ({
       onSendMessage(message);
  
       try {
-        const s = getNotificationsSocket();
+        const s = getChatSocket();
         if (s.connected) {
-          s.emit('message', message);
+          s.emit('chat:message', message);
         }
       } catch (err) {
-        console.error('Failed to emit message', err);
+        console.error('Failed to emit chat:message', err);
       }
  
       setMessage('');


### PR DESCRIPTION
## Summary
- use dedicated chat socket in ChatInput
- emit `chat:message` via chat socket instead of notifications socket

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdd1545ab08323ba722743e95857ab