### PR TITLE
Use qrcode library for generating QR images

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "lucide-react": "*",
         "mammoth": "^1.10.0",
         "pdfjs-dist": "^5.4.149",
+        "qrcode": "^1.5.3",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "lucide-react": "*",
     "mammoth": "^1.10.0",
     "pdfjs-dist": "^5.4.149",
+    "qrcode": "^1.5.3",
     "react-big-calendar": "^1.11.4",
     "date-fns": "^3.6.0",
     "react": "^18.2.0",

--- a/frontend/src/utils/qr.ts
+++ b/frontend/src/utils/qr.ts
@@ -1,10 +1,8 @@
-import { BrowserQRCodeReader, BrowserQRCodeSvgWriter } from '@zxing/browser';
+import { BrowserQRCodeReader } from '@zxing/browser';
+import QRCode from 'qrcode';
 
 export const generateQRCode = async (data: string): Promise<string> => {
-  const writer = new BrowserQRCodeSvgWriter();
-  const svg = writer.write(data, 300, 300);
-  const svgString = new XMLSerializer().serializeToString(svg);
-  return `data:image/svg+xml;base64,${btoa(svgString)}`;
+  return QRCode.toDataURL(data, { width: 300 });
 };
 
 export const scanQRCode = async (


### PR DESCRIPTION
## Summary
- add qrcode dependency for QR image generation
- switch QR code generation to qrcode and return data URL

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68c0276244c88323bb0be1b2ad510192