### PR TITLE
refactor: configure app routes with auth guard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,27 +1,29 @@
-import { Routes, Route, Navigate } from "react-router-dom";
- import Layout from "./components/layout/Layout";
-import Dashboard from "./pages/Dashboard";
+import { Navigate, Routes, Route } from "react-router-dom";
+import Login from "./pages/Login";
+import DashboardLayout from "./pages/dashboard/DashboardLayout";
+import DashboardHome from "./pages/dashboard/DashboardHome";
 import Analytics from "./pages/Analytics";
-import Departments from "./pages/Departments";
- import NotFound from "./pages/NotFound";
- 
+import RequireAuth from "./components/auth/RequireAuth";
 
 export default function App() {
   return (
-    <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
-      <Layout>
-        <Routes>
-           <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<DashboardLayout />}>
-            <Route index element={<Dashboard />} />
-            <Route path="analytics" element={<Analytics />} />
-          </Route>
-          <Route path="/departments" element={<Departments />} />
-           <Route path="*" element={<NotFound />} />
- 
-        </Routes>
-      </Layout>
-    </div>
- 
+    <Routes>
+      {/* Public */}
+      <Route path="/login" element={<Login />} />
+
+      {/* Private area */}
+      <Route element={<RequireAuth />}>
+        <Route path="/dashboard/*" element={<DashboardLayout />}>
+          <Route index element={<DashboardHome />} />
+          <Route path="analytics" element={<Analytics />} />
+        </Route>
+      </Route>
+
+      {/* Default redirect */}
+      <Route path="/" element={<Navigate to="/login" replace />} />
+
+      {/* 404 */}
+      <Route path="*" element={<div className="p-8">Not Found</div>} />
+    </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- rewrite App.tsx to define public login and protected dashboard routes
- ensure default redirect to login and add 404 route
- verify only DashboardLayout is imported as layout component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee9e748ec832380d790b03890940c