### PR TITLE
Add auth validation schemas

### DIFF
--- a/backend/validation/auth.ts
+++ b/backend/validation/auth.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export const registerSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  name: z.string().min(1).optional(),
+});


### PR DESCRIPTION
## Summary
- add login and registration validation schemas using zod

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08943e8248323a1d60de54b331861