### PR TITLE
Use auth context in RequireAuth

### DIFF
--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,8 +1,11 @@
 import { Navigate, Outlet, useLocation } from "react-router-dom";
-// TODO: wire to real auth
+import { useAuth } from "../../context/AuthContext";
+
 export default function RequireAuth() {
-  const user = true; // replace with real auth check
+  const { user, loading } = useAuth();
   const location = useLocation();
+
+  if (loading) return null;
   if (!user) return <Navigate to="/login" replace state={{ from: location }} />;
   return <Outlet />;
 }


### PR DESCRIPTION
## Summary
- use AuthContext to verify authenticated user in RequireAuth component
- redirect unauthenticated users to login while preserving original location

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bfd8ff3c488323b35e4e39549d3ac4