### PR TITLE
chore: add React import to vendor login

### DIFF
--- a/frontend/src/vendor/Login.tsx
+++ b/frontend/src/vendor/Login.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 


### PR DESCRIPTION
## Summary
- ensure vendor login includes explicit React import

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c1fad50184832382ea8038cc203912