### PR TITLE
Surface department API errors to callers

### DIFF
--- a/frontend/src/api/departments.ts
+++ b/frontend/src/api/departments.ts
@@ -7,11 +7,6 @@ export type Department = {
 };
 
 export async function listDepartments(): Promise<Department[]> {
-  try {
-    const { data } = await http.get<Department[]>('/departments');
-    return data;
-  } catch (e) {
-    // Return empty list if API not ready yet (so UI still renders)
-    return [];
-  }
+  const { data } = await http.get<Department[]>('/departments');
+  return data;
 }

--- a/frontend/src/components/assets/AssetModal.tsx
+++ b/frontend/src/components/assets/AssetModal.tsx
@@ -71,8 +71,9 @@ const AssetModal: React.FC<AssetModalProps> = ({
   useEffect(() => {
     fetchDepartments().catch((err) => {
       console.error("Failed to load departments", err);
+      addToast("Failed to load departments", "error");
     });
-  }, [fetchDepartments]);
+  }, [fetchDepartments, addToast]);
 
   useEffect(() => {
     if (!departmentId) {

--- a/frontend/src/components/teams/TeamModal.tsx
+++ b/frontend/src/components/teams/TeamModal.tsx
@@ -68,8 +68,13 @@ const TeamModal: React.FC<TeamModalProps> = ({ isOpen, onClose, member }) => {
   }, [role, setValue]);
 
   const fetchDepartmentOptions = async (q: string) => {
-    const list = await fetchDepartments();
-    return list.filter((d) => d.name.toLowerCase().includes(q.toLowerCase()));
+    try {
+      const list = await fetchDepartments();
+      return list.filter((d) => d.name.toLowerCase().includes(q.toLowerCase()));
+    } catch (e) {
+      addToast("Failed to load departments", "error");
+      return [];
+    }
   };
 
   const onSubmit = handleSubmit(async (data) => {

--- a/frontend/src/components/work-orders/WorkOrderForm.tsx
+++ b/frontend/src/components/work-orders/WorkOrderForm.tsx
@@ -63,6 +63,7 @@ const WorkOrderForm: React.FC<WorkOrderFormProps> = ({ workOrder, onSuccess }) =
         await fetchDepartments();
       } catch (err) {
         console.error('Failed to load departments', err);
+        addToast('Failed to load departments', 'error');
       }
     };
     fetchData();

--- a/frontend/src/components/work-orders/WorkOrderModal.tsx
+++ b/frontend/src/components/work-orders/WorkOrderModal.tsx
@@ -1,5 +1,5 @@
    
-import React, { useState, useRef, useEffect } from "react";   
+import React, { useState, useRef, useEffect } from "react";
 import { useForm, Controller } from "react-hook-form";
 import SignaturePad from "react-signature-canvas";
 import { useDropzone } from "react-dropzone";
@@ -10,6 +10,7 @@ import type { WorkOrder, Department } from "../../types";
 import http from "../../lib/http";
 import { searchAssets } from "../../api/search";
 import { useDepartmentStore } from "../../store/departmentStore";
+import { useToast } from "../../context/ToastContext";
    
 
 interface WorkOrderModalProps {
@@ -33,6 +34,7 @@ const WorkOrderModal: React.FC<WorkOrderModalProps> = ({
   const departments = useDepartmentStore((s) => s.departments);
   const fetchDepartments = useDepartmentStore((s) => s.fetchDepartments);
   const [loadingDeps, setLoadingDeps] = useState(true);
+  const { addToast } = useToast();
   
   const {
     register,
@@ -69,6 +71,7 @@ const WorkOrderModal: React.FC<WorkOrderModalProps> = ({
     fetchDepartments()
       .catch((err) => {
         console.error("Failed to load departments", err);
+        addToast("Failed to load departments", "error");
       })
       .finally(() => setLoadingDeps(false));
   }, [fetchDepartments]);

--- a/frontend/src/pages/Departments.tsx
+++ b/frontend/src/pages/Departments.tsx
@@ -12,7 +12,11 @@ export default function Departments() {
     setLoading(true);
     listDepartments()
       .then(setItems)
-      .catch((e) => setError(e?.message ?? "Failed to load"))
+      .catch((e) =>
+        setError(
+          e instanceof Error ? e.message : "Failed to load departments",
+        ),
+      )
       .finally(() => setLoading(false));
   }, []);
 


### PR DESCRIPTION
## Summary
- remove empty-array fallback from department list API
- show department loading errors in pages and forms

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)
- `npm install` (fails: 403 Forbidden from registry)


------
https://chatgpt.com/codex/tasks/task_e_68bfee6c34b08323ab05bbf4159125ed