### PR TITLE
chore: add eslint and ci lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Lint
+        run: npm run lint --if-present
+
       - name: Typecheck (if present)
         run: npm run typecheck --if-present
 
@@ -55,6 +58,9 @@ jobs:
 
       - name: Install
         run: npm ci
+
+      - name: Lint
+        run: npm run lint --if-present
 
       - name: Typecheck
         run: npm run typecheck --if-present

--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -18,5 +18,9 @@ module.exports = {
   ignorePatterns: ['dist', 'node_modules'],
   rules: {
     'prettier/prettier': 'error',
+    'sort-imports': ['error', { ignoreDeclarationSort: true }],
+    indent: ['error', 2],
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error'],
   },
 };

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -23,6 +23,10 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
+      'sort-imports': ['error', { ignoreDeclarationSort: true }],
+      indent: ['error', 2],
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': ['error'],
     },
   }
 );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint . --ext .ts,.tsx"
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",
@@ -55,6 +56,12 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.0.3",
+    "@eslint/js": "^8.57.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "eslint-plugin-react-refresh": "^0.4.6",
+    "globals": "^15.0.0",
+    "typescript-eslint": "^8.10.0",
     "autoprefixer": "^10",
     "jsdom": "^26.1.0",
     "postcss": "^8",


### PR DESCRIPTION
## Summary
- add TypeScript-aware ESLint rules for imports, spacing, and unused variables
- run lint in CI for frontend and backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d33a4b9c83238a5514eef0c587fd