### PR TITLE
Add field allowlists to key controllers

### DIFF
--- a/backend/controllers/UserController.ts
+++ b/backend/controllers/UserController.ts
@@ -1,4 +1,20 @@
 import User from '../models/User';
+import { filterFields } from '../utils/filterFields';
+
+const userCreateFields = [
+  'name',
+  'email',
+  'passwordHash',
+  'role',
+  'employeeId',
+  'managerId',
+  'theme',
+  'colorScheme',
+  'mfaEnabled',
+  'mfaSecret',
+];
+
+const userUpdateFields = [...userCreateFields];
 
 /**
  * @openapi
@@ -80,7 +96,8 @@ export const createUser: AuthedRequestHandler = async (
   next
 ) => {
   try {
-    const newItem = new User({ ...req.body, tenantId: req.tenantId });
+    const payload = filterFields(req.body, userCreateFields);
+    const newItem = new User({ ...payload, tenantId: req.tenantId });
     const saved = await newItem.save();
     const { passwordHash: _pw, ...safeUser } = saved.toObject();
     res.status(201).json(safeUser);
@@ -120,9 +137,10 @@ export const updateUser: AuthedRequestHandler = async (
   next
 ) => {
   try {
+    const update = filterFields(req.body, userUpdateFields);
     const updated = await User.findOneAndUpdate(
       { _id: req.params.id, tenantId: req.tenantId },
-      req.body,
+      update,
       {
         new: true,
         runValidators: true,

--- a/backend/utils/filterFields.ts
+++ b/backend/utils/filterFields.ts
@@ -1,0 +1,10 @@
+export const filterFields = <T extends Record<string, any>>(source: T, allowed: string[]): Partial<T> => {
+  const result: Partial<T> = {};
+  for (const field of allowed) {
+    if (source[field] !== undefined) {
+      (result as any)[field] = source[field];
+    }
+  }
+  return result;
+};
+


### PR DESCRIPTION
## Summary
- introduce utility to filter request bodies by allowed fields
- restrict Asset, User, and WorkOrder controllers to defined create/update fields

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c138fc8d6c8323b9c38908fcf71093