### PR TITLE
test: import afterEach from vitest

### DIFF
--- a/frontend/src/test/navigationStore.test.ts
+++ b/frontend/src/test/navigationStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useNavigationStore } from '../store/navigationStore';
 
 beforeEach(() => {
@@ -26,7 +26,3 @@ describe('navigation store', () => {
     expect(useNavigationStore.getState().sidebarOrder).toEqual(['c', 'a', 'b']);
   });
 });
-
-function afterEach(_arg0: () => void) {
-  throw new Error('Function not implemented.');
-}


### PR DESCRIPTION
## Summary
- import `afterEach` from Vitest and drop stub

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe066914c8323a236e55ecda7666a