### PR TITLE
Validate tenant and employee IDs during registration

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -73,7 +73,7 @@ router.post('/login', async (req, res) => {
 
 // Local register (optional)
 router.post('/register', async (req, res) => {
-  const parsed = registerSchema.safeParse(req.body);
+  const parsed = await registerSchema.safeParseAsync(req.body);
   if (!parsed.success) {
     return res.status(400).json({ message: 'Invalid request' });
   }

--- a/backend/validators/authValidators.ts
+++ b/backend/validators/authValidators.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+import Tenant from '../models/Tenant';
+import TeamMember from '../models/TeamMember';
 
 const email = z.string().email();
 
@@ -11,8 +13,18 @@ export const registerSchema = z.object({
   name: z.string().min(1),
   email,
   password: z.string().min(1),
-  tenantId: z.string().min(1),
-  employeeId: z.string().min(1),
+  tenantId: z
+    .string()
+    .regex(/^[0-9a-fA-F]{24}$/)
+    .refine((val) => Tenant.exists({ _id: val }).then(Boolean), {
+      message: 'tenant does not exist',
+    }),
+  employeeId: z
+    .string()
+    .regex(/^[A-Za-z0-9_-]+$/)
+    .refine((val) => TeamMember.exists({ employeeId: val }).then(Boolean), {
+      message: 'employee not found',
+    }),
 });
 
 export const assertEmail = (value: unknown): asserts value is string => {


### PR DESCRIPTION
## Summary
- validate tenantId and employeeId formats and existence when registering
- use async safeParse in register route to support DB checks

## Testing
- `npm test` (fails: sh: 1: vitest: not found)
- `npm install vitest` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c0d147880883239f71707c3c86972b