### PR TITLE
feat: add health probes to deployments

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,6 +27,14 @@ spec:
                   key: JWT_SECRET
             - name: CORS_ORIGIN
               value: http://workpro.local
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 5010
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 5010
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -47,3 +55,11 @@ spec:
           image: workpro-frontend:latest
           ports:
             - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80


### PR DESCRIPTION
## Summary
- add liveness and readiness probes for backend at /api/health on port 5010
- add liveness and readiness probes for frontend at / on port 80

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script: "test"*
- `kubectl apply -f k8s/deployment.yaml` *(fails: command not found)*
- `kubectl get pods` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe06901ec8323a1fb0d44ef3d0811