### PR TITLE
refactor: centralize assertEmail helper

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -6,12 +6,12 @@ import { generateMfa, verifyMfa } from '../controllers/authController';
 import { configureOIDC } from '../auth/oidc';
 import { configureOAuth, getOAuthScope, OAuthProvider } from '../auth/oauth';
 import { getJwtSecret } from '../utils/getJwtSecret';
- import User from '../models/User';
+import User from '../models/User';
 import {
   loginSchema,
   registerSchema,
-  assertEmail,
 } from '../validators/authValidators';
+import { assertEmail } from '../utils/assert';
  
 
 configureOIDC();

--- a/backend/validators/authValidators.ts
+++ b/backend/validators/authValidators.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+export { assertEmail } from '../utils/assert';
 
 const email = z.string().email();
 
@@ -14,10 +15,6 @@ export const registerSchema = z.object({
   tenantId: z.string().min(1),
   employeeId: z.string().min(1),
 });
-
-export const assertEmail = (value: unknown): asserts value is string => {
-  email.parse(value);
-};
 
 export type LoginInput = z.infer<typeof loginSchema>;
 export type RegisterInput = z.infer<typeof registerSchema>;


### PR DESCRIPTION
## Summary
- remove duplicate assertEmail definition in auth validators
- import shared assertEmail in auth routes
- re-export assertEmail from validators using backend/utils/assert

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68c0d135c840832381711b1157d2455c