### PR TITLE
test: simplify afterEach timer cleanup

### DIFF
--- a/frontend/src/test/navigationStore.test.ts
+++ b/frontend/src/test/navigationStore.test.ts
@@ -6,9 +6,7 @@ beforeEach(() => {
   vi.useFakeTimers();
 });
 
-afterEach(() => {
-  vi.useRealTimers();
-});
+afterEach(() => vi.useRealTimers());
 
 describe('navigation store', () => {
   it('persists sidebar order', async () => {


### PR DESCRIPTION
## Summary
- streamline timer cleanup in navigation store test by using vitest's `afterEach`

## Testing
- `cd frontend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c027ca29648323938385c0a686ca17