### PR TITLE
Refactor JWT secret retrieval

### DIFF
--- a/backend/routes/vendorPortal.ts
+++ b/backend/routes/vendorPortal.ts
@@ -34,12 +34,15 @@ router.post('/login', async (req: Request, res: Response) => {
     return;
   }
 
-  const secret = getJwtSecret(res, true);
-  if (!secret) {
+  let secret: string;
+  try {
+    secret = getJwtSecret(process.env, true);
+  } catch {
+    res.status(500).json({ message: 'Server configuration issue' });
     return;
   }
 
-  const token = jwt.sign({ id: vendor._id.toString() }, secret as string, {
+  const token = jwt.sign({ id: vendor._id.toString() }, secret, {
     expiresIn: '7d',
   });
   res.json({ token });

--- a/backend/utils/getJwtSecret.ts
+++ b/backend/utils/getJwtSecret.ts
@@ -1,16 +1,13 @@
-import type { Response } from 'express';
-
 export const getJwtSecret = (
-  res: Response,
+  env: NodeJS.ProcessEnv = process.env,
   includeVendor = false,
-): string | undefined => {
+): string => {
   const secret = includeVendor
-    ? process.env.VENDOR_JWT_SECRET || process.env.JWT_SECRET
-    : process.env.JWT_SECRET;
+    ? env.VENDOR_JWT_SECRET || env.JWT_SECRET
+    : env.JWT_SECRET;
 
   if (!secret) {
-    res.status(500).json({ message: 'Server configuration issue' });
-    return undefined;
+    throw new Error('Server configuration issue');
   }
 
   return secret;


### PR DESCRIPTION
## Summary
- Refactor getJwtSecret to accept an environment object and throw on missing config
- Update auth and vendor routes to handle JWT secret retrieval without mutating responses

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d33888b08323993836d089871914