### PR TITLE
Refactor inline route handlers and handle unused parameters

### DIFF
--- a/backend/routes/CalendarRoutes.ts
+++ b/backend/routes/CalendarRoutes.ts
@@ -1,18 +1,18 @@
-import express from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import WorkOrder from '../models/WorkOrder';
 
 const router = express.Router();
 
-router.get('/', async (_req, res, next) => {
+router.get('/', async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const events = await WorkOrder.find({ dueDate: { $exists: true } }).select(
       'title dueDate',
     );
-    res.json(
+    return res.json(
       events.map((e) => ({ id: e._id, title: e.title, date: e.dueDate })),
     );
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 

--- a/backend/routes/IntegrationRoutes.ts
+++ b/backend/routes/IntegrationRoutes.ts
@@ -1,34 +1,34 @@
-import { Router } from 'express';
+import { Router, type Request, type Response, type NextFunction } from 'express';
 import IntegrationHook from '../models/IntegrationHook';
 import { dispatchEvent, registerHook } from '../services/integrationHub';
 
 const router = Router();
 
-router.get('/hooks', async (_req, res, next) => {
+router.get('/hooks', async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const hooks = await IntegrationHook.find();
-    res.json(hooks);
+    return res.json(hooks);
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 
-router.post('/hooks', async (req, res, next) => {
+router.post('/hooks', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const hook = await registerHook(req.body);
-    res.status(201).json(hook);
+    return res.status(201).json(hook);
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 
-router.post('/dispatch', async (req, res, next) => {
+router.post('/dispatch', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { event, payload } = req.body;
     await dispatchEvent(event, payload);
-    res.status(202).json({ status: 'queued' });
+    return res.status(202).json({ status: 'queued' });
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 

--- a/backend/routes/requestPortal.ts
+++ b/backend/routes/requestPortal.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
 import RequestForm from '../models/RequestForm';
 
@@ -16,25 +16,31 @@ async function verifyCaptcha(token: string): Promise<boolean> {
   return token === 'valid-captcha';
 }
 
-router.get('/:slug', async (req, res, next) => {
+router.get('/:slug', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const form = await RequestForm.findOne({ slug: req.params.slug }).lean();
-    if (!form) return res.status(404).json({ message: 'Form not found' });
-    res.json(form.schema);
+    if (!form) {
+      return res.status(404).json({ message: 'Form not found' });
+    }
+    return res.json(form.schema);
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 
-router.post('/:slug', submissionLimiter, async (req, res, next) => {
+router.post('/:slug', submissionLimiter, async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
   try {
     const { captcha } = req.body;
     if (!(await verifyCaptcha(captcha))) {
       return res.status(400).json({ message: 'Invalid CAPTCHA' });
     }
-    res.json({ success: true });
+    return res.json({ success: true });
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 

--- a/backend/routes/webhooksRoutes.ts
+++ b/backend/routes/webhooksRoutes.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import crypto from 'crypto';
 import { handleWorkOrderHook } from '../controllers/WebhookController';
 import { requireThirdPartyAuth } from '../middleware/thirdPartyAuth';
@@ -8,7 +8,11 @@ import idempotency from '../middleware/idempotency';
 const router = express.Router();
 
 // Subscribe to events
-router.post('/subscribe', idempotency, async (req, res, next) => {
+router.post('/subscribe', idempotency, async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
   try {
     const { url, event } = req.body;
     if (!url || !event) {
@@ -16,11 +20,11 @@ router.post('/subscribe', idempotency, async (req, res, next) => {
     }
     const secret = crypto.randomBytes(32).toString('hex');
     const hook = await Webhook.create({ url, event, secret });
-    res
+    return res
       .status(201)
       .json({ id: hook._id, url: hook.url, event: hook.event, secret });
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 


### PR DESCRIPTION
## Summary
- Refactor inline route handlers to use typed async callbacks with try/catch and `next` error handling
- Rename unused parameters and ensure responses are returned to satisfy lint rules

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68c146f1714c8323b72578bf0fce8f1b