### PR TITLE
Handle missing JWT secret in auth routes

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -49,7 +49,7 @@ router.post('/login', async (req, res) => {
 
     const tenantId = user.tenantId ? user.tenantId.toString() : undefined;
     const secret = getJwtSecret(res);
-    if (!secret) {
+    if (secret === undefined) {
       return;
     }
     const token = jwt.sign({
@@ -112,11 +112,11 @@ router.get('/oauth/:provider/callback', (req, res, next) => {
         return res.status(400).json({ message: 'Authentication failed' });
       }
       const secret = getJwtSecret(res);
-      if (!secret) {
+      if (secret === undefined) {
         return;
       }
       assertEmail(user.email);
-      const token = jwt.sign({ email: user.email }, secret as string, {
+      const token = jwt.sign({ email: user.email }, secret, {
         expiresIn: '7d',
       });
       const frontend = process.env.FRONTEND_URL || 'http://localhost:5173/login';


### PR DESCRIPTION
## Summary
- Guard against missing JWT secret in login and OAuth callbacks
- Remove unnecessary casts by ensuring secret is defined

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d13c72808323b9af8afc5863f6f1