### PR TITLE
refactor: replace AuthedRequest with Express Request

### DIFF
--- a/backend/routes/PredictiveRoutes.ts
+++ b/backend/routes/PredictiveRoutes.ts
@@ -1,11 +1,11 @@
-import express from 'express';
+import express, { type Request } from 'express';
 import { getPredictions, getTrend } from '../controllers/PredictiveController';
 import { requireAuth } from '../middleware/authMiddleware';
 
 const router = express.Router();
 router.use(requireAuth);
-router.get('/', (req: AuthedRequest, res, next) => getPredictions(req, res, next));
-router.get('/trend/:assetId/:metric', (req: AuthedRequest, res, next) =>
+router.get('/', (req: Request, res, next) => getPredictions(req, res, next));
+router.get('/trend/:assetId/:metric', (req: Request, res, next) =>
   getTrend(req, res, next)
 );
 

--- a/backend/routes/vendorPortal.ts
+++ b/backend/routes/vendorPortal.ts
@@ -1,6 +1,5 @@
 import express, { type Request, type Response, type NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import type { AuthedRequest } from '../types/express';
 
 import Vendor from '../models/Vendor';
 import PurchaseOrder from '../models/PurchaseOrder';
@@ -72,7 +71,7 @@ router.get('/pos', listVendorPurchaseOrders);
 router.get(
   '/purchase-orders/:id',
   async (
-    req: AuthedRequest,
+    req: Request,
     res: Response,
     next: NextFunction,
   ): Promise<void> => {

--- a/backend/types/http.ts
+++ b/backend/types/http.ts
@@ -1,3 +1,4 @@
-import type { RequestHandler } from 'express';
+import type { Request, RequestHandler } from 'express';
 
 export type AuthedRequestHandler = RequestHandler;
+export type AuthedRequest = Request;


### PR DESCRIPTION
## Summary
- rely on Express Request type in predictive and vendor routes
- export AuthedRequest alias in http types to support augmented request typing

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm install @types/node` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68c19ca6aaa88323868a25b2c5fab142