### PR TITLE
feat: clarify login handler return types

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
 import passport from 'passport';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
@@ -21,7 +21,10 @@ const router = Router();
 router.use(passport.initialize());
 
 // Local login
-router.post('/login', async (req, res) => {
+router.post('/login', async (
+  req: Request,
+  res: Response,
+): Promise<Response> => {
   const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ message: 'Invalid request' });
@@ -50,7 +53,7 @@ router.post('/login', async (req, res) => {
     const tenantId = user.tenantId ? user.tenantId.toString() : undefined;
     const secret = getJwtSecret(res);
     if (!secret) {
-      return;
+      return res;
     }
     const token = jwt.sign({
       id: user._id.toString(),

--- a/backend/routes/vendorPortal.ts
+++ b/backend/routes/vendorPortal.ts
@@ -18,11 +18,13 @@ const router = express.Router();
 /**
  * Vendor login - issues a JWT for portal access
  */
-router.post('/login', async (req: Request, res: Response) => {
+router.post('/login', async (
+  req: Request,
+  res: Response,
+): Promise<Response> => {
   const { vendorId, email } = req.body as { vendorId?: string; email?: string };
   if (!vendorId) {
-    res.status(400).json({ message: 'vendorId required' });
-    return;
+    return res.status(400).json({ message: 'vendorId required' });
   }
   if (email !== undefined) {
     assertEmail(email);
@@ -30,19 +32,18 @@ router.post('/login', async (req: Request, res: Response) => {
 
   const vendor = await Vendor.findById(vendorId).lean();
   if (!vendor || (email && vendor.email !== email)) {
-    res.status(401).json({ message: 'Invalid credentials' });
-    return;
+    return res.status(401).json({ message: 'Invalid credentials' });
   }
 
   const secret = getJwtSecret(res, true);
   if (!secret) {
-    return;
+    return res;
   }
 
   const token = jwt.sign({ id: vendor._id.toString() }, secret as string, {
     expiresIn: '7d',
   });
-  res.json({ token });
+  return res.json({ token });
 });
 
 // All routes below require a valid vendor token


### PR DESCRIPTION
## Summary
- explicitly type auth login handler to return Promise<Response>
- add return type for vendor portal login and ensure consistent Response returns

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d300ee64832381e0badfe12c8bac