### PR TITLE
refactor: adjust async route handlers

### DIFF
--- a/backend/routes/CalendarRoutes.ts
+++ b/backend/routes/CalendarRoutes.ts
@@ -3,16 +3,16 @@ import WorkOrder from '../models/WorkOrder';
 
 const router = express.Router();
 
-router.get('/', async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const events = await WorkOrder.find({ dueDate: { $exists: true } }).select(
       'title dueDate',
     );
-    return res.json(
+    res.json(
       events.map((e) => ({ id: e._id, title: e.title, date: e.dueDate })),
     );
   } catch (err) {
-    return next(err);
+    next(err);
   }
 });
 

--- a/backend/routes/IntegrationRoutes.ts
+++ b/backend/routes/IntegrationRoutes.ts
@@ -4,31 +4,31 @@ import { dispatchEvent, registerHook } from '../services/integrationHub';
 
 const router = Router();
 
-router.get('/hooks', async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+router.get('/hooks', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const hooks = await IntegrationHook.find();
-    return res.json(hooks);
+    res.json(hooks);
   } catch (err) {
-    return next(err);
+    next(err);
   }
 });
 
-router.post('/hooks', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+router.post('/hooks', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const hook = await registerHook(req.body);
-    return res.status(201).json(hook);
+    res.status(201).json(hook);
   } catch (err) {
-    return next(err);
+    next(err);
   }
 });
 
-router.post('/dispatch', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+router.post('/dispatch', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { event, payload } = req.body;
     await dispatchEvent(event, payload);
-    return res.status(202).json({ status: 'queued' });
+    res.status(202).json({ status: 'queued' });
   } catch (err) {
-    return next(err);
+    next(err);
   }
 });
 

--- a/backend/routes/requestPortal.ts
+++ b/backend/routes/requestPortal.ts
@@ -16,15 +16,16 @@ async function verifyCaptcha(token: string): Promise<boolean> {
   return token === 'valid-captcha';
 }
 
-router.get('/:slug', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const form = await RequestForm.findOne({ slug: req.params.slug }).lean();
     if (!form) {
-      return res.status(404).json({ message: 'Form not found' });
+      res.status(404).json({ message: 'Form not found' });
+      return;
     }
-    return res.json(form.schema);
+    res.json(form.schema);
   } catch (err) {
-    return next(err);
+    next(err);
   }
 });
 
@@ -32,15 +33,16 @@ router.post('/:slug', submissionLimiter, async (
   req: Request,
   res: Response,
   next: NextFunction,
-): Promise<void> => {
+) => {
   try {
     const { captcha } = req.body;
     if (!(await verifyCaptcha(captcha))) {
-      return res.status(400).json({ message: 'Invalid CAPTCHA' });
+      res.status(400).json({ message: 'Invalid CAPTCHA' });
+      return;
     }
-    return res.json({ success: true });
+    res.json({ success: true });
   } catch (err) {
-    return next(err);
+    next(err);
   }
 });
 

--- a/backend/routes/webhooksRoutes.ts
+++ b/backend/routes/webhooksRoutes.ts
@@ -12,19 +12,20 @@ router.post('/subscribe', idempotency, async (
   req: Request,
   res: Response,
   next: NextFunction,
-): Promise<void> => {
+) => {
   try {
     const { url, event } = req.body;
     if (!url || !event) {
-      return res.status(400).json({ message: 'url and event required' });
+      res.status(400).json({ message: 'url and event required' });
+      return;
     }
     const secret = crypto.randomBytes(32).toString('hex');
     const hook = await Webhook.create({ url, event, secret });
-    return res
+    res
       .status(201)
       .json({ id: hook._id, url: hook.url, event: hook.event, secret });
   } catch (err) {
-    return next(err);
+    next(err);
   }
 });
 


### PR DESCRIPTION
## Summary
- avoid returning responses in various Express route handlers
- streamline error paths to call next without returning

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68c19ca33b288323932ccc1620990ff3