### PR TITLE
Rename password field to passwordHash and harden email constraints

### DIFF
--- a/backend/controllers/UserController.ts
+++ b/backend/controllers/UserController.ts
@@ -17,7 +17,7 @@ export const getAllUsers: AuthedRequestHandler = async (
   next
 ) => {
   try {
-    const items = await User.find({ tenantId: req.tenantId }).select('-password');
+    const items = await User.find({ tenantId: req.tenantId }).select('-passwordHash');
     res.json(items);
   } catch (err) {
     next(err);
@@ -49,7 +49,7 @@ export const getUserById: AuthedRequestHandler = async (
   next
 ) => {
   try {
-    const item = await User.findOne({ _id: req.params.id, tenantId: req.tenantId }).select('-password');
+    const item = await User.findOne({ _id: req.params.id, tenantId: req.tenantId }).select('-passwordHash');
     if (!item) return res.status(404).json({ message: 'Not found' });
     res.json(item);
   } catch (err) {
@@ -82,7 +82,7 @@ export const createUser: AuthedRequestHandler = async (
   try {
     const newItem = new User({ ...req.body, tenantId: req.tenantId });
     const saved = await newItem.save();
-    const { password: _pw, ...safeUser } = saved.toObject();
+    const { passwordHash: _pw, ...safeUser } = saved.toObject();
     res.status(201).json(safeUser);
   } catch (err) {
     next(err);
@@ -127,7 +127,7 @@ export const updateUser: AuthedRequestHandler = async (
         new: true,
         runValidators: true,
       }
-    ).select('-password');
+    ).select('-passwordHash');
     if (!updated) return res.status(404).json({ message: 'Not found' });
     res.json(updated);
   } catch (err) {

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -23,7 +23,7 @@ export const login = async (req: Request, res: Response): Promise<void> => {
       return;
     }
 
-    const valid = await bcrypt.compare(req.body.password, user.password);
+    const valid = await bcrypt.compare(req.body.password, user.passwordHash);
     logger.info('Password comparison result', { valid });
     if (!valid) {
       res.status(401).json({ message: 'Invalid email or password' });
@@ -49,7 +49,7 @@ export const login = async (req: Request, res: Response): Promise<void> => {
     }
     const token = jwt.sign(payload, secret, { expiresIn: '7d' });
 
-    const { password: _pw, ...safeUser } = user.toObject();
+    const { passwordHash: _pw, ...safeUser } = user.toObject();
     res.status(200).json({ token, user: { ...safeUser, tenantId } });
   } catch (err) {
     logger.error('Login error', err);
@@ -72,7 +72,7 @@ export const register = async (req: Request, res: Response): Promise<void> => {
       return;
     }
 
-    const user = new User({ name, email, password, tenantId, employeeId });
+    const user = new User({ name, email, passwordHash: password, tenantId, employeeId });
     await user.save();
 
     res.status(201).json({ message: "User registered successfully" });
@@ -160,7 +160,7 @@ export const verifyMfa = async (req: Request, res: Response): Promise<void> => {
       return;
     }
     const jwtToken = jwt.sign(payload, secret, { expiresIn: '7d' });
-    const { password: _pw, ...safeUser } = user.toObject();
+    const { passwordHash: _pw, ...safeUser } = user.toObject();
     res.json({ token: jwtToken, user: { ...safeUser, tenantId } });
   } catch (err) {
     logger.error('verifyMfa error', err);

--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -8,7 +8,7 @@ export interface UserDocument extends Document {
   _id: Types.ObjectId;
   name: string;
   email: string;
-  password: string;
+  passwordHash: string;
   role: UserRole;
   tenantId: mongoose.Schema.Types.ObjectId;
   employeeId: string;
@@ -25,8 +25,15 @@ export interface UserDocument extends Document {
 const userSchema = new Schema<UserDocument>(
   {
     name: { type: String, required: true },
-    email: { type: String, required: true, unique: true },
-    password: { type: String, required: true },
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      index: true,
+      lowercase: true,
+    },
+    passwordHash: { type: String, required: true },
     role: {
       type: String,
       enum: ['admin', 'manager', 'technician', 'viewer'],
@@ -58,10 +65,10 @@ const userSchema = new Schema<UserDocument>(
 
 // ✅ Password hashing
 userSchema.pre<UserDocument>('save', async function (next) {
-  if (!this.isModified('password')) return next();
+  if (!this.isModified('passwordHash')) return next();
 
   try {
-    this.password = await bcrypt.hash(this.password, 10);
+    this.passwordHash = await bcrypt.hash(this.passwordHash, 10);
     next();
   } catch (err) {
     next(err as Error);

--- a/backend/scripts/resetAndSeed.ts
+++ b/backend/scripts/resetAndSeed.ts
@@ -52,9 +52,8 @@ async function resetAndSeed() {
 
         const adminPassword = await bcrypt.hash('admin123', 10);
         await User.create({
- 
             email: 'admin@example.com',
-            password: hashedPassword,
+            passwordHash: adminPassword,
             role: 'admin'
         });
         console.log(`👤 Created admin user: ${adminUser.email}`);

--- a/backend/scripts/seedAdmin.ts
+++ b/backend/scripts/seedAdmin.ts
@@ -35,7 +35,7 @@ const seedAdmin = async () => {
       {
         name: 'Admin User',
         email: 'admin@example.com',
-        password: hashedPassword,
+        passwordHash: hashedPassword,
         role: 'admin',
         tenantId: tenant._id,
       },

--- a/backend/scripts/seedDefaultAdmin.ts
+++ b/backend/scripts/seedDefaultAdmin.ts
@@ -32,7 +32,7 @@ const seed = async () => {
       await User.create({
         name: 'Admin',
         email: 'admin@example.com',
-        password: hashedPassword,
+        passwordHash: hashedPassword,
         role: 'admin',
         tenantId: tenant._id,
       });

--- a/backend/scripts/seedTeam.ts
+++ b/backend/scripts/seedTeam.ts
@@ -51,7 +51,7 @@ const seedTeam = async () => {
       { email: adminEmail },
       {
         email: adminEmail,
-        password: hashedPassword,
+        passwordHash: hashedPassword,
         role: "admin",
         tenantId: tenant._id,
       },

--- a/backend/seed.ts
+++ b/backend/seed.ts
@@ -51,7 +51,7 @@ mongoose.connect(mongoUri).then(async () => {
   const admin = await User.create({
     name: 'Admin',
     email: 'admin@example.com',
-    password: 'admin123',
+    passwordHash: 'admin123',
     role: 'admin',
     tenantId,
     employeeId: 'ADM001',
@@ -59,7 +59,7 @@ mongoose.connect(mongoUri).then(async () => {
   const tech = await User.create({
     name: 'Tech',
     email: 'tech@example.com',
-    password: 'tech123',
+    passwordHash: 'tech123',
     role: 'technician',
     tenantId,
     employeeId: 'TECH001',
@@ -69,7 +69,7 @@ mongoose.connect(mongoUri).then(async () => {
   const departmentLeader = await User.create({
     name: 'Department Leader',
     email: 'department.leader@example.com',
-    password: 'leader123',
+    passwordHash: 'leader123',
     role: 'manager',
     employeeId: 'DL001',
     tenantId,
@@ -79,7 +79,7 @@ mongoose.connect(mongoUri).then(async () => {
   const areaLeader = await User.create({
     name: 'Area Leader',
     email: 'area.leader@example.com',
-    password: 'area123',
+    passwordHash: 'area123',
     role: 'manager',
     employeeId: 'AL001',
     tenantId,
@@ -89,7 +89,7 @@ mongoose.connect(mongoUri).then(async () => {
   const teamLeader = await User.create({
     name: 'Team Leader',
     email: 'team.leader@example.com',
-    password: 'team123',
+    passwordHash: 'team123',
     role: 'manager',
     employeeId: 'TL001',
     tenantId,
@@ -100,7 +100,7 @@ mongoose.connect(mongoUri).then(async () => {
     {
       name: 'Team Member One',
       email: 'member.one@example.com',
-      password: 'member123',
+      passwordHash: 'member123',
       role: 'technician',
       employeeId: 'TM001',
       tenantId,
@@ -109,7 +109,7 @@ mongoose.connect(mongoUri).then(async () => {
     {
       name: 'Team Member Two',
       email: 'member.two@example.com',
-      password: 'member123',
+      passwordHash: 'member123',
       role: 'technician',
       employeeId: 'TM002',
       tenantId,
@@ -118,7 +118,7 @@ mongoose.connect(mongoUri).then(async () => {
     {
       name: 'Team Member Three',
       email: 'member.three@example.com',
-      password: 'member123',
+      passwordHash: 'member123',
       role: 'technician',
       employeeId: 'TM003',
       tenantId,

--- a/backend/tests/analyticsRoutes.test.ts
+++ b/backend/tests/analyticsRoutes.test.ts
@@ -33,7 +33,7 @@ beforeEach(async () => {
   const user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/assetRoutes.test.ts
+++ b/backend/tests/assetRoutes.test.ts
@@ -34,7 +34,7 @@ beforeEach(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/auth/authorize.test.ts
+++ b/backend/tests/auth/authorize.test.ts
@@ -35,7 +35,7 @@ beforeEach(async () => {
   const admin = await User.create({
     name: 'Admin',
     email: 'admin@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'admin',
     tenantId: new mongoose.Types.ObjectId(),
   });
@@ -44,7 +44,7 @@ beforeEach(async () => {
   const viewer = await User.create({
     name: 'Viewer',
     email: 'viewer@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'viewer',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/authRoutes.test.ts
+++ b/backend/tests/authRoutes.test.ts
@@ -35,7 +35,7 @@ describe('Auth Routes', () => {
     await User.create({
       name: 'Test',
       email: 'test@example.com',
-      password: 'pass123',
+      passwordHash: 'pass123',
       role: 'admin',
       tenantId: new mongoose.Types.ObjectId(),
     });
@@ -60,7 +60,7 @@ describe('Auth Routes', () => {
     await User.create({
       name: 'Me',
       email: 'me@example.com',
-      password: 'pass123',
+      passwordHash: 'pass123',
       role: 'viewer',
       tenantId: new mongoose.Types.ObjectId(),
     });

--- a/backend/tests/conditionEvaluator.test.ts
+++ b/backend/tests/conditionEvaluator.test.ts
@@ -28,7 +28,7 @@ beforeAll(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
     employeeId: 'EMP001',
@@ -53,7 +53,7 @@ beforeEach(async () => {
     _id: user._id,
     name: user.name,
     email: user.email,
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: user.role,
     tenantId: user.tenantId,
     employeeId: user.employeeId,

--- a/backend/tests/departmentRoutes.test.ts
+++ b/backend/tests/departmentRoutes.test.ts
@@ -48,7 +48,7 @@ beforeAll(async () => {
   user = (await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   })) as unknown as UserDocument;
@@ -68,7 +68,7 @@ beforeEach(async () => {
   user = (await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   })) as unknown as UserDocument;

--- a/backend/tests/documentRoutes.test.ts
+++ b/backend/tests/documentRoutes.test.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/inventory.test.ts
+++ b/backend/tests/inventory.test.ts
@@ -25,7 +25,7 @@ beforeAll(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/inventoryRoutes.test.ts
+++ b/backend/tests/inventoryRoutes.test.ts
@@ -24,7 +24,7 @@ beforeAll(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/lineRoutes.test.ts
+++ b/backend/tests/lineRoutes.test.ts
@@ -24,7 +24,7 @@ beforeAll(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });
@@ -41,7 +41,7 @@ beforeEach(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/notificationRoutes.test.ts
+++ b/backend/tests/notificationRoutes.test.ts
@@ -33,14 +33,14 @@ beforeAll(async () => {
   userA = await User.create({
     name: 'A',
     email: 'a@example.com',
-    password: 'pass',
+    passwordHash: 'pass',
     role: 'admin',
     tenantId: tenantA,
   });
   userB = await User.create({
     name: 'B',
     email: 'b@example.com',
-    password: 'pass',
+    passwordHash: 'pass',
     role: 'admin',
     tenantId: tenantB,
   });
@@ -55,8 +55,8 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await mongoose.connection.db?.dropDatabase();
-  await User.create({ _id: userA._id, name: userA.name, email: userA.email, password: userA.password, role: userA.role, tenantId: tenantA });
-  await User.create({ _id: userB._id, name: userB.name, email: userB.email, password: userB.password, role: userB.role, tenantId: tenantB });
+  await User.create({ _id: userA._id, name: userA.name, email: userA.email, passwordHash: userA.passwordHash, role: userA.role, tenantId: tenantA });
+  await User.create({ _id: userB._id, name: userB.name, email: userB.email, passwordHash: userB.passwordHash, role: userB.role, tenantId: tenantB });
   io.emit.mockReset();
 });
 

--- a/backend/tests/notifyUser.test.ts
+++ b/backend/tests/notifyUser.test.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
   const user = await User.create({
     name: 'Test User',
     email: 'test@example.com',
-    password: 'pass',
+    passwordHash: 'pass',
     role: 'admin',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/pmTaskRoutes.test.ts
+++ b/backend/tests/pmTaskRoutes.test.ts
@@ -31,7 +31,7 @@ beforeEach(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/predictiveRoutes.test.ts
+++ b/backend/tests/predictiveRoutes.test.ts
@@ -26,7 +26,7 @@ beforeAll(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
     employeeId: 'EMP001',
@@ -45,7 +45,7 @@ beforeEach(async () => {
     _id: user._id,
     name: user.name,
     email: user.email,
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: user.role,
     tenantId: user.tenantId,
     employeeId: user.employeeId,

--- a/backend/tests/purchaseOrderLifecycle.test.ts
+++ b/backend/tests/purchaseOrderLifecycle.test.ts
@@ -42,7 +42,7 @@ beforeAll(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/reportMetrics.test.ts
+++ b/backend/tests/reportMetrics.test.ts
@@ -32,7 +32,7 @@ beforeEach(async () => {
   const user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/siteIsolation.test.ts
+++ b/backend/tests/siteIsolation.test.ts
@@ -31,7 +31,7 @@ beforeEach(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/tenantRoutes.test.ts
+++ b/backend/tests/tenantRoutes.test.ts
@@ -30,7 +30,7 @@ beforeEach(async () => {
   const admin = await User.create({
     name: 'Admin',
     email: 'admin@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'admin',
     tenantId: new mongoose.Types.ObjectId(),
     employeeId: 'ADMIN1',

--- a/backend/tests/themeRoutes.test.ts
+++ b/backend/tests/themeRoutes.test.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'viewer'
   });
   token = jwt.sign({ id: user._id.toString() }, process.env.JWT_SECRET!);
@@ -39,7 +39,7 @@ beforeEach(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'viewer',
     theme: 'light',
     colorScheme: 'default'

--- a/backend/tests/timeSheetRoutes.test.ts
+++ b/backend/tests/timeSheetRoutes.test.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });
@@ -41,7 +41,7 @@ beforeEach(async () => {
     _id: user._id,
     name: user.name,
     email: user.email,
-    password: user.password,
+    passwordHash: user.passwordHash,
     role: user.role,
     tenantId: user.tenantId,
   });

--- a/backend/tests/userRoutes.test.ts
+++ b/backend/tests/userRoutes.test.ts
@@ -31,7 +31,7 @@ beforeEach(async () => {
   admin = await User.create({
     name: 'Admin',
     email: 'admin@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'admin',
     tenantId: new mongoose.Types.ObjectId(),
     employeeId: 'ADMIN1',

--- a/backend/tests/userThemeRoutes.test.ts
+++ b/backend/tests/userThemeRoutes.test.ts
@@ -31,7 +31,7 @@ beforeEach(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'viewer',
   });
   token = jwt.sign({ id: user._id.toString(), role: user.role }, process.env.JWT_SECRET!);

--- a/backend/tests/vendorRoutes.test.ts
+++ b/backend/tests/vendorRoutes.test.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });
@@ -41,7 +41,7 @@ beforeEach(async () => {
     _id: user._id,
     name: user.name,
     email: user.email,
-    password: user.password,
+    passwordHash: user.passwordHash,
     role: user.role,
     tenantId: user.tenantId,
   });

--- a/backend/tests/workOrderAssist.test.ts
+++ b/backend/tests/workOrderAssist.test.ts
@@ -36,7 +36,7 @@ beforeEach(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });

--- a/backend/tests/workOrderRoutes.test.ts
+++ b/backend/tests/workOrderRoutes.test.ts
@@ -44,7 +44,7 @@ beforeEach(async () => {
   user = await User.create({
     name: 'Tester',
     email: 'tester@example.com',
-    password: 'pass123',
+    passwordHash: 'pass123',
     role: 'manager',
     tenantId: new mongoose.Types.ObjectId(),
   });


### PR DESCRIPTION
## Summary
- enforce trimmed, unique, indexed, lowercase email in User schema
- rename password to passwordHash across model, controllers, scripts, and tests

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c089441b7c8323808d36997f998c84