### PR TITLE
feat: require jwt secret

### DIFF
--- a/backend/config/validateEnv.ts
+++ b/backend/config/validateEnv.ts
@@ -18,8 +18,11 @@ export type EnvVars = z.infer<typeof envSchema>;
 export function validateEnv(): EnvVars {
   const parsed = envSchema.safeParse(process.env);
   if (!parsed.success) {
-    const missing = parsed.error.flatten().fieldErrors;
-    console.error('❌ Invalid environment variables:', missing);
+    const errors = parsed.error.flatten().fieldErrors;
+    if (errors.JWT_SECRET) {
+      throw new Error('JWT_SECRET environment variable is required');
+    }
+    console.error('❌ Invalid environment variables:', errors);
     throw new Error('Missing or invalid environment variables');
   }
   return parsed.data;


### PR DESCRIPTION
## Summary
- ensure the backend fails fast when JWT_SECRET is missing by throwing a clear error during env validation

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d2fa5fa48323ac33b72fe1ee60e0