### PR TITLE
feat(auth): limit login and register attempts

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import passport from 'passport';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
+import rateLimit from 'express-rate-limit';
 import { generateMfa, verifyMfa } from '../controllers/authController';
 import { configureOIDC } from '../auth/oidc';
 import { configureOAuth, getOAuthScope, OAuthProvider } from '../auth/oauth';
@@ -17,11 +18,27 @@ import {
 configureOIDC();
 configureOAuth();
 
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60_000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: 'Too many login attempts. Please try again later.' },
+});
+
+const registerLimiter = rateLimit({
+  windowMs: 60 * 60_000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: 'Too many registration attempts. Please try again later.' },
+});
+
 const router = Router();
 router.use(passport.initialize());
 
 // Local login
-router.post('/login', async (req, res) => {
+router.post('/login', loginLimiter, async (req, res) => {
   const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ message: 'Invalid request' });
@@ -72,7 +89,7 @@ router.post('/login', async (req, res) => {
 });
 
 // Local register (optional)
-router.post('/register', async (req, res) => {
+router.post('/register', registerLimiter, async (req, res) => {
   const parsed = registerSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ message: 'Invalid request' });


### PR DESCRIPTION
## Summary
- add express-rate-limit middleware for /login
- throttle registration attempts via express-rate-limit

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm ci --offline` *(fails: ENOTCACHED, no cached response available)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d141d7bc8323899265ea84ec48dc