### PR TITLE
refactor: centralize OAuth scope configuration

### DIFF
--- a/backend/auth/oauth.ts
+++ b/backend/auth/oauth.ts
@@ -3,13 +3,7 @@ import type { Strategy as PassportStrategy } from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import { Strategy as GithubStrategy } from 'passport-github2';
 
-export type OAuthProvider = 'google' | 'github';
-
-export const getOAuthScope = (provider: OAuthProvider): string[] => {
-  return provider === 'google'
-    ? ['profile', 'email']
-    : ['user:email'];
-};
+export { type OAuthProvider } from '../config/oauthScopes';
 
 interface OAuthProfile {
   emails?: Array<{ value?: string }>;

--- a/backend/config/oauthScopes.ts
+++ b/backend/config/oauthScopes.ts
@@ -1,0 +1,11 @@
+export type OAuthProvider = 'google' | 'github';
+
+export const oauthScopes: Record<OAuthProvider, string[]> = {
+  google: ['profile', 'email'],
+  github: ['user:email'],
+};
+
+export const getOAuthScope = (provider: OAuthProvider): string[] =>
+  oauthScopes[provider];
+
+export default oauthScopes;

--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -4,7 +4,8 @@ import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 import { generateMfa, verifyMfa } from '../controllers/authController';
 import { configureOIDC } from '../auth/oidc';
-import { configureOAuth, getOAuthScope, OAuthProvider } from '../auth/oauth';
+import { configureOAuth } from '../auth/oauth';
+import { OAuthProvider, getOAuthScope } from '../config/oauthScopes';
 import { getJwtSecret } from '../utils/getJwtSecret';
  import User from '../models/User';
 import {


### PR DESCRIPTION
## Summary
- centralize OAuth provider scopes in `backend/config/oauthScopes.ts`
- update auth routes to pull OAuth scopes from config
- re-export `OAuthProvider` type from oauth module

## Testing
- `npm --prefix backend test` *(fails: vitest not found)*
- `npm --prefix backend run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68c0d2ff4170832397ab4f4c2e904c99