### PR TITLE
chore: tighten backend type safety and linting

### DIFF
--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json'],
+    tsconfigRootDir: __dirname,
+  },
+  env: {
+    node: true,
+    es2020: true,
+  },
+  plugins: ['@typescript-eslint', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  ignorePatterns: ['dist/', 'node_modules/'],
+};

--- a/backend/.husky/_/husky.sh
+++ b/backend/.husky/_/husky.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# minimal husky shim
+true

--- a/backend/.husky/pre-commit
+++ b/backend/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run typecheck && npm run lint && npm test

--- a/backend/.prettierrc
+++ b/backend/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,9 @@
     "test": "echo \"(no backend tests yet)\" && exit 0",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
-    "swagger:check": "ts-node utils/swagger.ts"
+    "swagger:check": "ts-node utils/swagger.ts",
+    "lint": "eslint . --ext .ts",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@types/helmet": "^0.0.48",
@@ -78,7 +80,14 @@
     "supertest": "^7.1.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@typescript-eslint/eslint-plugin": "^8.10.0",
+    "@typescript-eslint/parser": "^8.10.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "prettier": "^3.3.3",
+    "husky": "^9.1.1"
   },
   "overrides": {
     "rollup": "4.46.2",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -10,7 +10,12 @@
     "outDir": "dist",
     "types": ["node"],
     "typeRoots": ["./node_modules/@types", "./types"],
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true
   },
   "include": [
     "**/*.ts",

--- a/backend/tsconfig.typecheck.json
+++ b/backend/tsconfig.typecheck.json
@@ -2,7 +2,12 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true
   },
   "exclude": [
     "**/*.test.ts",


### PR DESCRIPTION
## Summary
- enable strict TypeScript flags
- add ESLint, Prettier and Husky pre-commit hook

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm run lint` *(fails: ESLint couldn't find configuration file due to v9 requirement)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfc8c88c7483239edc87386b35ef29