### PR TITLE
feat: parse auth requests with zod

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -1,10 +1,17 @@
 import { Router } from 'express';
 import passport from 'passport';
 import jwt from 'jsonwebtoken';
-import { login, generateMfa, verifyMfa } from '../controllers/authController';
+import bcrypt from 'bcryptjs';
+import { generateMfa, verifyMfa } from '../controllers/authController';
 import { configureOIDC } from '../auth/oidc';
 import { configureOAuth, getOAuthScope, OAuthProvider } from '../auth/oauth';
 import { getJwtSecret } from '../utils/getJwtSecret';
+import User from '../models/User';
+import {
+  loginSchema,
+  registerSchema,
+  assertEmail,
+} from '../validators/authValidators';
 
 configureOIDC();
 configureOAuth();
@@ -13,7 +20,76 @@ const router = Router();
 router.use(passport.initialize());
 
 // Local login
-router.post('/login', login);
+router.post('/login', async (req, res) => {
+  const parsed = loginSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: 'Invalid request' });
+  }
+  const { email, password } = parsed.data;
+
+  try {
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(400).json({ message: 'Invalid email or password' });
+    }
+
+    assertEmail(user.email);
+
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) {
+      return res.status(400).json({ message: 'Invalid email or password' });
+    }
+
+    if (user.mfaEnabled) {
+      return res
+        .status(200)
+        .json({ mfaRequired: true, userId: user._id.toString() });
+    }
+
+    const tenantId = user.tenantId ? user.tenantId.toString() : undefined;
+    const secret = getJwtSecret(res);
+    if (!secret) {
+      return;
+    }
+    const token = jwt.sign({
+      id: user._id.toString(),
+      email: user.email,
+      tenantId,
+    }, secret, { expiresIn: '7d' });
+    const { password: _pw, ...safeUser } = user.toObject();
+    return res
+      .cookie('token', token, {
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+      })
+      .status(200)
+      .json({ token, user: { ...safeUser, tenantId } });
+  } catch {
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// Local register (optional)
+router.post('/register', async (req, res) => {
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: 'Invalid request' });
+  }
+  const { name, email, password, tenantId, employeeId } = parsed.data;
+
+  try {
+    const existing = await User.findOne({ email });
+    if (existing) {
+      return res.status(400).json({ message: 'Email already in use' });
+    }
+    const user = new User({ name, email, password, tenantId, employeeId });
+    await user.save();
+    return res.status(201).json({ message: 'User registered successfully' });
+  } catch {
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
 
 // OAuth routes
 router.get('/oauth/:provider', (req, res, next) => {

--- a/backend/validators/authValidators.ts
+++ b/backend/validators/authValidators.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+const email = z.string().email();
+
+export const loginSchema = z.object({
+  email,
+  password: z.string().min(1),
+});
+
+export const registerSchema = z.object({
+  name: z.string().min(1),
+  email,
+  password: z.string().min(1),
+  tenantId: z.string().min(1),
+  employeeId: z.string().min(1),
+});
+
+export const assertEmail = (value: unknown): asserts value is string => {
+  email.parse(value);
+};
+
+export type LoginInput = z.infer<typeof loginSchema>;
+export type RegisterInput = z.infer<typeof registerSchema>;


### PR DESCRIPTION
## Summary
- Validate auth requests with new Zod schemas
- Inline /login and /register logic with email assertions

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08942a89c832396b8c11624e7001b