### PR TITLE
feat: handle offline sync conflicts with diff UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@playwright/test": "^1.48.2",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^20.11.30",
     "@types/react": "^18.2.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './src/test',
+  projects: [{ name: 'api', use: {} }],
+});

--- a/frontend/src/components/offline/ConflictResolver.tsx
+++ b/frontend/src/components/offline/ConflictResolver.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+import type { SyncConflict } from '../../utils/offlineQueue';
+
+type Props = {
+  conflict: SyncConflict | null;
+  onResolve: (choice: 'local' | 'server') => void;
+  onClose: () => void;
+};
+
+export default function ConflictResolver({ conflict, onResolve, onClose }: Props) {
+  const ref = useRef<HTMLDialogElement>(null);
+  useEffect(() => {
+    if (conflict) {
+      ref.current?.showModal();
+    } else {
+      ref.current?.close();
+    }
+  }, [conflict]);
+
+  if (!conflict) return null;
+
+  return (
+    <dialog
+      ref={ref}
+      className="rounded-xl w-[600px] max-w-[95vw] p-0 backdrop:bg-black/30"
+    >
+      <div className="p-6 space-y-4">
+        <h3 className="text-lg font-semibold">Sync Conflict</h3>
+        <p className="text-sm text-neutral-600">
+          Local changes conflict with the server. Choose which version to keep.
+        </p>
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left">Field</th>
+              <th className="text-left">Local</th>
+              <th className="text-left">Server</th>
+            </tr>
+          </thead>
+          <tbody>
+            {conflict.diffs.map((d) => (
+              <tr key={d.field}>
+                <td className="font-medium pr-2">{d.field}</td>
+                <td className="pr-2">{String(d.local ?? '')}</td>
+                <td>{String(d.server ?? '')}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            className="rounded px-3 py-2 border hover:bg-neutral-100"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            className="rounded px-3 py-2 bg-neutral-200 hover:bg-neutral-300"
+            onClick={() => onResolve('server')}
+          >
+            Use Server
+          </button>
+          <button
+            className="rounded px-3 py-2 bg-blue-600 text-white hover:bg-blue-700"
+            onClick={() => onResolve('local')}
+          >
+            Keep Local
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/src/test/offlineConflict.pw.test.ts
+++ b/frontend/src/test/offlineConflict.pw.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import {
+  addToQueue,
+  flushQueue,
+  onSyncConflict,
+  setHttpClient,
+} from '../utils/offlineQueue';
+
+// Simulate a conflict response followed by server data
+const mockClient = async (args: { method: string; url: string; data?: any }) => {
+  if (args.method !== 'get') {
+    const err: any = new Error('conflict');
+    err.response = { status: 409 };
+    throw err;
+  }
+  return { data: { id: '1', name: 'Server' } };
+};
+
+test('emits conflict with diff info', async () => {
+  setHttpClient(mockClient);
+  addToQueue({ method: 'put', url: '/assets/1', data: { id: '1', name: 'Local' } });
+  const conflicts: any[] = [];
+  onSyncConflict((c) => conflicts.push(c));
+  await flushQueue(false);
+  expect(conflicts).toHaveLength(1);
+  expect(conflicts[0].diffs).toEqual([
+    { field: 'name', local: 'Local', server: 'Server' },
+  ]);
+});


### PR DESCRIPTION
## Summary
- capture server vs local diffs on offline sync conflicts
- add ConflictResolver modal to choose server or local changes
- surface conflict UI from Work Orders and Assets pages
- add Playwright test for conflict diff handling

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc8d049248323b3e70ee046365675