### PR TITLE
feat: add integration hub

### DIFF
--- a/backend/integrations/graphql.ts
+++ b/backend/integrations/graphql.ts
@@ -1,0 +1,21 @@
+import IntegrationHook from '../models/IntegrationHook';
+import { registerHook } from '../services/integrationHub';
+
+export const schema = `
+  type IntegrationHook { id: ID! name: String! type: String! url: String events: [String!]! }
+  type Query { integrationHooks: [IntegrationHook!]! }
+  input HookInput { name: String! type: String! url: String events: [String!]! }
+  type Mutation { registerHook(input: HookInput!): IntegrationHook! }
+`;
+
+export async function execute(query: string, variables?: any) {
+  if (query.includes('integrationHooks')) {
+    const hooks = await IntegrationHook.find();
+    return { data: { integrationHooks: hooks } };
+  }
+  if (query.includes('registerHook')) {
+    const hook = await registerHook(variables.input);
+    return { data: { registerHook: hook } };
+  }
+  return { errors: ['Unknown query'] };
+}

--- a/backend/models/IntegrationHook.ts
+++ b/backend/models/IntegrationHook.ts
@@ -1,0 +1,27 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export interface IntegrationHookDocument extends Document {
+  name: string;
+  type: 'webhook' | 'sap' | 'powerbi';
+  url?: string;
+  events: string[];
+  createdAt: Date;
+}
+
+const integrationHookSchema = new Schema<IntegrationHookDocument>({
+  name: { type: String, required: true },
+  type: { type: String, required: true, enum: ['webhook', 'sap', 'powerbi'] },
+  url: { type: String },
+  events: { type: [String], default: [] },
+  createdAt: { type: Date, default: Date.now },
+});
+
+integrationHookSchema.index({ type: 1, name: 1 });
+
+const IntegrationHook: Model<IntegrationHookDocument> =
+  mongoose.model<IntegrationHookDocument>(
+    'IntegrationHook',
+    integrationHookSchema,
+  );
+
+export default IntegrationHook;

--- a/backend/routes/IntegrationRoutes.ts
+++ b/backend/routes/IntegrationRoutes.ts
@@ -1,0 +1,23 @@
+import { Router } from 'express';
+import IntegrationHook from '../models/IntegrationHook';
+import { dispatchEvent, registerHook } from '../services/integrationHub';
+
+const router = Router();
+
+router.get('/hooks', async (_req, res) => {
+  const hooks = await IntegrationHook.find();
+  res.json(hooks);
+});
+
+router.post('/hooks', async (req, res) => {
+  const hook = await registerHook(req.body);
+  res.status(201).json(hook);
+});
+
+router.post('/dispatch', async (req, res) => {
+  const { event, payload } = req.body;
+  await dispatchEvent(event, payload);
+  res.status(202).json({ status: 'queued' });
+});
+
+export default router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -29,6 +29,7 @@ import teamRoutes from "./routes/TeamRoutes";
 import notificationsRoutes from "./routes/notifications";
 import TenantRoutes from "./routes/TenantRoutes";
 import webhooksRoutes from "./routes/webhooksRoutes";
+import IntegrationRoutes from "./routes/IntegrationRoutes";
 import ThemeRoutes from "./routes/ThemeRoutes";
 import chatRoutes from "./routes/ChatRoutes";
 import requestPortalRoutes from "./routes/requestPortal";
@@ -151,6 +152,7 @@ app.use("/api/chat", chatRoutes);
 app.use("/api/hooks", webhooksRoutes);
 app.use("/api/webhooks", webhooksRoutes);
 app.use("/api/calendar", calendarRoutes);
+app.use("/api/integrations", IntegrationRoutes);
 
 app.use("/api/summary", summaryRoutes);
 

--- a/backend/services/integrationHub.ts
+++ b/backend/services/integrationHub.ts
@@ -1,0 +1,37 @@
+import IntegrationHook from '../models/IntegrationHook';
+
+export async function registerHook(data: {
+  name: string;
+  type: 'webhook' | 'sap' | 'powerbi';
+  url?: string;
+  events: string[];
+}) {
+  return IntegrationHook.create(data);
+}
+
+export async function dispatchEvent(event: string, payload: unknown) {
+  const hooks = await IntegrationHook.find({ events: event });
+  for (const hook of hooks) {
+    if (hook.type === 'webhook' && hook.url) {
+      await fetch(hook.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ event, payload }),
+      });
+    } else if (hook.type === 'sap') {
+      await sendToSap(event, payload);
+    } else if (hook.type === 'powerbi') {
+      await sendToPowerBi(event, payload);
+    }
+  }
+}
+
+export async function sendToSap(event: string, payload: unknown) {
+  // stub connector
+  return { event, payload };
+}
+
+export async function sendToPowerBi(event: string, payload: unknown) {
+  // stub connector
+  return { event, payload };
+}

--- a/backend/tests/integrationHub.test.ts
+++ b/backend/tests/integrationHub.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect, vi } from 'vitest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { registerHook, dispatchEvent } from '../services/integrationHub';
+import { execute } from '../integrations/graphql';
+
+let mongo: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create({ binary: { version: '7.0.3' } });
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+});
+
+describe('integration hub', () => {
+  it('dispatches webhook events', async () => {
+    await registerHook({ name: 'w', type: 'webhook', url: 'http://example.com', events: ['ping'] });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dispatchEvent('ping', { a: 1 });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    vi.unstubAllGlobals();
+  });
+
+  it('queries hooks via GraphQL', async () => {
+    await registerHook({ name: 'w', type: 'webhook', url: 'http://x', events: ['ping'] });
+    const res: any = await execute('{ integrationHooks { name type } }');
+    expect(res.data.integrationHooks[0].name).toBe('w');
+  });
+});

--- a/frontend/src/integrations/HookForm.tsx
+++ b/frontend/src/integrations/HookForm.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onCreated: (hook: any) => void;
+}
+
+export default function HookForm({ onCreated }: Props) {
+  const [name, setName] = useState('');
+  const [url, setUrl] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/integrations/hooks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, type: 'webhook', url, events: ['ping'] }),
+    });
+    const data = await res.json();
+    onCreated(data);
+    setName('');
+    setUrl('');
+  };
+
+  return (
+    <form onSubmit={submit}>
+      <input placeholder="name" value={name} onChange={(e) => setName(e.target.value)} />
+      <input placeholder="url" value={url} onChange={(e) => setUrl(e.target.value)} />
+      <button type="submit">Register</button>
+    </form>
+  );
+}

--- a/frontend/src/integrations/Integrations.tsx
+++ b/frontend/src/integrations/Integrations.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import HookForm from './HookForm';
+
+interface Hook {
+  _id: string;
+  name: string;
+  type: string;
+}
+
+export default function Integrations() {
+  const [hooks, setHooks] = useState<Hook[]>([]);
+
+  useEffect(() => {
+    fetch('/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: '{ integrationHooks { _id name type } }' }),
+    })
+      .then((res) => res.json())
+      .then((res) => setHooks(res.data.integrationHooks));
+  }, []);
+
+  return (
+    <div>
+      <h1>Integrations</h1>
+      <HookForm onCreated={(hook) => setHooks([...hooks, hook])} />
+      <ul>
+        {hooks.map((h) => (
+          <li key={h._id}>
+            {h.name} - {h.type}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/test/integrations.test.tsx
+++ b/frontend/src/test/integrations.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Integrations from '../integrations/Integrations';
+
+describe('Integrations page', () => {
+  it('registers a hook', async () => {
+    const fetchMock = vi
+      .fn()
+      // first call for initial GraphQL fetch
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ data: { integrationHooks: [] } }) })
+      // second call for registering hook
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ _id: '1', name: 'Test', type: 'webhook' }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<Integrations />);
+
+    fireEvent.change(screen.getByPlaceholderText('name'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('url'), { target: { value: 'http://example.com' } });
+    fireEvent.click(screen.getByText('Register'));
+
+    await screen.findByText('Test - webhook');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
## Summary
- add IntegrationHook model for registering webhooks/connectors
- expose REST, GraphQL, and service layer for integration hub
- add basic UI for registering hooks with tests

## Testing
- `npm test` (backend)
- `node tests/integrationHub.test.ts` (backend) *(fails: Unknown file extension ".ts")*
- `npx vitest run frontend/src/test/integrations.test.tsx` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc8cbdcc48323a7182813ba8a5e79