### PR TITLE
refactor: remove unused types from work order controller

### DIFF
--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -30,10 +30,6 @@ const workOrderCreateFields = [
 
 const workOrderUpdateFields = [...workOrderCreateFields];
 
-// Single, shared param type for routes with :id
-type IdParams = { id: string };
- 
-
 function toWorkOrderUpdatePayload(doc: any): WorkOrderUpdatePayload {
   const plain = typeof doc.toObject === "function"
     ? doc.toObject({ getters: true, virtuals: false })
@@ -43,13 +39,6 @@ function toWorkOrderUpdatePayload(doc: any): WorkOrderUpdatePayload {
     _id: (plain._id as Types.ObjectId | string)?.toString(),
   } as WorkOrderUpdatePayload;
 }
-
-type SearchQuery = {
-  status?: 'open' | 'in-progress' | 'on-hold' | 'completed';
-  priority?: 'low' | 'medium' | 'high' | 'critical';
-  startDate?: string;
-  endDate?: string;
-};
 
 /**
  * @openapi


### PR DESCRIPTION
## Summary
- remove unused IdParams and SearchQuery type declarations from WorkOrderController

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c17f46abc083238c9d7f22a8302d1d