### PR TITLE
Handle bcrypt compare errors

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -25,7 +25,14 @@ export const login = async (req: Request, res: Response): Promise<void> => {
       return;
     }
 
-    const valid = await bcrypt.compare(req.body.password, user.passwordHash);
+    let valid: boolean;
+    try {
+      valid = await bcrypt.compare(req.body.password, user.passwordHash);
+    } catch (err) {
+      logger.error('Password comparison error', err);
+      res.status(500).json({ message: 'Server error' });
+      return;
+    }
     logger.info('Password comparison result', { valid });
     if (!valid) {
       res.status(401).json({ message: 'Invalid email or password' });

--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -36,7 +36,13 @@ router.post('/login', async (req, res) => {
 
     assertEmail(user.email);
 
-    const valid = await bcrypt.compare(password, user.password);
+    let valid: boolean;
+    try {
+      valid = await bcrypt.compare(password, user.password);
+    } catch (err) {
+      console.error('Password comparison error', err);
+      return res.status(500).json({ message: 'Server error' });
+    }
     if (!valid) {
       return res.status(400).json({ message: 'Invalid email or password' });
     }

--- a/backend/scripts/verifyAdminHash.ts
+++ b/backend/scripts/verifyAdminHash.ts
@@ -10,6 +10,10 @@ const storedHash = "$2b$10$lbmUy86xKlj1/lR8TPPby.1/KfNmrRrgOgGs3u21jcd2SzCBRqDB.
 const password = "admin123";
 
 (async () => {
-  const match = await bcrypt.compare(password, storedHash);
-  console.log(match);
+  try {
+    const match = await bcrypt.compare(password, storedHash);
+    console.log(match);
+  } catch (err) {
+    console.error('Error verifying password hash', err);
+  }
 })();


### PR DESCRIPTION
## Summary
- wrap bcrypt.compare in try/catch in verifyAdminHash script
- guard bcrypt.compare in auth login controller
- log and handle bcrypt.compare errors in auth routes

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d30062ac83238622773eecfd2914