### PR TITLE
Wire up department actions

### DIFF
--- a/frontend/src/api/departments.ts
+++ b/frontend/src/api/departments.ts
@@ -15,3 +15,6 @@ export async function listDepartments(): Promise<Department[]> {
     return [];
   }
 }
+
+export const deleteDepartment = (id: string) =>
+  http.delete<void>(`/departments/${id}`).then((res) => res.data);

--- a/frontend/src/pages/Departments.tsx
+++ b/frontend/src/pages/Departments.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { listDepartments } from "../api/departments";
+import { useNavigate } from "react-router-dom";
+import { listDepartments, deleteDepartment } from "../api/departments";
 
 type Department = { _id: string; name: string; description?: string };
 
@@ -7,6 +8,17 @@ export default function Departments() {
   const [items, setItems] = useState<Department[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm("Delete this department?")) return;
+    try {
+      await deleteDepartment(id);
+      setItems((prev) => prev.filter((d) => d._id !== id));
+    } catch (e) {
+      setError((e as Error)?.message ?? "Failed to delete");
+    }
+  };
 
   useEffect(() => {
     setLoading(true);
@@ -36,8 +48,18 @@ export default function Departments() {
                 {d.description && <div className="text-xs text-neutral-500">{d.description}</div>}
               </div>
               <div className="space-x-2">
-                <button className="rounded border px-2 py-1 text-sm">Edit</button>
-                <button className="rounded border px-2 py-1 text-sm">Delete</button>
+                <button
+                  className="rounded border px-2 py-1 text-sm"
+                  onClick={() => navigate(`/departments/${d._id}/edit`)}
+                >
+                  Edit
+                </button>
+                <button
+                  className="rounded border px-2 py-1 text-sm"
+                  onClick={() => handleDelete(d._id)}
+                >
+                  Delete
+                </button>
               </div>
             </li>
           ))}


### PR DESCRIPTION
## Summary
- Enable Department list page to navigate to edit pages and delete entries with confirmation
- Add API helper for deleting departments

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bfee6a159c83238691091a16fd49d6