### PR TITLE
chore: normalize login timing with fake bcrypt compare

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -7,6 +7,9 @@ import logger from "../utils/logger";
 import User from "../models/User";
 import { assertEmail } from '../utils/assert';
 
+const FAKE_PASSWORD_HASH =
+  '$2b$10$lbmUy86xKlj1/lR8TPPby.1/KfNmrRrgOgGs3u21jcd2SzCBRqDB.';
+
 export const login = async (req: Request, res: Response): Promise<void> => {
   const { email, password } = req.body;
   logger.info('Login attempt', { email });
@@ -21,6 +24,8 @@ export const login = async (req: Request, res: Response): Promise<void> => {
     const user = await User.findOne({ email });
     logger.info('User lookup result', { found: !!user });
     if (!user) {
+      // Perform fake compare to mitigate timing attacks
+      await bcrypt.compare(req.body.password, FAKE_PASSWORD_HASH);
       res.status(401).json({ message: 'Invalid email or password' });
       return;
     }

--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -12,6 +12,9 @@ import {
   registerSchema,
   assertEmail,
 } from '../validators/authValidators';
+
+const FAKE_PASSWORD_HASH =
+  '$2b$10$lbmUy86xKlj1/lR8TPPby.1/KfNmrRrgOgGs3u21jcd2SzCBRqDB.';
  
 
 configureOIDC();
@@ -31,6 +34,8 @@ router.post('/login', async (req, res) => {
   try {
     const user = await User.findOne({ email });
     if (!user) {
+      // Perform fake compare to mitigate timing attacks
+      await bcrypt.compare(password, FAKE_PASSWORD_HASH);
       return res.status(400).json({ message: 'Invalid email or password' });
     }
 


### PR DESCRIPTION
## Summary
- mitigate timing attacks by performing fake bcrypt comparison when login email not found
- reuse constant bcrypt hash to maintain consistent response time

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d2f812ac83238ee78272e8817268