### PR TITLE
refactor: adjust validateObjectId middleware to return void

### DIFF
--- a/backend/middleware/validateObjectId.ts
+++ b/backend/middleware/validateObjectId.ts
@@ -8,9 +8,10 @@ const validateObjectId = (paramName: string) => (
 ): void => {
   const id = req.params[paramName];
   if (!mongoose.Types.ObjectId.isValid(id)) {
-    return res.status(400).json({ message: `Invalid ${paramName}` });
+    res.status(400).json({ message: `Invalid ${paramName}` });
+    return;
   }
-  return next();
+  next();
 };
 
 export default validateObjectId;


### PR DESCRIPTION
## Summary
- streamline validateObjectId middleware to return void and send 400 error without chaining

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18ddcc7e4832384cc431073d2988d