### PR TITLE
chore: limit auth user fields

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -18,7 +18,9 @@ export const login = async (req: Request, res: Response): Promise<void> => {
   assertEmail(email);
 
   try {
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email }).select(
+      '+passwordHash name email role tenantId mfaEnabled'
+    );
     logger.info('User lookup result', { found: !!user });
     if (!user) {
       res.status(401).json({ message: 'Invalid email or password' });


### PR DESCRIPTION
## Summary
- select only required user fields, explicitly including passwordHash, during login lookup

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d335c150832399775bfa0e2bb38e