### PR TITLE
Log provider errors in OAuth callback

### DIFF
--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -109,6 +109,9 @@ router.get('/oauth/:provider/callback', (req, res, next) => {
     { session: false },
     (err: Error | null, user: Express.User | false | null) => {
       if (err || !user) {
+        if (err) {
+          console.error(`OAuth ${provider} callback error:`, err);
+        }
         return res.status(400).json({ message: 'Authentication failed' });
       }
       const secret = getJwtSecret(res);


### PR DESCRIPTION
## Summary
- log OAuth callback errors with provider name before returning 400

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d33b0a688323b744859aefbeeef1