### PR TITLE
refactor: centralize bcrypt salt rounds

### DIFF
--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -1,6 +1,11 @@
 import mongoose, { Schema, Document, Model, Types } from 'mongoose';
 import bcrypt from 'bcryptjs';
 
+// Number of bcrypt salt rounds. Increasing this value strengthens password hashes
+// but slows down hashing, impacting performance. Adjust here to change the
+// hashing cost globally.
+export const SALT_ROUNDS = 10;
+
 export type UserRole = 'admin' | 'manager' | 'technician' | 'viewer';
 
 // ✅ Interface for a user document
@@ -68,7 +73,7 @@ userSchema.pre<UserDocument>('save', async function (next) {
   if (!this.isModified('passwordHash')) return next();
 
   try {
-    this.passwordHash = await bcrypt.hash(this.passwordHash, 10);
+    this.passwordHash = await bcrypt.hash(this.passwordHash, SALT_ROUNDS);
     next();
   } catch (err) {
     next(err as Error);


### PR DESCRIPTION
## Summary
- export SALT_ROUNDS constant for bcrypt hashing in User model
- document security/performance tradeoffs for adjusting salt rounds
- replace magic number with constant

## Testing
- `npm test` (fails: sh: 1: vitest: not found)
- `npm run lint` (fails: ESLint couldn't find an eslint.config.* file)


------
https://chatgpt.com/codex/tasks/task_e_68c0d13e01708323bd44a1fb9b440d49