### PR TITLE
Add navigation for new department button

### DIFF
--- a/frontend/src/pages/Departments.tsx
+++ b/frontend/src/pages/Departments.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { listDepartments } from "../api/departments";
 
 type Department = { _id: string; name: string; description?: string };
@@ -7,6 +8,7 @@ export default function Departments() {
   const [items, setItems] = useState<Department[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     setLoading(true);
@@ -20,7 +22,11 @@ export default function Departments() {
     <div>
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-xl font-semibold">Departments</h1>
-        <button className="rounded bg-neutral-900 text-white px-3 py-1 text-sm dark:bg-white dark:text-neutral-900">
+        <button
+          type="button"
+          onClick={() => navigate("/departments/new")}
+          className="rounded bg-neutral-900 text-white px-3 py-1 text-sm dark:bg-white dark:text-neutral-900"
+        >
           Add Department
         </button>
       </div>


### PR DESCRIPTION
## Summary
- use React Router's `useNavigate` to handle Add Department button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found; dependencies installation failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c023ce023883239ac80cbe995e4240