### PR TITLE
feat: add conflict resolution test

### DIFF
--- a/frontend/src/test/offlineConflict.pw.test.ts
+++ b/frontend/src/test/offlineConflict.pw.test.ts
@@ -4,6 +4,7 @@ import {
   flushQueue,
   onSyncConflict,
   setHttpClient,
+  loadQueue,
 } from '../utils/offlineQueue';
 
 // Simulate a conflict response followed by server data
@@ -26,4 +27,46 @@ test('emits conflict with diff info', async () => {
   expect(conflicts[0].diffs).toEqual([
     { field: 'name', local: 'Local', server: 'Server' },
   ]);
+});
+
+test('allows resolving with local version', async () => {
+  let attempt = 0;
+  const resolvingClient = async ({
+    method,
+    url,
+    data,
+  }: {
+    method: string;
+    url: string;
+    data?: any;
+  }) => {
+    if (method === 'get') {
+      return { data: { id: '1', name: 'Server' } };
+    }
+    attempt++;
+    if (attempt === 1) {
+      const err: any = new Error('conflict');
+      err.response = { status: 409 };
+      throw err;
+    }
+    expect(data).toEqual({ id: '1', name: 'Local' });
+    return { data: { ok: true } };
+  };
+
+  setHttpClient(resolvingClient);
+  addToQueue({ method: 'put', url: '/assets/1', data: { id: '1', name: 'Local' } });
+  let conflict: any = null;
+  onSyncConflict((c) => (conflict = c));
+  await flushQueue(false);
+  expect(conflict).toBeTruthy();
+  expect(conflict.diffs).toEqual([
+    { field: 'name', local: 'Local', server: 'Server' },
+  ]);
+  expect(loadQueue()).toHaveLength(0);
+  await resolvingClient({
+    method: conflict.method,
+    url: conflict.url,
+    data: conflict.local,
+  });
+  expect(attempt).toBe(2);
 });


### PR DESCRIPTION
## Summary
- ensure offline queue conflict diff is resolvable by retrying local changes
- verify conflict events clear queue and allow second attempt

## Testing
- `cd frontend && npx playwright test src/test/offlineConflict.pw.test.ts` *(fails: E403 Forbidden fetching Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68c027add81083238876ec090651e6c7