### PR TITLE
chore: update frontend env naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ not committed to the repository.
 ## frontend setup
 
 1. `cd frontend`
-2. Copy `frontend/.env.example` to `.env` and update `VITE_API_URL`,
+2. Copy `frontend/.env.example` to `.env.local` and update `VITE_API_URL`,
     `VITE_WS_URL`, and `VITE_WS_PATH`.
  
 3. Install dependencies with `npm install`.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
-VITE_API_URL=http://localhost:5010/api
+VITE_API_URL=http://localhost:5010
 VITE_WS_URL=ws://localhost:5010
 VITE_WS_PATH=/socket.io
 

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,3 +1,3 @@
-VITE_API_URL=http://localhost:5010/api
+VITE_API_URL=http://localhost:5010
 VITE_WS_URL=ws://localhost:5010
 VITE_SOCKET_PATH=/socket.io

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -50,7 +50,7 @@ The optimized bundle is written to the `dist` folder.
 
 The following variables from `.env.example` configure the frontend:
 
-- `VITE_API_URL` – Base URL for API requests. Defaults to `http://localhost:5010/api`.
+- `VITE_API_URL` – Base URL for API requests. Defaults to `http://localhost:5010`.
 - `VITE_WS_URL` – WebSocket server URL for real‑time updates. Defaults to `ws://localhost:5010`.
 - `VITE_SOCKET_PATH` – WebSocket endpoint path. Defaults to `/socket.io`.
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const base = (import.meta.env.VITE_API_URL || 'http://localhost:5010/api').replace(/\/+$/, '');
+const baseUrl = (import.meta.env.VITE_API_URL || 'http://localhost:5010').replace(/\/+$/, '');
+const base = `${baseUrl}/api`;
 
 export const api = axios.create({
   baseURL: base,

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
+const baseUrl = (import.meta.env.VITE_API_URL ?? 'http://localhost:5010').replace(/\/+$/, '');
 const http = axios.create({
-  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:5010/api',
+  baseURL: `${baseUrl}/api`,
   withCredentials: true,
 });
 

--- a/frontend/src/utils/env.ts
+++ b/frontend/src/utils/env.ts
@@ -4,8 +4,8 @@ const getEnvVar = (key: string): string | undefined =>
   (import.meta.env as unknown as ViteEnv)?.[key];
 
 export const config = {
-  // Full API base including /api
-  apiUrl: getEnvVar('VITE_API_URL') ?? 'http://localhost:5010/api',
+  // Base server URL (without trailing /api)
+  apiUrl: getEnvVar('VITE_API_URL') ?? 'http://localhost:5010',
   // Optional explicit origins/urls
   httpOrigin: getEnvVar('VITE_HTTP_ORIGIN'),
   wsUrl: getEnvVar('VITE_WS_URL'),


### PR DESCRIPTION
## Summary
- rename frontend .env to .env.local and point VITE_API_URL to http://localhost:5010
- adjust axios helpers to add /api suffix
- document new env file name and base API URL

## Testing
- `npm test --prefix frontend` (fails: Missing script "test")
- `npm run build --prefix frontend` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68c033b2d5408323b807aa77293274a9