### PR TITLE
Fix auth controller exports and cleanup auth routes

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -1,34 +1,47 @@
-import type { NextFunction, Response } from 'express';
-import type { AuthedRequest, AuthedRequestHandler } from '../types/http';
-import Asset from '../models/Asset';
-import { validationResult } from 'express-validator';
-import mongoose from 'mongoose';
+import type { Response, NextFunction } from 'express';
+import type { AuthedRequestHandler } from '../types/http';
 
-// GET /assets
-export const getAllAssets: AuthedRequestHandler = async (req, res, next) => {
+/**
+ * Return the authenticated user's payload from the request.
+ */
+export const getMe: AuthedRequestHandler = async (req, res, next) => {
   try {
-    const filter: any = { tenantId: req.tenantId };
-    if (req.siteId) filter.siteId = req.siteId;
-    const assets = await Asset.find(filter);
-    return res.json(assets);
-  } catch (err) {
-    return next(err);
-  }
-};
-
-// GET /assets/:id
-export const getAssetById: AuthedRequestHandler = async (req, res, next) => {
-  try {
-    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
-      return res.status(400).json({ message: 'Invalid ID' });
+    const user = (req as any).user;
+    if (!user) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
     }
-    const filter: any = { _id: req.params.id, tenantId: req.tenantId };
-    if (req.siteId) filter.siteId = req.siteId;
-
-    const asset = await Asset.findOne(filter);
-    if (!asset) return res.status(404).json({ message: 'Not found' });
-    return res.json(asset);
+    res.status(200).json({ user });
+    return;
   } catch (err) {
-    return next(err);
+    next(err);
+    return;
   }
 };
+
+/**
+ * Clear the authentication token cookie and end the session.
+ */
+export const logout: AuthedRequestHandler = (req, res) => {
+  res.clearCookie('token');
+  res.status(200).json({ message: 'Logged out successfully' });
+  return;
+};
+
+/**
+ * Placeholder MFA setup handler. In a real implementation this would
+ * generate and return a secret for the user to configure their MFA device.
+ */
+export const setupMfa: AuthedRequestHandler = (req, res) => {
+  res.status(501).json({ message: 'MFA setup not implemented' });
+  return;
+};
+
+/**
+ * Placeholder MFA token validation handler.
+ */
+export const validateMfaToken: AuthedRequestHandler = (req, res) => {
+  res.status(501).json({ message: 'MFA token validation not implemented' });
+  return;
+};
+


### PR DESCRIPTION
## Summary
- add placeholder auth controller methods like getMe, logout and MFA helpers
- normalize auth route handlers to send responses then return

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c17f42f8188323b62d0b55b24d815e