### PR TITLE
Implement chat models and routes

### DIFF
--- a/backend/controllers/ChatController.ts
+++ b/backend/controllers/ChatController.ts
@@ -1,57 +1,242 @@
-import { Request, Response } from 'express';
-
-// These controller methods are placeholders. The actual implementations
-// will be provided by the application logic. Each handler currently
-// returns a 501 Not Implemented response.
+import { AuthedRequest, AuthedRequestHandler } from '../types/http';
+import Channel from '../models/Channel';
+import ChatMessage from '../models/ChatMessage';
 
 // Channel controllers
-export const getChannels = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const getChannels: AuthedRequestHandler = async (
+  req: AuthedRequest,
+  res,
+  next
+) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    const channels = await Channel.find({
+      tenantId: req.tenantId,
+      isDirect: false,
+      ...(userId ? { members: userId } : {}),
+    }).sort({ name: 1 });
+    return res.json(channels);
+  } catch (err) {
+    return next(err);
+  }
 };
 
-export const createChannel = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const createChannel: AuthedRequestHandler<unknown, any, { name: string; description?: string; members?: string[] }> = async (
+  req: AuthedRequest<unknown, any, { name: string; description?: string; members?: string[] }>,
+  res,
+  next
+) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    const { name, description, members = [] } = req.body;
+    if (!userId) return res.status(400).json({ message: 'User required' });
+    const channel = await Channel.create({
+      name,
+      description,
+      members: Array.from(new Set([userId, ...members])),
+      createdBy: userId,
+      tenantId: req.tenantId,
+      isDirect: false,
+    });
+    return res.status(201).json(channel);
+  } catch (err) {
+    return next(err);
+  }
 };
 
-export const deleteChannel = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const deleteChannel: AuthedRequestHandler<{ channelId: string }> = async (
+  req: AuthedRequest<{ channelId: string }>,
+  res,
+  next
+) => {
+  try {
+    await Channel.findOneAndDelete({
+      _id: req.params.channelId,
+      tenantId: req.tenantId,
+      isDirect: false,
+    });
+    await ChatMessage.deleteMany({ channelId: req.params.channelId });
+    return res.status(204).end();
+  } catch (err) {
+    return next(err);
+  }
 };
 
-export const getChannelMessages = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const getChannelMessages: AuthedRequestHandler<{ channelId: string }> = async (
+  req: AuthedRequest<{ channelId: string }>,
+  res,
+  next
+) => {
+  try {
+    const messages = await ChatMessage.find({ channelId: req.params.channelId }).sort({ createdAt: 1 });
+    return res.json(messages);
+  } catch (err) {
+    return next(err);
+  }
 };
 
-export const sendChannelMessage = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const sendChannelMessage: AuthedRequestHandler<{ channelId: string }, any, { content: string }> = async (
+  req: AuthedRequest<{ channelId: string }, any, { content: string }>,
+  res,
+  next
+) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    const { content } = req.body;
+    const message = await ChatMessage.create({
+      channelId: req.params.channelId,
+      sender: userId,
+      content,
+    });
+    return res.status(201).json(message);
+  } catch (err) {
+    return next(err);
+  }
 };
 
 // Message controllers shared between channel and direct messages
-export const updateMessage = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const updateMessage: AuthedRequestHandler<{ channelId: string; messageId: string }, any, { content: string }> = async (
+  req: AuthedRequest<{ channelId: string; messageId: string }, any, { content: string }>,
+  res,
+  next
+) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    const message = await ChatMessage.findOneAndUpdate(
+      { _id: req.params.messageId, sender: userId },
+      { content: req.body.content, updatedAt: new Date() },
+      { new: true }
+    );
+    if (!message) return res.status(404).end();
+    return res.json(message);
+  } catch (err) {
+    return next(err);
+  }
 };
 
-export const deleteMessage = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const deleteMessage: AuthedRequestHandler<{ channelId: string; messageId: string }> = async (
+  req: AuthedRequest<{ channelId: string; messageId: string }>,
+  res,
+  next
+) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    await ChatMessage.findOneAndDelete({ _id: req.params.messageId, sender: userId });
+    return res.status(204).end();
+  } catch (err) {
+    return next(err);
+  }
 };
 
 // Direct message controllers
-export const getDirectMessages = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const getDirectMessages: AuthedRequestHandler = async (
+  req: AuthedRequest,
+  res,
+  next
+) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    const channels = await Channel.find({
+      tenantId: req.tenantId,
+      isDirect: true,
+      members: userId,
+    });
+    return res.json(channels);
+  } catch (err) {
+    return next(err);
+  }
 };
 
-export const createDirectMessage = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const createDirectMessage: AuthedRequestHandler<unknown, any, { userId: string }> = async (
+  req: AuthedRequest<unknown, any, { userId: string }>,
+  res,
+  next
+) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    const otherId = req.body.userId;
+    const members = [userId, otherId];
+    const existing = await Channel.findOne({
+      tenantId: req.tenantId,
+      isDirect: true,
+      members: { $all: members },
+    });
+    if (existing) return res.json(existing);
+    const channel = await Channel.create({
+      name: '',
+      isDirect: true,
+      members,
+      createdBy: userId!,
+      tenantId: req.tenantId,
+    });
+    return res.status(201).json(channel);
+  } catch (err) {
+    return next(err);
+  }
 };
 
-export const deleteDirectMessage = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const deleteDirectMessage: AuthedRequestHandler<{ conversationId: string }> = async (
+  req: AuthedRequest<{ conversationId: string }>,
+  res,
+  next
+) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    await Channel.findOneAndDelete({
+      _id: req.params.conversationId,
+      tenantId: req.tenantId,
+      isDirect: true,
+      members: userId,
+    });
+    await ChatMessage.deleteMany({ channelId: req.params.conversationId });
+    return res.status(204).end();
+  } catch (err) {
+    return next(err);
+  }
 };
 
-export const getDirectMessagesForUser = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const getDirectMessagesForUser: AuthedRequestHandler<{ conversationId: string }> = async (
+  req: AuthedRequest<{ conversationId: string }>,
+  res,
+  next
+) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    const channel = await Channel.findOne({
+      _id: req.params.conversationId,
+      tenantId: req.tenantId,
+      isDirect: true,
+      members: userId,
+    });
+    if (!channel) return res.status(404).end();
+    const messages = await ChatMessage.find({ channelId: channel._id }).sort({ createdAt: 1 });
+    return res.json(messages);
+  } catch (err) {
+    return next(err);
+  }
 };
 
-export const sendDirectMessage = (_req: Request, res: Response) => {
-  res.status(501).json({ message: 'Not implemented' });
+export const sendDirectMessage: AuthedRequestHandler<{ conversationId: string }, any, { content: string }> = async (
+  req: AuthedRequest<{ conversationId: string }, any, { content: string }>,
+  res,
+  next
+) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    const channel = await Channel.findOne({
+      _id: req.params.conversationId,
+      tenantId: req.tenantId,
+      isDirect: true,
+      members: userId,
+    });
+    if (!channel) return res.status(404).end();
+    const message = await ChatMessage.create({
+      channelId: channel._id,
+      sender: userId!,
+      content: req.body.content,
+    });
+    return res.status(201).json(message);
+  } catch (err) {
+    return next(err);
+  }
 };
-

--- a/backend/models/Channel.ts
+++ b/backend/models/Channel.ts
@@ -1,0 +1,31 @@
+import mongoose, { Schema, Document, Model, Types } from 'mongoose';
+
+export interface ChannelDocument extends Document {
+  _id: Types.ObjectId;
+  name: string;
+  description?: string;
+  isDirect: boolean;
+  members: Types.ObjectId[];
+  createdBy: Types.ObjectId;
+  tenantId: Types.ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const channelSchema = new Schema<ChannelDocument>(
+  {
+    name: { type: String, required: true },
+    description: { type: String },
+    isDirect: { type: Boolean, default: false },
+    members: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+    createdBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    tenantId: { type: Schema.Types.ObjectId, ref: 'Tenant', required: true },
+  },
+  { timestamps: true }
+);
+
+channelSchema.index({ tenantId: 1 });
+
+const Channel: Model<ChannelDocument> = mongoose.model<ChannelDocument>('Channel', channelSchema);
+
+export default Channel;

--- a/backend/models/ChatMessage.ts
+++ b/backend/models/ChatMessage.ts
@@ -1,0 +1,25 @@
+import mongoose, { Schema, Document, Model, Types } from 'mongoose';
+
+export interface ChatMessageDocument extends Document {
+  _id: Types.ObjectId;
+  channelId: Types.ObjectId;
+  sender: Types.ObjectId;
+  content: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const chatMessageSchema = new Schema<ChatMessageDocument>(
+  {
+    channelId: { type: Schema.Types.ObjectId, ref: 'Channel', required: true },
+    sender: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    content: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+chatMessageSchema.index({ channelId: 1, createdAt: 1 });
+
+const ChatMessage: Model<ChatMessageDocument> = mongoose.model<ChatMessageDocument>('ChatMessage', chatMessageSchema);
+
+export default ChatMessage;

--- a/backend/routes/ChatRoutes.ts
+++ b/backend/routes/ChatRoutes.ts
@@ -1,10 +1,44 @@
 import express from 'express';
+import {
+  getChannels,
+  createChannel,
+  deleteChannel,
+  getChannelMessages,
+  sendChannelMessage,
+  updateMessage,
+  deleteMessage,
+  getDirectMessages,
+  createDirectMessage,
+  deleteDirectMessage,
+  getDirectMessagesForUser,
+  sendDirectMessage,
+} from '../controllers/ChatController';
+import { requireAuth } from '../middleware/authMiddleware';
 
 const router = express.Router();
 
-router.get('/', (_req, res) => {
-  res.json({ message: 'Chat route placeholder' });
-});
+// All chat routes require authentication
+router.use(requireAuth);
+
+// Channel management
+router.get('/channels', getChannels);
+router.post('/channels', createChannel);
+router.delete('/channels/:channelId', deleteChannel);
+
+// Channel messages
+router.get('/channels/:channelId/messages', getChannelMessages);
+router.post('/channels/:channelId/messages', sendChannelMessage);
+router.put('/channels/:channelId/messages/:messageId', updateMessage);
+router.delete('/channels/:channelId/messages/:messageId', deleteMessage);
+
+// Direct messages
+router.get('/dm', getDirectMessages);
+router.post('/dm', createDirectMessage);
+router.delete('/dm/:conversationId', deleteDirectMessage);
+
+router.get('/dm/:conversationId/messages', getDirectMessagesForUser);
+router.post('/dm/:conversationId/messages', sendDirectMessage);
+router.put('/dm/:conversationId/messages/:messageId', updateMessage);
+router.delete('/dm/:conversationId/messages/:messageId', deleteMessage);
 
 export default router;
-


### PR DESCRIPTION
## Summary
- add MongoDB models for chat channels and messages
- implement channel and direct message CRUD in controller
- secure chat routes and expose RESTful endpoints

## Testing
- `npm test --prefix backend`
- `npm run typecheck --prefix backend` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68bfd9034f6c8323829902fc97f528ca