### PR TITLE
Add color scheme schema

### DIFF
--- a/frontend/src/design-system/theme.ts
+++ b/frontend/src/design-system/theme.ts
@@ -1,5 +1,6 @@
-import { MantineProvider, ColorSchemeProvider, ColorScheme } from '@mantine/core';
+import { MantineProvider, ColorSchemeProvider } from '@mantine/core';
 import { useState } from 'react';
+import type { ColorScheme } from '../modules/schema';
 import { colors } from './tokens/colors';
 import { spacing } from './tokens/spacing';
 import { typography } from './tokens/typography';

--- a/frontend/src/modules/schema.ts
+++ b/frontend/src/modules/schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const colorScheme = z.enum(['light', 'dark']);
+export type ColorScheme = z.infer<typeof colorScheme>;
+


### PR DESCRIPTION
## Summary
- define `colorScheme` zod schema and export inferred `ColorScheme` type
- use shared `ColorScheme` type in theme provider

## Testing
- `cd frontend && npm test` (fails: Missing script "test")
- `cd backend && npm test` (fails: sh: 1: vitest: not found)
- `cd backend && npm install vitest` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c0395db0f08323be4b86d9bf3ec2dc