### PR TITLE
chore: move helmet types to dev deps

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "cmms-backend-commonjs",
       "version": "1.0.0",
       "dependencies": {
-        "@types/helmet": "^0.0.48",
         "@types/mongoose": "^5.11.96",
         "arima": "0.2.5",
         "bcryptjs": "^3.0.2",
@@ -43,6 +42,7 @@
         "@types/bcryptjs": "^2.4.6",
         "@types/cookie-parser": "^1.4.9",
         "@types/express": "^5.0.3",
+        "@types/helmet": "^0.0.48",
         "@types/ioredis": "^4.28.10",
         "@types/json2csv": "^5.0.7",
         "@types/jsonwebtoken": "^9.0.10",
@@ -1128,7 +1128,8 @@
       "license": "MIT",
       "dependencies": {
         "@types/express": "*"
-      }
+      },
+      "dev": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,6 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@types/helmet": "^0.0.48",
     "@types/mongoose": "^5.11.96",
     "arima": "0.2.5",
     "bcryptjs": "^3.0.2",
@@ -56,6 +55,7 @@
     "@types/bcryptjs": "^2.4.6",
     "@types/cookie-parser": "^1.4.9",
     "@types/express": "^5.0.3",
+    "@types/helmet": "^0.0.48",
     "@types/ioredis": "^4.28.10",
     "@types/json2csv": "^5.0.7",
     "@types/jsonwebtoken": "^9.0.10",


### PR DESCRIPTION
## Summary
- move `@types/helmet` to devDependencies in backend package files

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68c0274a6a648323bd91267a625717b6