### PR TITLE
refactor: avoid response returns in webhook subscribe

### DIFF
--- a/backend/routes/webhooksRoutes.ts
+++ b/backend/routes/webhooksRoutes.ts
@@ -12,7 +12,7 @@ router.post('/subscribe', idempotency, async (
   req: Request,
   res: Response,
   next: NextFunction,
-) => {
+): Promise<void> => {
   try {
     const { url, event } = req.body;
     if (!url || !event) {
@@ -24,6 +24,7 @@ router.post('/subscribe', idempotency, async (
     res
       .status(201)
       .json({ id: hook._id, url: hook.url, event: hook.event, secret });
+    return;
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## Summary
- annotate webhook subscribe handler with explicit Promise<void>
- avoid returning Express response objects

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a03e1b3883239b6feb16cf5fe850