### PR TITLE
Remove redundant email assertions in auth routes

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -7,11 +7,8 @@ import { configureOIDC } from '../auth/oidc';
 import { configureOAuth, getOAuthScope, OAuthProvider } from '../auth/oauth';
 import { getJwtSecret } from '../utils/getJwtSecret';
  import User from '../models/User';
-import {
-  loginSchema,
-  registerSchema,
-  assertEmail,
-} from '../validators/authValidators';
+import { loginSchema, registerSchema } from '../validators/authValidators';
+import { assertEmail } from '../utils/assert';
  
 
 configureOIDC();
@@ -33,8 +30,6 @@ router.post('/login', async (req, res) => {
     if (!user) {
       return res.status(400).json({ message: 'Invalid email or password' });
     }
-
-    assertEmail(user.email);
 
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) {

--- a/backend/validators/authValidators.ts
+++ b/backend/validators/authValidators.ts
@@ -15,9 +15,5 @@ export const registerSchema = z.object({
   employeeId: z.string().min(1),
 });
 
-export const assertEmail = (value: unknown): asserts value is string => {
-  email.parse(value);
-};
-
 export type LoginInput = z.infer<typeof loginSchema>;
 export type RegisterInput = z.infer<typeof registerSchema>;


### PR DESCRIPTION
## Summary
- Drop unnecessary email assertion in login handler now that Zod validates the request
- Use shared assertEmail helper for OAuth callback
- Remove unused assertEmail helper from auth validators

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d338cd088323ad231909863b2a5f