### PR TITLE
fix: add SyncEvent typing to service worker

### DIFF
--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -13,6 +13,12 @@ interface SyncEvent extends ExtendableEvent {
   readonly tag: string;
 }
 
+declare global {
+  interface ServiceWorkerGlobalScopeEventMap {
+    sync: SyncEvent;
+  }
+}
+
 const DB_NAME = 'offline-queue';
 const STORE_NAME = 'requests';
 let offlineQueue: QueueItem[] = [];


### PR DESCRIPTION
## Summary
- add SyncEvent type augmentation for service worker

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c1976bb1ac8323bce6b37a4f5df89a