### PR TITLE
refactor: add typed http request utilities

### DIFF
--- a/Backend/types/http.ts
+++ b/Backend/types/http.ts
@@ -1,4 +1,16 @@
-import type { Request, RequestHandler } from 'express';
+import type { RequestHandler, Request, ParamsDictionary } from 'express';
+import type { ParsedQs } from 'qs';
 
-export type AuthedRequestHandler = RequestHandler;
-export type AuthedRequest = Request;
+export type AuthedRequestHandler<
+  P = ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = ParsedQs,
+> = RequestHandler<P, ResBody, ReqBody, ReqQuery>;
+
+export type AuthedRequest<
+  P = ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = ParsedQs,
+> = Request<P, ResBody, ReqBody, ReqQuery>;

--- a/backend/types/http.ts
+++ b/backend/types/http.ts
@@ -1,4 +1,16 @@
-import type { Request, RequestHandler } from 'express';
+import type { RequestHandler, Request, ParamsDictionary } from 'express';
+import type { ParsedQs } from 'qs';
 
-export type AuthedRequestHandler = RequestHandler;
-export type AuthedRequest = Request;
+export type AuthedRequestHandler<
+  P = ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = ParsedQs,
+> = RequestHandler<P, ResBody, ReqBody, ReqQuery>;
+
+export type AuthedRequest<
+  P = ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = ParsedQs,
+> = Request<P, ResBody, ReqBody, ReqQuery>;


### PR DESCRIPTION
## Summary
- expand HTTP request utilities with generic support for params and queries
- update both backend HTTP type definitions

## Testing
- `npm run typecheck` (fails: Cannot find type definition file for 'node')
- `npx tsc -p Backend/tsconfig.json --noEmit` (fails: Cannot find type definition file for 'node')

------
https://chatgpt.com/codex/tasks/task_e_68c1a03c3cf88323b1484680b3b59a53