### PR TITLE
chore: enforce strict same-site cookies

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -70,8 +70,12 @@ Running the seed script adds a small reporting hierarchy of example users:
 
 ## Authentication
 
-User sessions rely on a JWT stored in the `token` cookie. Clients must include this cookie on each request so the `requireAuth` middleware can verify the session. Ensure cookies are enabled in your HTTP client or browser.
-When `NODE_ENV` is set to `production` the cookie is created with the `Secure` flag enabled and is also cleared using the same option so it is only sent over HTTPS connections.
+User sessions rely on a JWT stored in the `token` cookie. Clients must include
+this cookie on each request so the `requireAuth` middleware can verify the
+session. The cookie is issued with `HttpOnly` and `SameSite=Strict` flags to
+mitigate cross-site request forgery, and when `NODE_ENV` is set to `production`
+the `Secure` flag is also enabled so it is only sent over HTTPS connections.
+Ensure cookies are enabled in your HTTP client or browser.
 
 ## Summary Endpoints
 

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -196,7 +196,7 @@ export const logout = (
   res
     .clearCookie('token', {
       httpOnly: true,
-      sameSite: 'lax',
+      sameSite: 'strict',
       secure: process.env.NODE_ENV === 'production',
     })
     .sendStatus(200);

--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -61,7 +61,7 @@ router.post('/login', async (req, res) => {
     return res
       .cookie('token', token, {
         httpOnly: true,
-        sameSite: 'lax',
+        sameSite: 'strict',
         secure: process.env.NODE_ENV === 'production',
       })
       .status(200)

--- a/backend/tests/authRoutes.test.ts
+++ b/backend/tests/authRoutes.test.ts
@@ -48,6 +48,7 @@ describe('Auth Routes', () => {
     const cookies = res.headers['set-cookie'];
     expect(cookies).toBeDefined();
     expect(cookies[0]).toMatch(/token=/);
+    expect(cookies[0]).toMatch(/SameSite=Strict/);
 
     expect(res.body.user.email).toBe('test@example.com');
 


### PR DESCRIPTION
## Summary
- issue authentication cookies with `SameSite=Strict` to mitigate CSRF
- document strict cookie policy in backend README
- cover new flag in auth route tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d33a0aac8323b5cceba2b28ffce3