### PR TITLE
refactor: use AxiosRequestHeaders for interceptor

### DIFF
--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import type { AxiosRequestHeaders } from 'axios';
 import { API_URL } from '@/config/env';
 
 const http = axios.create({
@@ -16,13 +17,13 @@ function getCookie(name: string): string | undefined {
 }
 
 http.interceptors.request.use((config) => {
-   const headers: Record<string, string> = (config.headers ?? {}) as Record<string, string>;
+  const headers: AxiosRequestHeaders = config.headers ?? {};
   const token = localStorage.getItem(TOKEN_KEY);
  
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
-   const tenantId = localStorage.getItem(TENANT_KEY);
+  const tenantId = localStorage.getItem(TENANT_KEY);
   const siteId = localStorage.getItem(SITE_KEY);
   if (tenantId) headers['x-tenant-id'] = tenantId;
   if (siteId) headers['x-site-id'] = siteId;


### PR DESCRIPTION
## Summary
- use `AxiosRequestHeaders` for header manipulation in HTTP interceptor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx eslint frontend/src/lib/http.ts` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68c03ba905d08323ae5e8c8bd3180135