### PR TITLE
feat: add email assertion utility

### DIFF
--- a/backend/controllers/GoodsReceiptController.ts
+++ b/backend/controllers/GoodsReceiptController.ts
@@ -4,6 +4,7 @@ import PurchaseOrder from '../models/PurchaseOrder';
 import Vendor from '../models/Vendor';
 import { addStock } from '../services/inventory';
 import nodemailer from 'nodemailer';
+import { assertEmail } from '../utils/assert';
 
 export const createGoodsReceipt = async (
   req: Request,
@@ -46,6 +47,7 @@ export const createGoodsReceipt = async (
 
     const vendor = await Vendor.findById(po.vendor).lean();
     if (vendor?.email) {
+      assertEmail(vendor.email);
       const transporter = nodemailer.createTransport({ jsonTransport: true });
       await transporter.sendMail({
         to: vendor.email,

--- a/backend/controllers/NotificationController.ts
+++ b/backend/controllers/NotificationController.ts
@@ -3,6 +3,7 @@ import Notification, { NotificationDocument } from '../models/Notifications';
 import User from '../models/User';
 import nodemailer from 'nodemailer';
 import { Response, NextFunction } from 'express';
+import { assertEmail } from '../utils/assert';
 
 type IdParams = { id: string };
 
@@ -65,6 +66,7 @@ export const createNotification: AuthedRequestHandler<unknown, NotificationDocum
       if (saved.user) {
         const user = await User.findById(saved.user);
         if (user?.email) {
+          assertEmail(user.email);
           await transporter.sendMail({
             from: process.env.SMTP_FROM || process.env.SMTP_USER,
             to: user.email,

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -5,6 +5,7 @@ import crypto from "crypto";
 import * as speakeasy from "speakeasy";
 import logger from "../utils/logger";
 import User from "../models/User";
+import { assertEmail } from '../utils/assert';
 
 export const login = async (req: Request, res: Response): Promise<void> => {
   const { email, password } = req.body;
@@ -14,6 +15,7 @@ export const login = async (req: Request, res: Response): Promise<void> => {
     res.status(400).json({ message: 'Email and password required' });
     return;
   }
+  assertEmail(email);
 
   try {
     const user = await User.findOne({ email });
@@ -64,6 +66,7 @@ export const register = async (req: Request, res: Response): Promise<void> => {
     res.status(400).json({ message: "Missing required fields" });
     return;
   }
+  assertEmail(email);
 
   try {
     const existing = await User.findOne({ email });
@@ -92,6 +95,7 @@ export const requestPasswordReset = async (
     res.status(400).json({ message: "Email required" });
     return;
   }
+  assertEmail(email);
 
   try {
     const user = await User.findOne({ email });

--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -5,6 +5,7 @@ import { login, generateMfa, verifyMfa } from '../controllers/authController';
 import { configureOIDC } from '../auth/oidc';
 import { configureOAuth, getOAuthScope, OAuthProvider } from '../auth/oauth';
 import { getJwtSecret } from '../utils/getJwtSecret';
+import { assertEmail } from '../utils/assert';
 
 configureOIDC();
 configureOAuth();
@@ -38,6 +39,7 @@ router.get('/oauth/:provider/callback', (req, res, next) => {
       if (!secret) {
         return;
       }
+      assertEmail(user.email);
       const token = jwt.sign({ email: user.email }, secret as string, {
         expiresIn: '7d',
       });

--- a/backend/routes/vendorPortal.ts
+++ b/backend/routes/vendorPortal.ts
@@ -6,6 +6,7 @@ import Vendor from '../models/Vendor';
 import PurchaseOrder from '../models/PurchaseOrder';
 import { requireVendorAuth } from '../middleware/vendorAuth';
 import { getJwtSecret } from '../utils/getJwtSecret';
+import { assertEmail } from '../utils/assert';
 
 import {
   listVendorPurchaseOrders,
@@ -22,6 +23,9 @@ router.post('/login', async (req: Request, res: Response) => {
   if (!vendorId) {
     res.status(400).json({ message: 'vendorId required' });
     return;
+  }
+  if (email !== undefined) {
+    assertEmail(email);
   }
 
   const vendor = await Vendor.findById(vendorId).lean();

--- a/backend/utils/assert.ts
+++ b/backend/utils/assert.ts
@@ -1,0 +1,9 @@
+export function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+export function assertEmail(v: unknown): asserts v is string {
+  if (typeof v !== 'string' || v.trim() === '') {
+    throw new Error('Email is required and must be a non-empty string');
+  }
+}

--- a/backend/utils/notify.ts
+++ b/backend/utils/notify.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 import Notification from '../models/Notifications';
 import User from '../models/User';
 import nodemailer from 'nodemailer';
+import { assertEmail } from './assert';
 
 export const notifyUser = async (userId: mongoose.Types.ObjectId, message: string) => {
   if (!userId) return;
@@ -13,6 +14,7 @@ export const notifyUser = async (userId: mongoose.Types.ObjectId, message: strin
 
   if (process.env.SMTP_HOST && process.env.SMTP_USER && process.env.SMTP_PASS) {
     if (user.email) {
+      assertEmail(user.email);
       const transporter = nodemailer.createTransport({
         host: process.env.SMTP_HOST,
         port: parseInt(process.env.SMTP_PORT || '587', 10),


### PR DESCRIPTION
## Summary
- add invariant/assertEmail utilities
- verify email inputs before calling APIs

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08940f38083239b7985767a5a6dfd