### PR TITLE
chore: remove legacy layout wrapper

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,5 @@
 import { Routes, Route, Navigate } from "react-router-dom";
- import Layout from "./components/layout/Layout";
-import Dashboard from "./pages/Dashboard";
+ import Dashboard from "./pages/Dashboard";
 import Analytics from "./pages/Analytics";
 import Departments from "./pages/Departments";
  import NotFound from "./pages/NotFound";
@@ -9,8 +8,7 @@ import Departments from "./pages/Departments";
 export default function App() {
   return (
     <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
-      <Layout>
-        <Routes>
+              <Routes>
            <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<DashboardLayout />}>
             <Route index element={<Dashboard />} />
@@ -20,7 +18,6 @@ export default function App() {
            <Route path="*" element={<NotFound />} />
  
         </Routes>
-      </Layout>
     </div>
  
   );

--- a/frontend/src/pages/AdminTenants.tsx
+++ b/frontend/src/pages/AdminTenants.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
 import http from '../lib/http';
 import { useToast } from '../context/ToastContext';
@@ -66,8 +65,7 @@ const AdminTenants = () => {
   };
 
   return (
-    <Layout>
-      <div className="max-w-xl mx-auto p-4">
+          <div className="max-w-xl mx-auto p-4">
         <h1 className="text-2xl font-bold mb-4">Tenants</h1>
         <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
           <input
@@ -106,7 +104,6 @@ const AdminTenants = () => {
           ))}
         </ul>
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Layout from '../components/layout/Layout';
 import { Download, Calendar, Filter } from 'lucide-react';
 import Button from '../components/common/Button';
 import Card from '../components/common/Card';
@@ -92,23 +91,18 @@ const Analytics: React.FC = () => {
 
   if (loading) {
     return (
-      <Layout title="Analytics">
-        <p>Loading...</p>
-      </Layout>
+      <p>Loading...</p>
     );
   }
 
   if (error || !data) {
     return (
-      <Layout title="Analytics">
-        <p className="text-red-600">{error || 'No data available'}</p>
-      </Layout>
+      <p className="text-red-600">{error || 'No data available'}</p>
     );
   }
 
   return (
-    <Layout title="Analytics">
-      <div className="space-y-6">
+    <div className="space-y-6">
           <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
             <div className="space-y-1">
               <h2 className="text-2xl font-bold text-neutral-900">Analytics</h2>
@@ -524,7 +518,7 @@ const Analytics: React.FC = () => {
           </div>
         </Card>
       </div>
-    </Layout>
+    </div>
   );
 };
 

--- a/frontend/src/pages/AssetDetails.tsx
+++ b/frontend/src/pages/AssetDetails.tsx
@@ -1,15 +1,12 @@
-import Layout from '../components/layout/Layout';
 import { useParams } from 'react-router-dom';
 
 const AssetDetails = () => {
   const { id } = useParams<{ id: string }>();
 
   return (
-    <Layout title="Asset Details">
-      <div className="p-4">
+          <div className="p-4">
         <p>Details for asset {id}</p>
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/AssetScan.tsx
+++ b/frontend/src/pages/AssetScan.tsx
@@ -1,12 +1,9 @@
-import Layout from '../components/layout/Layout';
 
 const AssetScan = () => {
   return (
-    <Layout title="Scan Asset">
-      <div className="p-4">
+          <div className="p-4">
         <p>Use your device to scan an asset's QR code.</p>
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/AssetsPage.tsx
+++ b/frontend/src/pages/AssetsPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import Layout from '../components/layout/Layout';
 import AssetTable from '../components/assets/AssetTable';
 import AssetModal from '../components/assets/AssetModal';
 import WorkOrderModal from '../components/work-orders/WorkOrderModal';
@@ -98,8 +97,7 @@ const AssetsPage = () => {
   };
 
   return (
-    <Layout title="Assets">
-      <div className="space-y-6">
+          <div className="space-y-6">
         <div className="flex justify-between items-center">
           <h2 className="text-2xl font-bold">Assets</h2>
           <Button variant="primary" onClick={() => { setSelected(null); setModalOpen(true); }}>
@@ -152,7 +150,6 @@ const AssetsPage = () => {
           }}
         />
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/Documentation.tsx
+++ b/frontend/src/pages/Documentation.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import Layout from '../components/layout/Layout';
 import { Search, Book, Video, FileText, MessageCircle, ChevronRight, Plus, Trash2, FolderPlus, Edit2 } from 'lucide-react';
 import Card from '../components/common/Card';
 import Button from '../components/common/Button';
@@ -105,8 +104,7 @@ const Documentation: React.FC = () => {
   };
 
   return (
-    <Layout title="Documentation">
-      <div className="space-y-6">
+          <div className="space-y-6">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
           <div className="space-y-1">
             <h2 className="text-2xl font-bold text-neutral-900">Documentation</h2>
@@ -263,7 +261,6 @@ const Documentation: React.FC = () => {
           </div>
         </Card>
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import Layout from '../components/layout/Layout';
 import { Plus, Search, Download, Upload, AlertTriangle, QrCode } from 'lucide-react';
 import Button from '../components/common/Button';
 import InventoryTable from '../components/inventory/InventoryTable';
@@ -71,8 +70,7 @@ const Inventory: React.FC = () => {
   );
 
   return (
-    <Layout title="Inventory">
-      <div className="space-y-6">
+          <div className="space-y-6">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
           <div className="space-y-1">
             <h2 className="text-2xl font-bold text-neutral-900">Inventory</h2>
@@ -181,7 +179,6 @@ const Inventory: React.FC = () => {
           onScanComplete={(data) => handleOpenModal(null, data)}
         />
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/Maintenance.tsx
+++ b/frontend/src/pages/Maintenance.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Layout from '../components/layout/Layout';
 import { Plus, Search, Calendar, Download, Upload } from 'lucide-react';
 import Button from '../components/common/Button';
 import MaintenanceScheduleTable from '../components/maintenance/MaintenanceSchedule';
@@ -80,8 +79,7 @@ const Maintenance: React.FC = () => {
   };
 
   return (
-    <Layout title="Maintenance">
-      <div className="space-y-6">
+          <div className="space-y-6">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
           <div className="space-y-1">
             <h2 className="text-2xl font-bold text-neutral-900">Maintenance</h2>
@@ -158,7 +156,6 @@ const Maintenance: React.FC = () => {
           }}
         />
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import Layout from '../components/layout/Layout';
 import ChatSidebar from '../components/messaging/ChatSidebar';
 import ChatHeader from '../components/messaging/ChatHeader';
 import MessageList from '../components/messaging/MessageList';
@@ -249,7 +248,7 @@ const Messages: React.FC = () => {
   };
 
   return (
-    <Layout>
+    <>
       <div className="flex h-[calc(100vh-4rem)]">
         <ChatSidebar
           channels={channels}
@@ -310,7 +309,7 @@ const Messages: React.FC = () => {
           <SettingsModal isOpen={settingsOpen} channelId={activeChannel.id} onClose={() => setSettingsOpen(false)} />
         </>
       )}
-    </Layout>
+    </>
   );
 };
 

--- a/frontend/src/pages/NewDepartmentPage.tsx
+++ b/frontend/src/pages/NewDepartmentPage.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Layout from '../components/layout/Layout';
 import { DepartmentForm, type DepartmentPayload } from '../components/departments/forms';
 import { useNavigate } from 'react-router-dom';
 import { createDepartment } from '../api/departments';
@@ -7,8 +6,7 @@ import { createDepartment } from '../api/departments';
 const NewDepartmentPage: React.FC = () => {
   const navigate = useNavigate();
   return (
-    <Layout title="New Department">
-      <div className="max-w-lg mx-auto p-6">
+          <div className="max-w-lg mx-auto p-6">
         <DepartmentForm
           onSubmit={async (dep: DepartmentPayload) => {
             await createDepartment(dep);
@@ -17,7 +15,6 @@ const NewDepartmentPage: React.FC = () => {
           onCancel={() => navigate('/departments')}
         />
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
 import http from '../lib/http';
 import type { NotificationType } from '../types';
@@ -69,8 +68,7 @@ const Notifications = () => {
   };
 
   return (
-    <Layout title="Notifications">
-      <div className="space-y-4">
+          <div className="space-y-4">
         {notifications.map(n => (
           <div
             key={n.id}
@@ -110,7 +108,6 @@ const Notifications = () => {
           </div>
         )}
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/PMTasksPage.tsx
+++ b/frontend/src/pages/PMTasksPage.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
 import PmTaskForm from '../components/maintenance/PmTaskForm';
 import http from '../lib/http';
@@ -34,8 +33,7 @@ const PMTasksPage: React.FC = () => {
   };
 
   return (
-    <Layout title="PM Tasks">
-      <div className="space-y-6 p-6">
+          <div className="space-y-6 p-6">
         <div className="flex justify-between items-center">
           <h1 className="text-2xl font-bold">PM Tasks</h1>
           <Button variant="primary" onClick={() => { setSelected(null); setShowForm(true); }}>
@@ -63,7 +61,6 @@ const PMTasksPage: React.FC = () => {
           </div>
         )}
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import Layout from '../components/layout/Layout';
 import {
  
   Palette,
@@ -81,8 +80,7 @@ const Settings: React.FC = () => {
   };
 
   return (
-    <Layout title="Settings">
-      <div className="space-y-6">
+          <div className="space-y-6">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
           <div className="space-y-1">
             <h2 className="text-2xl font-bold text-neutral-900 dark:text-white">Settings</h2>
@@ -283,7 +281,6 @@ const Settings: React.FC = () => {
           </Card>
         </div>
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/TeamMemberProfile.tsx
+++ b/frontend/src/pages/TeamMemberProfile.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useParams, Link } from 'react-router-dom';
-import Layout from '../components/layout/Layout';
 import Avatar from '../components/common/Avatar';
 import WorkHistoryCard from '../components/teams/WorkHistoryCard';
 import { teamMembers } from '../utils/data';
@@ -12,9 +11,7 @@ const TeamMemberProfile: React.FC = () => {
 
   if (!member) {
     return (
-      <Layout title="Member Not Found">
-        <p className="text-neutral-500">Member not found.</p>
-      </Layout>
+      <p className="text-neutral-500">Member not found.</p>
     );
   }
 
@@ -81,8 +78,7 @@ const TeamMemberProfile: React.FC = () => {
   };
 
   return (
-    <Layout title={member.name}>
-      <div className="space-y-6">
+    <div className="space-y-6">
         <div className="bg-white rounded-lg shadow-sm border border-neutral-200 p-6 flex items-center space-x-4">
           <Avatar name={member.name} src={member.avatar} size="lg" />
           <div>
@@ -124,7 +120,7 @@ const TeamMemberProfile: React.FC = () => {
 
         <WorkHistoryCard metrics={sampleWorkHistory.metrics} recentWork={sampleWorkHistory.recentWork} />
       </div>
-    </Layout>
+    </div>
   );
 };
 

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -1,7 +1,6 @@
  
 import { useEffect, useState } from 'react';
  
-import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
 import TeamTable from '../components/teams/TeamTable';
 import TeamModal from '../components/teams/TeamModal';
@@ -28,8 +27,7 @@ const Teams = () => {
   };
 
   return (
-    <Layout title="Team">
-      <div className="space-y-6">
+          <div className="space-y-6">
          <div className="flex justify-end">
           <Button
             onClick={() => {
@@ -52,7 +50,6 @@ const Teams = () => {
  
         />
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/TimeSheets.tsx
+++ b/frontend/src/pages/TimeSheets.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
 import http from '../lib/http';
 import type { Timesheet } from '../types';
@@ -84,8 +83,7 @@ const TimeSheets: React.FC = () => {
   };
 
   return (
-    <Layout title="Timesheets">
-      <div className="max-w-2xl mx-auto space-y-6">
+          <div className="max-w-2xl mx-auto space-y-6">
         <form
           onSubmit={handleSubmit}
           className="bg-white dark:bg-neutral-800 p-4 rounded-lg shadow space-y-4"
@@ -163,7 +161,6 @@ const TimeSheets: React.FC = () => {
           ))}
         </div>
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/VendorsPage.tsx
+++ b/frontend/src/pages/VendorsPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
 import DataTable from '../components/common/DataTable';
 import VendorModal from '../components/vendors/VendorModal';
@@ -76,8 +75,7 @@ const VendorsPage = () => {
   ];
 
   return (
-    <Layout title="Vendors">
-      <div className="space-y-6">
+          <div className="space-y-6">
         <div className="flex justify-between items-center">
           <h2 className="text-2xl font-bold">Vendors</h2>
           <Button
@@ -98,7 +96,6 @@ const VendorsPage = () => {
           onSave={handleSave}
         />
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/pages/WorkOrders.tsx
+++ b/frontend/src/pages/WorkOrders.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import Layout from '../components/layout/Layout';
 import http from '../lib/http';
 import { addToQueue } from '../utils/offlineQueue';
 import DataTable from '../components/common/DataTable';
@@ -162,8 +161,7 @@ export default function WorkOrders() {
   ];
 
   return (
-    <Layout title="Work Orders">
-      <div className="space-y-6 p-6">
+          <div className="space-y-6 p-6">
         <div className="flex justify-between items-center">
           <h1 className="text-2xl font-bold">Work Orders</h1>
           <Button variant="primary" onClick={() => setShowCreateModal(true)}>
@@ -263,6 +261,5 @@ export default function WorkOrders() {
           }}
         />
       </div>
-    </Layout>
   );
 }

--- a/frontend/src/pm/ConditionRules.tsx
+++ b/frontend/src/pm/ConditionRules.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Layout from '../components/layout/Layout';
 import Button from '../components/common/Button';
 import http from '../lib/http';
 
@@ -58,8 +57,7 @@ const ConditionRules: React.FC = () => {
   };
 
   return (
-    <Layout title="Condition Rules">
-      <div className="p-6 space-y-6">
+          <div className="p-6 space-y-6">
         <div className="flex justify-between items-center">
           <h1 className="text-2xl font-bold">Condition Rules</h1>
           <Button variant="primary" onClick={() => setForm({ ...emptyRule })}>
@@ -142,7 +140,6 @@ const ConditionRules: React.FC = () => {
           </div>
         )}
       </div>
-    </Layout>
   );
 };
 

--- a/frontend/src/test/analyticsCharts.test.tsx
+++ b/frontend/src/test/analyticsCharts.test.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import http from '../lib/http';
 
 vi.mock('../lib/http');
-vi.mock('../components/layout/Layout', () => ({ default: ({ children }: any) => <div>{children}</div> }));
 vi.mock('../components/kpi/KpiWidget', () => ({ default: () => <div /> }));
 vi.mock('../components/kpi/KpiExportButtons', () => ({ default: () => <div /> }));
 vi.mock('../components/common/Button', () => ({ default: ({ children }: any) => <button>{children}</button> }));

--- a/frontend/src/test/dashboardDepartments.test.tsx
+++ b/frontend/src/test/dashboardDepartments.test.tsx
@@ -5,9 +5,6 @@ import { useAuthStore } from '../store/authStore';
 import Dashboard from '../pages/Dashboard';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../components/layout/Layout', () => ({
-  default: ({ children }: any) => <div>{children}</div>,
-}));
 
 const mockSocket = { on: vi.fn(), off: vi.fn() };
 vi.mock('../utils/notificationsSocket', () => ({

--- a/frontend/src/test/settings.test.tsx
+++ b/frontend/src/test/settings.test.tsx
@@ -2,9 +2,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../components/layout/Layout', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
 
 vi.mock('../components/documentation/DocumentUploader', () => ({
   default: () => <div />,

--- a/frontend/src/test/vendorsPage.test.tsx
+++ b/frontend/src/test/vendorsPage.test.tsx
@@ -2,9 +2,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../components/layout/Layout', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
 
 vi.mock('../lib/http', () => ({
   default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },


### PR DESCRIPTION
## Summary
- drop Layout imports from pages and wrap content with simple containers
- clean up tests that mocked Layout
- ensure no components/layout/Layout references remain

## Testing
- `npx vitest run` *(fails: 403 Forbidden for vitest)*
- `rg "components/layout/Layout" src`


------
https://chatgpt.com/codex/tasks/task_e_68beea00533883239eecb3f30924a10d