### PR TITLE
feat(frontend): add design system with theme and tokens

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/sortable": "10.0.0",
     "@dnd-kit/utilities": "3.2.2",
+    "@mantine/core": "^7.10.2",
     "@zxing/browser": "^0.1.5",
     "axios": "^1.11.0",
     "chart.js": "^4.4.2",

--- a/frontend/src/design-system/README.md
+++ b/frontend/src/design-system/README.md
@@ -1,0 +1,32 @@
+# Design System
+
+Shared theme configuration, design tokens, and basic UI components built with [Mantine](https://mantine.dev).
+
+## Theme
+
+Wrap the application with the `ThemeProvider` to apply global styles and enable light/dark modes:
+
+```tsx
+import { ThemeProvider } from './design-system';
+
+<ThemeProvider>
+  <App />
+</ThemeProvider>
+```
+
+## Tokens
+
+- `tokens/colors.ts` – color palettes for light and dark schemes.
+- `tokens/spacing.ts` – spacing scale.
+- `tokens/typography.ts` – font families and sizes.
+
+## Components
+
+- `EmptyState` – placeholder shown when no data is available.
+- `ErrorState` – displays an error message with an optional retry action.
+
+Import components as needed:
+
+```tsx
+import { EmptyState, ErrorState } from './design-system';
+```

--- a/frontend/src/design-system/components/EmptyState.tsx
+++ b/frontend/src/design-system/components/EmptyState.tsx
@@ -1,0 +1,15 @@
+import { Center, Stack, Text } from '@mantine/core';
+
+interface EmptyStateProps {
+  message?: string;
+}
+
+export function EmptyState({ message = 'No data available' }: EmptyStateProps) {
+  return (
+    <Center py="xl">
+      <Stack spacing="sm" align="center">
+        <Text c="dimmed">{message}</Text>
+      </Stack>
+    </Center>
+  );
+}

--- a/frontend/src/design-system/components/ErrorState.tsx
+++ b/frontend/src/design-system/components/ErrorState.tsx
@@ -1,0 +1,21 @@
+import { Button, Center, Stack, Text } from '@mantine/core';
+
+interface ErrorStateProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export function ErrorState({ message = 'Something went wrong', onRetry }: ErrorStateProps) {
+  return (
+    <Center py="xl">
+      <Stack spacing="sm" align="center">
+        <Text c="red">{message}</Text>
+        {onRetry && (
+          <Button variant="light" onClick={onRetry}>
+            Retry
+          </Button>
+        )}
+      </Stack>
+    </Center>
+  );
+}

--- a/frontend/src/design-system/components/index.ts
+++ b/frontend/src/design-system/components/index.ts
@@ -1,0 +1,2 @@
+export { EmptyState } from './EmptyState';
+export { ErrorState } from './ErrorState';

--- a/frontend/src/design-system/index.ts
+++ b/frontend/src/design-system/index.ts
@@ -1,0 +1,5 @@
+export { ThemeProvider } from './theme';
+export * from './tokens/colors';
+export * from './tokens/spacing';
+export * from './tokens/typography';
+export * from './components';

--- a/frontend/src/design-system/theme.ts
+++ b/frontend/src/design-system/theme.ts
@@ -1,0 +1,32 @@
+import { MantineProvider, ColorSchemeProvider, ColorScheme } from '@mantine/core';
+import { useState } from 'react';
+import { colors } from './tokens/colors';
+import { spacing } from './tokens/spacing';
+import { typography } from './tokens/typography';
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [colorScheme, setColorScheme] = useState<ColorScheme>('light');
+  const toggleColorScheme = (value?: ColorScheme) =>
+    setColorScheme(value || (colorScheme === 'dark' ? 'light' : 'dark'));
+
+  const theme = {
+    colorScheme,
+    colors: { brand: colors[colorScheme].brand },
+    primaryColor: 'brand',
+    fontFamily: typography.fontFamily,
+    fontSizes: typography.fontSizes,
+    spacing,
+  } as const;
+
+  return (
+    <ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}>
+      <MantineProvider withGlobalStyles withNormalizeCSS theme={theme}>
+        {children}
+      </MantineProvider>
+    </ColorSchemeProvider>
+  );
+}

--- a/frontend/src/design-system/tokens/colors.ts
+++ b/frontend/src/design-system/tokens/colors.ts
@@ -1,0 +1,34 @@
+export const colors = {
+  light: {
+    brand: [
+      '#e7f5ff',
+      '#d0ebff',
+      '#a5d8ff',
+      '#74c0fc',
+      '#4dabf7',
+      '#339af0',
+      '#228be6',
+      '#1c7ed6',
+      '#1971c2',
+      '#1864ab',
+    ],
+    background: '#ffffff',
+    text: '#000000',
+  },
+  dark: {
+    brand: [
+      '#d0ebff',
+      '#a5d8ff',
+      '#74c0fc',
+      '#4dabf7',
+      '#339af0',
+      '#228be6',
+      '#1c7ed6',
+      '#1971c2',
+      '#1864ab',
+      '#1b4f99',
+    ],
+    background: '#1a1b1e',
+    text: '#ffffff',
+  },
+};

--- a/frontend/src/design-system/tokens/spacing.ts
+++ b/frontend/src/design-system/tokens/spacing.ts
@@ -1,0 +1,7 @@
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+};

--- a/frontend/src/design-system/tokens/typography.ts
+++ b/frontend/src/design-system/tokens/typography.ts
@@ -1,0 +1,10 @@
+export const typography = {
+  fontFamily: 'Inter, sans-serif',
+  fontSizes: {
+    xs: '12px',
+    sm: '14px',
+    md: '16px',
+    lg: '20px',
+    xl: '24px',
+  },
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,13 +4,16 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./i18n"; // remove this line if the file doesn't exist
 import { AuthProvider } from "./context/AuthContext";
+import { ThemeProvider } from "./design-system";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <AuthProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add Mantine-based design system with theme provider and tokens
- include EmptyState and ErrorState components
- wrap app with new ThemeProvider and document usage

## Testing
- `npm test` *(fails: bash: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c033b20e3883238cb5f9817d2cbf39