### PR TITLE
chore: remove duplicate express imports

### DIFF
--- a/backend/controllers/AnalyticsController.ts
+++ b/backend/controllers/AnalyticsController.ts
@@ -3,7 +3,6 @@ import { getKPIs } from '../services/analytics';
 import { Parser as Json2csvParser } from 'json2csv';
 import PDFDocument from 'pdfkit';
 import { escapeXml } from '../utils/escapeXml';
-import { Request, Response, NextFunction } from 'express';
 
  export const kpiJson = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
  

--- a/backend/controllers/DepartmentController.ts
+++ b/backend/controllers/DepartmentController.ts
@@ -1,6 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
 import Department from '../models/Department';
-import { Request, Response, NextFunction } from 'express';
 
  export const listDepartments = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
  

--- a/backend/controllers/MeterController.ts
+++ b/backend/controllers/MeterController.ts
@@ -1,7 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import Meter from '../models/Meter';
 import MeterReading from '../models/MeterReading';
-import { Request, Response, NextFunction } from 'express';
 
  export const getMeters = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
  

--- a/backend/controllers/ReportsController.ts
+++ b/backend/controllers/ReportsController.ts
@@ -7,7 +7,6 @@ import WorkHistory from '../models/WorkHistory';
 import User from '../models/User';
 import TimeSheet from '../models/TimeSheet';
 import Inventory from '../models/Inventory';
-import { Request, Response, NextFunction } from 'express';
 
 async function calculateStats(tenantId: string, role?: string) {
   const roleFilter = role || 'technician';

--- a/backend/controllers/ThemeController.ts
+++ b/backend/controllers/ThemeController.ts
@@ -1,6 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
 import User from '../models/User';
-import { Request, Response, NextFunction } from 'express';
 
  export const getTheme = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {


### PR DESCRIPTION
## Summary
- remove duplicate Request/Response/NextFunction imports across backend controllers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68c197637cf48323aa4ed8ea17a2a388