### PR TITLE
refactor: clarify MFA controller naming

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -118,7 +118,7 @@ export const requestPasswordReset = async (
   }
 };
 
-export const generateMfa = async (req: Request, res: Response): Promise<void> => {
+export const setupMfa = async (req: Request, res: Response): Promise<void> => {
   const { userId } = req.body;
   try {
     const user = await User.findById(userId);
@@ -132,12 +132,12 @@ export const generateMfa = async (req: Request, res: Response): Promise<void> =>
     const token = speakeasy.totp({ secret: user.mfaSecret, encoding: 'base32' });
     res.json({ secret: user.mfaSecret, token });
   } catch (err) {
-    logger.error('generateMfa error', err);
+    logger.error('setupMfa error', err);
     res.status(500).json({ message: 'Server error' });
   }
 };
 
-export const verifyMfa = async (req: Request, res: Response): Promise<void> => {
+export const validateMfaToken = async (req: Request, res: Response): Promise<void> => {
   const { userId, token } = req.body;
   try {
     const user = await User.findById(userId);
@@ -167,7 +167,7 @@ export const verifyMfa = async (req: Request, res: Response): Promise<void> => {
     const { passwordHash: _pw, ...safeUser } = user.toObject();
     res.json({ token: jwtToken, user: { ...safeUser, tenantId } });
   } catch (err) {
-    logger.error('verifyMfa error', err);
+    logger.error('validateMfaToken error', err);
     res.status(500).json({ message: 'Server error' });
   }
 };

--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import passport from 'passport';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
-import { generateMfa, verifyMfa } from '../controllers/authController';
+import { setupMfa, validateMfaToken } from '../controllers/authController';
 import { configureOIDC } from '../auth/oidc';
 import { configureOAuth, getOAuthScope, OAuthProvider } from '../auth/oauth';
 import { getJwtSecret } from '../utils/getJwtSecret';
@@ -129,7 +129,7 @@ router.get('/oauth/:provider/callback', (req, res, next) => {
 });
 
 // MFA endpoints
-router.post('/mfa/setup', generateMfa);
-router.post('/mfa/verify', verifyMfa);
+router.post('/mfa/setup', setupMfa);
+router.post('/mfa/verify', validateMfaToken);
 
 export default router;


### PR DESCRIPTION
## Summary
- rename generateMfa to setupMfa for clearer multi-factor setup naming
- rename verifyMfa to validateMfaToken to reflect token validation
- update auth routes to use new MFA controller names

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d2fe45f8832398f98f03fcb6cf35