### PR TITLE
feat: enhance PM scheduler calendar interactions

### DIFF
--- a/frontend/src/pages/PMScheduler.tsx
+++ b/frontend/src/pages/PMScheduler.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
 import { format, parse, startOfWeek, getDay } from 'date-fns';
 import { enUS } from 'date-fns/locale';
@@ -35,7 +35,17 @@ const PMScheduler: React.FC = () => {
   const [assets, setAssets] = useState<string[]>([]);
   const [rule, setRule] = useState('');
   const [plans, setPlans] = useState<Plan[]>([]);
-  const [selected, setSelected] = useState<CalendarEvent | null>(null);
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const events = useMemo(
+    () =>
+      plans.map(p => ({
+        title: p.asset,
+        start: new Date(p.nextDue),
+        end: new Date(p.nextDue),
+      })),
+    [plans],
+  );
 
   const generate = () => {
     const next = new Date().toISOString().slice(0, 10);
@@ -81,27 +91,34 @@ const PMScheduler: React.FC = () => {
         <div className="border p-4">
           <Calendar
             localizer={localizer}
-            events={plans.map(p => ({
-              title: p.asset,
-              start: new Date(p.nextDue),
-              end: new Date(p.nextDue),
-            }))}
+            events={events}
             startAccessor="start"
             endAccessor="end"
             style={{ height: 500 }}
             selectable
-            onSelectEvent={e =>
-              setSelected({
+            onSelectEvent={e => {
+              setSelectedEvent({
                 title: e.title as string,
                 start: e.start as Date,
                 end: e.end as Date,
-              })
-            }
+              });
+              setSelectedDate(null);
+            }}
+            onSelectSlot={slot => {
+              setSelectedDate(slot.start as Date);
+              setSelectedEvent(null);
+            }}
           />
-          {selected && (
+          {selectedEvent && (
             <div className="mt-4 p-2 border rounded">
-              <p className="font-semibold">{selected.title}</p>
-              <p>{selected.start.toDateString()}</p>
+              <p className="font-semibold">{selectedEvent.title}</p>
+              <p>{selectedEvent.start.toDateString()}</p>
+            </div>
+          )}
+          {selectedDate && (
+            <div className="mt-4 p-2 border rounded">
+              <p className="font-semibold">Selected Date</p>
+              <p>{selectedDate.toDateString()}</p>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- allow selecting calendar dates or events when scheduling PM plans
- derive calendar events from generated plans with `useMemo`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)
- `npm ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)

------
https://chatgpt.com/codex/tasks/task_e_68c0276477008323b02d5f3a2e794d69