### PR TITLE
feat: make cookie security configurable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,7 @@ CORS_ORIGIN=http://localhost:5173
 # PM_SCHEDULER_CRON=*/5 * * * *
 # PM_SCHEDULER_TASK=./tasks/pmSchedulerTask
 # NODE_ENV=development
+# COOKIE_SECURE=
 # RATE_LIMIT_WINDOW_MS=60000
 # RATE_LIMIT_MAX=100
 # LOG_LEVEL=info

--- a/backend/README.md
+++ b/backend/README.md
@@ -152,7 +152,7 @@ below along with its default value if one exists.
 | --- | --- | --- |
 | `MONGO_URI` | MongoDB connection string. | `mongodb://localhost:27017/platinum_cmms` |
 | `PORT` | HTTP port the server listens on. | `5010` |
-| `NODE_ENV` | Environment name controlling secure cookies. | `development` |
+| `NODE_ENV` | Environment name controlling secure cookies when `COOKIE_SECURE` is unset. | `development` |
 | `JWT_SECRET` | Secret key used to sign JWT tokens. Required for authentication. | *(none)* |
 | `CORS_ORIGIN` | Allowed origins for CORS, comma separated. | `http://localhost:5173` |
 | `PM_SCHEDULER_CRON` | Cron expression controlling the PM scheduler. | `*/5 * * * *` |
@@ -162,6 +162,7 @@ below along with its default value if one exists.
 | `SMTP_USER` | Username for SMTP authentication. | *(none)* |
 | `SMTP_PASS` | Password for SMTP authentication. | *(none)* |
 | `SMTP_FROM` | Default from address for outgoing mail. | value of `SMTP_USER` |
+| `COOKIE_SECURE` | Set to `'true'` to always send cookies with the `Secure` flag, or `'false'` to disable it. Defaults to `NODE_ENV === 'production'`. | *(unset)* |
  
 | `KAFKA_BROKERS` | Comma-separated Kafka brokers used for the event queue. | *(none)* |
 | `KAFKA_CLIENT_ID` | Client id for the Kafka connection. | `cmms-backend` |

--- a/backend/config/validateEnv.ts
+++ b/backend/config/validateEnv.ts
@@ -8,6 +8,7 @@ const envSchema = z.object({
   RATE_LIMIT_WINDOW_MS: z.string().default('900000'),
   RATE_LIMIT_MAX: z.string().default('100'),
   NODE_ENV: z.string().default('development'),
+  COOKIE_SECURE: z.string().optional(),
   PM_SCHEDULER_CRON: z.string().default('*/5 * * * *'),
   PM_SCHEDULER_TASK: z.string().default('./tasks/pmSchedulerTask'),
   DEFAULT_TENANT_ID: z.string().optional(),

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -6,6 +6,7 @@ import * as speakeasy from "speakeasy";
 import logger from "../utils/logger";
 import User from "../models/User";
 import { assertEmail } from '../utils/assert';
+import { isCookieSecure } from '../utils/isCookieSecure';
 
 export const login = async (req: Request, res: Response): Promise<void> => {
   const { email, password } = req.body;
@@ -197,7 +198,7 @@ export const logout = (
     .clearCookie('token', {
       httpOnly: true,
       sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
+      secure: isCookieSecure(),
     })
     .sendStatus(200);
 };

--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -6,7 +6,8 @@ import { generateMfa, verifyMfa } from '../controllers/authController';
 import { configureOIDC } from '../auth/oidc';
 import { configureOAuth, getOAuthScope, OAuthProvider } from '../auth/oauth';
 import { getJwtSecret } from '../utils/getJwtSecret';
- import User from '../models/User';
+import User from '../models/User';
+import { isCookieSecure } from '../utils/isCookieSecure';
 import {
   loginSchema,
   registerSchema,
@@ -62,7 +63,7 @@ router.post('/login', async (req, res) => {
       .cookie('token', token, {
         httpOnly: true,
         sameSite: 'lax',
-        secure: process.env.NODE_ENV === 'production',
+        secure: isCookieSecure(),
       })
       .status(200)
       .json({ token, user: { ...safeUser, tenantId } });

--- a/backend/tests/authRoutes.test.ts
+++ b/backend/tests/authRoutes.test.ts
@@ -83,4 +83,26 @@ describe('Auth Routes', () => {
       .set('Cookie', cookies)
       .expect(200);
   });
+
+  it('uses secure cookies when configured', async () => {
+    process.env.COOKIE_SECURE = 'true';
+    await User.create({
+      name: 'Secure',
+      email: 'secure@example.com',
+      passwordHash: 'pass123',
+      role: 'viewer',
+      tenantId: new mongoose.Types.ObjectId(),
+    });
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'secure@example.com', password: 'pass123' })
+      .expect(200);
+
+    const cookies = res.headers['set-cookie'];
+    expect(cookies).toBeDefined();
+    expect(cookies[0]).toMatch(/Secure/);
+
+    delete process.env.COOKIE_SECURE;
+  });
 });

--- a/backend/utils/isCookieSecure.ts
+++ b/backend/utils/isCookieSecure.ts
@@ -1,0 +1,8 @@
+export const isCookieSecure = (): boolean => {
+  if (process.env.COOKIE_SECURE !== undefined) {
+    return process.env.COOKIE_SECURE === 'true';
+  }
+  return process.env.NODE_ENV === 'production';
+};
+
+export default isCookieSecure;


### PR DESCRIPTION
## Summary
- allow overriding cookie Secure flag with COOKIE_SECURE env variable
- document COOKIE_SECURE and add tests

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68c0d2fba39c83238b0074aa74f19764