### PR TITLE
Surface department API failures to users

### DIFF
--- a/frontend/src/api/departments.ts
+++ b/frontend/src/api/departments.ts
@@ -7,11 +7,6 @@ export type Department = {
 };
 
 export async function listDepartments(): Promise<Department[]> {
-  try {
-    const { data } = await http.get<Department[]>('/departments');
-    return data;
-  } catch (e) {
-    // Return empty list if API not ready yet (so UI still renders)
-    return [];
-  }
+  const { data } = await http.get<Department[]>('/departments');
+  return data;
 }

--- a/frontend/src/components/assets/AssetModal.tsx
+++ b/frontend/src/components/assets/AssetModal.tsx
@@ -59,6 +59,7 @@ const AssetModal: React.FC<AssetModalProps> = ({
   const lines = departmentId ? linesMap[departmentId] || [] : [];
   const stations = lineId ? stationsMap[lineId] || [] : [];
   const [error, setError] = useState<string | null>(null);
+  const { addToast } = useToast();
 
   useEffect(() => {
     reset(asset || defaultAssetState);
@@ -71,8 +72,9 @@ const AssetModal: React.FC<AssetModalProps> = ({
   useEffect(() => {
     fetchDepartments().catch((err) => {
       console.error("Failed to load departments", err);
+      addToast("Failed to load departments", "error");
     });
-  }, [fetchDepartments]);
+  }, [fetchDepartments, addToast]);
 
   useEffect(() => {
     if (!departmentId) {
@@ -82,8 +84,9 @@ const AssetModal: React.FC<AssetModalProps> = ({
     }
     fetchLines(departmentId).catch((err) => {
       console.error("Failed to load lines", err);
+      addToast("Failed to load lines", "error");
     });
-  }, [departmentId, fetchLines]);
+  }, [departmentId, fetchLines, addToast]);
 
   useEffect(() => {
     if (!departmentId || !lineId) {
@@ -92,8 +95,9 @@ const AssetModal: React.FC<AssetModalProps> = ({
     }
     fetchStations(departmentId, lineId).catch((err) => {
       console.error("Failed to load stations", err);
+      addToast("Failed to load stations", "error");
     });
-  }, [departmentId, lineId, fetchStations]);
+  }, [departmentId, lineId, fetchStations, addToast]);
 
   const { getRootProps, getInputProps } = useDropzone({
     accept: {
@@ -104,8 +108,6 @@ const AssetModal: React.FC<AssetModalProps> = ({
       setFiles([...files, ...acceptedFiles]);
     },
   });
-
-  const { addToast } = useToast();
 
   const onSubmit = async (data: any) => {
     setError(null);

--- a/frontend/src/components/assets/HierarchyView.tsx
+++ b/frontend/src/components/assets/HierarchyView.tsx
@@ -2,21 +2,28 @@ import React, { useEffect, useState } from 'react';
 import http from '../../lib/http';
 import type { DepartmentHierarchy } from '../../types';
 import { useDepartmentStore } from '../../store/departmentStore';
+import { useToast } from '../../context/ToastContext';
 
 const HierarchyView: React.FC = () => {
   const [data, setData] = useState<DepartmentHierarchy[]>([]);
   const refreshCache = useDepartmentStore((s) => s.refreshCache);
+  const { addToast } = useToast();
 
   const fetchHierarchy = async () => {
-    await refreshCache();
-    const departments = useDepartmentStore.getState().departments;
-    const detailed = await Promise.all(
-      departments.map(async (dep) => {
-        const hRes = await http.get(`/departments/${dep.id}/hierarchy`);
-        return hRes.data as DepartmentHierarchy;
-      })
-    );
-    setData(detailed);
+    try {
+      await refreshCache();
+      const departments = useDepartmentStore.getState().departments;
+      const detailed = await Promise.all(
+        departments.map(async (dep) => {
+          const hRes = await http.get(`/departments/${dep.id}/hierarchy`);
+          return hRes.data as DepartmentHierarchy;
+        })
+      );
+      setData(detailed);
+    } catch (err) {
+      console.error('Failed to load hierarchy', err);
+      addToast('Failed to load departments', 'error');
+    }
   };
 
   useEffect(() => {

--- a/frontend/src/components/teams/TeamModal.tsx
+++ b/frontend/src/components/teams/TeamModal.tsx
@@ -68,8 +68,15 @@ const TeamModal: React.FC<TeamModalProps> = ({ isOpen, onClose, member }) => {
   }, [role, setValue]);
 
   const fetchDepartmentOptions = async (q: string) => {
-    const list = await fetchDepartments();
-    return list.filter((d) => d.name.toLowerCase().includes(q.toLowerCase()));
+    try {
+      const list = await fetchDepartments();
+      return list.filter((d) =>
+        d.name.toLowerCase().includes(q.toLowerCase())
+      );
+    } catch (e) {
+      addToast('Failed to load departments', 'error');
+      return [];
+    }
   };
 
   const onSubmit = handleSubmit(async (data) => {

--- a/frontend/src/components/work-orders/WorkOrderForm.tsx
+++ b/frontend/src/components/work-orders/WorkOrderForm.tsx
@@ -32,6 +32,7 @@ const WorkOrderForm: React.FC<WorkOrderFormProps> = ({ workOrder, onSuccess }) =
   const [stationId, setStationId] = useState('');
   const lines = departmentId ? linesMap[departmentId] || [] : [];
   const stations = lineId ? stationsMap[lineId] || [] : [];
+  const { addToast } = useToast();
   const [formData, setFormData] = useState<Partial<WorkOrder>>({
     title: workOrder?.title || '',
     description: workOrder?.description || '',
@@ -63,6 +64,7 @@ const WorkOrderForm: React.FC<WorkOrderFormProps> = ({ workOrder, onSuccess }) =
         await fetchDepartments();
       } catch (err) {
         console.error('Failed to load departments', err);
+        addToast('Failed to load departments', 'error');
       }
     };
     fetchData();
@@ -76,6 +78,7 @@ const WorkOrderForm: React.FC<WorkOrderFormProps> = ({ workOrder, onSuccess }) =
     }
     fetchLines(departmentId).catch((err) => {
       console.error('Failed to load lines', err);
+      addToast('Failed to load lines', 'error');
     });
   }, [departmentId, fetchLines]);
 
@@ -86,10 +89,9 @@ const WorkOrderForm: React.FC<WorkOrderFormProps> = ({ workOrder, onSuccess }) =
     }
     fetchStations(departmentId, lineId).catch((err) => {
       console.error('Failed to load stations', err);
+      addToast('Failed to load stations', 'error');
     });
   }, [departmentId, lineId, fetchStations]);
-
-  const { addToast } = useToast();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/work-orders/WorkOrderModal.tsx
+++ b/frontend/src/components/work-orders/WorkOrderModal.tsx
@@ -10,6 +10,7 @@ import type { WorkOrder, Department } from "../../types";
 import http from "../../lib/http";
 import { searchAssets } from "../../api/search";
 import { useDepartmentStore } from "../../store/departmentStore";
+import { useToast } from "../../context/ToastContext";
    
 
 interface WorkOrderModalProps {
@@ -33,6 +34,7 @@ const WorkOrderModal: React.FC<WorkOrderModalProps> = ({
   const departments = useDepartmentStore((s) => s.departments);
   const fetchDepartments = useDepartmentStore((s) => s.fetchDepartments);
   const [loadingDeps, setLoadingDeps] = useState(true);
+  const { addToast } = useToast();
   
   const {
     register,
@@ -69,9 +71,10 @@ const WorkOrderModal: React.FC<WorkOrderModalProps> = ({
     fetchDepartments()
       .catch((err) => {
         console.error("Failed to load departments", err);
+        addToast("Failed to load departments", "error");
       })
       .finally(() => setLoadingDeps(false));
-  }, [fetchDepartments]);
+  }, [fetchDepartments, addToast]);
 
   if (!isOpen) return null;
 

--- a/frontend/src/pages/Departments.tsx
+++ b/frontend/src/pages/Departments.tsx
@@ -12,7 +12,12 @@ export default function Departments() {
     setLoading(true);
     listDepartments()
       .then(setItems)
-      .catch((e) => setError(e?.message ?? "Failed to load"))
+      .catch((e) => {
+        console.error("Failed to load departments", e);
+        setError(
+          e instanceof Error ? e.message : "Failed to load departments"
+        );
+      })
       .finally(() => setLoading(false));
   }, []);
 


### PR DESCRIPTION
## Summary
- Let `listDepartments` propagate errors instead of returning an empty list
- Show descriptive messages when loading departments fails across pages and modals

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c023cf13d4832388234dde306ce660