### PR TITLE
test: mark chart mocks as virtual modules

### DIFF
--- a/frontend/src/test/analyticsCharts.test.tsx
+++ b/frontend/src/test/analyticsCharts.test.tsx
@@ -11,8 +11,13 @@ vi.mock('../components/common/Button', () => ({ default: ({ children }: any) => 
 vi.mock('../components/common/Card', () => ({ default: ({ children, title }: any) => <div>{title}{children}</div> }));
 vi.mock('../components/common/Badge', () => ({ default: () => <span /> }));
 const lineMock = vi.fn((props: any) => <canvas {...props} />);
-vi.mock('react-chartjs-2', () => ({ Line: (props: any) => lineMock(props) }));
-vi.mock('chart.js', () => ({ CategoryScale: {}, LinearScale: {}, PointElement: {}, LineElement: {}, Tooltip: {}, Legend: {}, Chart: {}, register: () => {} }));
+// TODO: Remove `{ virtual: true }` once chart libraries are installed and imported correctly.
+vi.mock('react-chartjs-2', () => ({ Line: (props: any) => lineMock(props) }), { virtual: true });
+vi.mock(
+  'chart.js',
+  () => ({ CategoryScale: {}, LinearScale: {}, PointElement: {}, LineElement: {}, Tooltip: {}, Legend: {}, Chart: {}, register: () => {} }),
+  { virtual: true },
+);
 
 import Analytics from '../pages/Analytics';
 


### PR DESCRIPTION
## Summary
- mark chart mocks as virtual modules so tests can run without chart.js libs

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npx vitest run src/test/analyticsCharts.test.tsx` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68bee2077c148323b8224de00571773c