### PR TITLE
refactor: type sync event

### DIFF
--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -99,7 +99,7 @@ self.addEventListener('message', (event) => {
   }
 });
 
-self.addEventListener('sync', (event) => {
+self.addEventListener('sync', (event: SyncEvent) => {
   if (event.tag === 'offline-queue') {
     event.waitUntil(processQueue());
   }


### PR DESCRIPTION
## Summary
- type service worker sync listener as `SyncEvent`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint%2fjs)*

------
https://chatgpt.com/codex/tasks/task_e_68c18ddd6ddc8323b5dacf4b83b2473b