### PR TITLE
Wrap async routes with error handling

### DIFF
--- a/backend/routes/CalendarRoutes.ts
+++ b/backend/routes/CalendarRoutes.ts
@@ -3,11 +3,17 @@ import WorkOrder from '../models/WorkOrder';
 
 const router = express.Router();
 
-router.get('/', async (_req, res) => {
-  const events = await WorkOrder.find({ dueDate: { $exists: true } }).select('title dueDate');
-  res.json(
-    events.map((e) => ({ id: e._id, title: e.title, date: e.dueDate }))
-  );
+router.get('/', async (_req, res, next) => {
+  try {
+    const events = await WorkOrder.find({ dueDate: { $exists: true } }).select(
+      'title dueDate',
+    );
+    res.json(
+      events.map((e) => ({ id: e._id, title: e.title, date: e.dueDate })),
+    );
+  } catch (err) {
+    next(err);
+  }
 });
 
 export default router;

--- a/backend/routes/IntegrationRoutes.ts
+++ b/backend/routes/IntegrationRoutes.ts
@@ -4,20 +4,32 @@ import { dispatchEvent, registerHook } from '../services/integrationHub';
 
 const router = Router();
 
-router.get('/hooks', async (_req, res) => {
-  const hooks = await IntegrationHook.find();
-  res.json(hooks);
+router.get('/hooks', async (_req, res, next) => {
+  try {
+    const hooks = await IntegrationHook.find();
+    res.json(hooks);
+  } catch (err) {
+    next(err);
+  }
 });
 
-router.post('/hooks', async (req, res) => {
-  const hook = await registerHook(req.body);
-  res.status(201).json(hook);
+router.post('/hooks', async (req, res, next) => {
+  try {
+    const hook = await registerHook(req.body);
+    res.status(201).json(hook);
+  } catch (err) {
+    next(err);
+  }
 });
 
-router.post('/dispatch', async (req, res) => {
-  const { event, payload } = req.body;
-  await dispatchEvent(event, payload);
-  res.status(202).json({ status: 'queued' });
+router.post('/dispatch', async (req, res, next) => {
+  try {
+    const { event, payload } = req.body;
+    await dispatchEvent(event, payload);
+    res.status(202).json({ status: 'queued' });
+  } catch (err) {
+    next(err);
+  }
 });
 
 export default router;

--- a/backend/routes/requestPortal.ts
+++ b/backend/routes/requestPortal.ts
@@ -16,18 +16,26 @@ async function verifyCaptcha(token: string): Promise<boolean> {
   return token === 'valid-captcha';
 }
 
-router.get('/:slug', async (req, res) => {
-  const form = await RequestForm.findOne({ slug: req.params.slug }).lean();
-  if (!form) return res.status(404).json({ message: 'Form not found' });
-  res.json(form.schema);
+router.get('/:slug', async (req, res, next) => {
+  try {
+    const form = await RequestForm.findOne({ slug: req.params.slug }).lean();
+    if (!form) return res.status(404).json({ message: 'Form not found' });
+    res.json(form.schema);
+  } catch (err) {
+    next(err);
+  }
 });
 
-router.post('/:slug', submissionLimiter, async (req, res) => {
-  const { captcha, ...data } = req.body;
-  if (!(await verifyCaptcha(captcha))) {
-    return res.status(400).json({ message: 'Invalid CAPTCHA' });
+router.post('/:slug', submissionLimiter, async (req, res, next) => {
+  try {
+    const { captcha } = req.body;
+    if (!(await verifyCaptcha(captcha))) {
+      return res.status(400).json({ message: 'Invalid CAPTCHA' });
+    }
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
   }
-  res.json({ success: true });
 });
 
 export default router;

--- a/backend/routes/vendorPortal.ts
+++ b/backend/routes/vendorPortal.ts
@@ -18,31 +18,35 @@ const router = express.Router();
 /**
  * Vendor login - issues a JWT for portal access
  */
-router.post('/login', async (req: Request, res: Response) => {
-  const { vendorId, email } = req.body as { vendorId?: string; email?: string };
-  if (!vendorId) {
-    res.status(400).json({ message: 'vendorId required' });
-    return;
-  }
-  if (email !== undefined) {
-    assertEmail(email);
-  }
+router.post('/login', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { vendorId, email } = req.body as { vendorId?: string; email?: string };
+    if (!vendorId) {
+      res.status(400).json({ message: 'vendorId required' });
+      return;
+    }
+    if (email !== undefined) {
+      assertEmail(email);
+    }
 
-  const vendor = await Vendor.findById(vendorId).lean();
-  if (!vendor || (email && vendor.email !== email)) {
-    res.status(401).json({ message: 'Invalid credentials' });
-    return;
-  }
+    const vendor = await Vendor.findById(vendorId).lean();
+    if (!vendor || (email && vendor.email !== email)) {
+      res.status(401).json({ message: 'Invalid credentials' });
+      return;
+    }
 
-  const secret = getJwtSecret(res, true);
-  if (!secret) {
-    return;
-  }
+    const secret = getJwtSecret(res, true);
+    if (!secret) {
+      return;
+    }
 
-  const token = jwt.sign({ id: vendor._id.toString() }, secret as string, {
-    expiresIn: '7d',
-  });
-  res.json({ token });
+    const token = jwt.sign({ id: vendor._id.toString() }, secret as string, {
+      expiresIn: '7d',
+    });
+    res.json({ token });
+  } catch (err) {
+    next(err);
+  }
 });
 
 // All routes below require a valid vendor token


### PR DESCRIPTION
## Summary
- ensure integration routes forward async errors via try/catch
- protect vendor, request portal, webhook, and calendar routes with error forwarding

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d2f59e8c8323926516250ab192c1