### PR TITLE
feat(auth): remove token from login response by default

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -52,12 +52,26 @@ router.post('/login', async (req, res) => {
     if (!secret) {
       return;
     }
-    const token = jwt.sign({
-      id: user._id.toString(),
-      email: user.email,
-      tenantId,
-    }, secret, { expiresIn: '7d' });
+    const token = jwt.sign(
+      {
+        id: user._id.toString(),
+        email: user.email,
+        tenantId,
+      },
+      secret,
+      { expiresIn: '7d' },
+    );
+
     const { password: _pw, ...safeUser } = user.toObject();
+
+    const responseBody: Record<string, unknown> = {
+      user: { ...safeUser, tenantId },
+    };
+
+    if (process.env.INCLUDE_AUTH_TOKEN === 'true') {
+      responseBody.token = token;
+    }
+
     return res
       .cookie('token', token, {
         httpOnly: true,
@@ -65,7 +79,7 @@ router.post('/login', async (req, res) => {
         secure: process.env.NODE_ENV === 'production',
       })
       .status(200)
-      .json({ token, user: { ...safeUser, tenantId } });
+      .json(responseBody);
   } catch {
     return res.status(500).json({ message: 'Server error' });
   }

--- a/backend/tests/authRoutes.test.ts
+++ b/backend/tests/authRoutes.test.ts
@@ -50,10 +50,31 @@ describe('Auth Routes', () => {
     expect(cookies[0]).toMatch(/token=/);
 
     expect(res.body.user.email).toBe('test@example.com');
+    expect(res.body.token).toBeUndefined();
 
     const token = cookies[0].split(';')[0].split('=')[1];
     const payload = jwt.verify(token, process.env.JWT_SECRET!) as jwt.JwtPayload;
     expect(payload.tenantId).toBe(res.body.user.tenantId);
+  });
+
+  it('optionally returns token in response when enabled', async () => {
+    process.env.INCLUDE_AUTH_TOKEN = 'true';
+    await User.create({
+      name: 'Config',
+      email: 'config@example.com',
+      passwordHash: 'pass123',
+      role: 'admin',
+      tenantId: new mongoose.Types.ObjectId(),
+    });
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'config@example.com', password: 'pass123' })
+      .expect(200);
+
+    expect(res.body.token).toBeDefined();
+
+    delete process.env.INCLUDE_AUTH_TOKEN;
   });
 
   it('gets current user with cookie and logs out', async () => {


### PR DESCRIPTION
## Summary
- make login response rely on http-only cookie and omit token unless `INCLUDE_AUTH_TOKEN` is true
- test that token is excluded by default and can be optionally returned

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d1396c0c8323b5189123c829a46b