### PR TITLE
Use passwordHash during user registration

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -84,7 +84,7 @@ router.post('/register', async (req, res) => {
     if (existing) {
       return res.status(400).json({ message: 'Email already in use' });
     }
-    const user = new User({ name, email, password, tenantId, employeeId });
+    const user = new User({ name, email, passwordHash: password, tenantId, employeeId });
     await user.save();
     return res.status(201).json({ message: 'User registered successfully' });
   } catch {


### PR DESCRIPTION
## Summary
- use `passwordHash` property when creating new users in auth routes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d13460fc83238579b1a0cc2b501c