### PR TITLE
Handle duplicate key errors during user registration

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -76,12 +76,24 @@ export const register = async (req: Request, res: Response): Promise<void> => {
     }
 
     const user = new User({ name, email, passwordHash: password, tenantId, employeeId });
-    await user.save();
+    await user.save().catch((err: any) => {
+      if (err.code === 11000) {
+        res.status(400).json({ message: "Email or employee ID already in use" });
+        return;
+      }
+      throw err;
+    });
+
+    if (res.headersSent) {
+      return;
+    }
 
     res.status(201).json({ message: "User registered successfully" });
   } catch (err) {
-    logger.error("Register error", err);
-    res.status(500).json({ message: "Server error" });
+    if (!res.headersSent) {
+      logger.error("Register error", err);
+      res.status(500).json({ message: "Server error" });
+    }
   }
 };
 

--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -85,10 +85,21 @@ router.post('/register', async (req, res) => {
       return res.status(400).json({ message: 'Email already in use' });
     }
     const user = new User({ name, email, password, tenantId, employeeId });
-    await user.save();
+    await user.save().catch((err: any) => {
+      if (err.code === 11000) {
+        res.status(400).json({ message: 'Email or employee ID already in use' });
+        return;
+      }
+      throw err;
+    });
+    if (res.headersSent) {
+      return;
+    }
     return res.status(201).json({ message: 'User registered successfully' });
-  } catch {
-    return res.status(500).json({ message: 'Server error' });
+  } catch (err) {
+    if (!res.headersSent) {
+      return res.status(500).json({ message: 'Server error' });
+    }
   }
 });
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -47,6 +47,7 @@ import mongoose from "mongoose";
 import errorHandler from "./middleware/errorHandler";
 import { validateEnv, type EnvVars } from "./config/validateEnv";
 import { initChatSocket } from "./socket/chatSocket";
+import User from "./models/User";
 import type {
   WorkOrderUpdatePayload,
   InventoryUpdatePayload,
@@ -170,8 +171,14 @@ app.use(errorHandler);
 if (env.NODE_ENV !== "test") {
   mongoose
     .connect(MONGO_URI)
-    .then(() => {
+    .then(async () => {
       logger.info("MongoDB connected");
+      try {
+        await User.syncIndexes();
+        logger.info("User indexes synchronized");
+      } catch (indexErr) {
+        logger.error("User index sync error", indexErr);
+      }
       httpServer.listen(PORT, () =>
         logger.info(`Server listening on http://localhost:${PORT}`),
       );


### PR DESCRIPTION
## Summary
- handle duplicate key errors when saving users during registration
- ensure user collection indexes are synchronized at startup

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68c0d2fa3bc08323a689ca09a459eaa2