### PR TITLE
feat: disable body scroll when mobile sidebar is open

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -44,6 +44,17 @@ const Layout: React.FC<LayoutProps> = ({ children, title }) => {
   };
 
   useEffect(() => {
+    if (sidebarMobileOpen) {
+      document.body.classList.add('overflow-hidden');
+    } else {
+      document.body.classList.remove('overflow-hidden');
+    }
+    return () => {
+      document.body.classList.remove('overflow-hidden');
+    };
+  }, [sidebarMobileOpen]);
+
+  useEffect(() => {
     const handler = (e: Event) => {
       e.preventDefault();
       setInstallEvent(e as BeforeInstallPromptEvent);


### PR DESCRIPTION
## Summary
- lock body scrolling while mobile sidebar is open

## Testing
- `npm test` (fails: Missing script "test")
- `npm install` (fails: 403 Forbidden accessing registry)
- `npm run build` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68bdd1f361b083239359e2dbf88cdf98