### PR TITLE
Add explicit types for analytics cost and downtime data

### DIFF
--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -39,6 +39,18 @@ interface KPIData {
   backlog: number;
 }
 
+interface CostRecord {
+  period: string;
+  laborCost: number;
+  materialCost: number;
+  maintenanceCost: number;
+}
+
+interface DowntimeRecord {
+  period: string;
+  downtime: number;
+}
+
 export default function Analytics() {
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [kpis, setKpis] = useState<KPIData | null>(null);
@@ -46,8 +58,8 @@ export default function Analytics() {
   const [error, setError] = useState<string | null>(null);
   const [showFilters, setShowFilters] = useState(false);
   const { selectedRole: role, setSelectedRole } = useDashboardStore();
-  const [costs, setCosts] = useState<any[]>([]);
-  const [downtime, setDowntime] = useState<any[]>([]);
+  const [costs, setCosts] = useState<CostRecord[]>([]);
+  const [downtime, setDowntime] = useState<DowntimeRecord[]>([]);
 
   const fetchData = async () => {
     setLoading(true);
@@ -56,9 +68,9 @@ export default function Analytics() {
       setData(res.data);
       const kpiRes = await http.get('/v1/analytics/kpis');
       setKpis(kpiRes.data);
-      const costRes = await http.get('/reports/costs');
+      const costRes = await http.get<CostRecord[]>('/reports/costs');
       setCosts(costRes.data);
-      const downtimeRes = await http.get('/reports/downtime');
+      const downtimeRes = await http.get<DowntimeRecord[]>('/reports/downtime');
       setDowntime(downtimeRes.data);
       setError(null);
     } catch (err) {


### PR DESCRIPTION
## Summary
- add CostRecord and DowntimeRecord interfaces
- use typed state hooks and HTTP requests for cost and downtime data

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0274ac5b48323bca2ec1ee0f92803