### PR TITLE
feat(frontend): add src alias configuration

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -6,7 +6,8 @@
     "module": "ESNext",
     "skipLibCheck": true,
      "types": ["vite/client", "node", "react", "react-dom"],
- 
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
 
     /* Bundler mode */
     "moduleResolution": "Bundler",

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -4,6 +4,8 @@
     "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [react()],
   server: { port: 5173 },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- configure TypeScript baseUrl and @ path alias
- add matching Vite resolve alias

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` (fails: errors in theme.ts and TeamMemberProfile.tsx)
- `npx tsc -p tsconfig.node.json --noEmit` (fails: cannot find type definition file for 'node')
- `npx vite` (fails: 403 Forbidden from npm registry)


------
https://chatgpt.com/codex/tasks/task_e_68c03ba89b5083239b78ea4793a7bd9e