### PR TITLE
refactor: stabilize inventory modal callback

### DIFF
--- a/frontend/src/components/inventory/InventoryScanModal.tsx
+++ b/frontend/src/components/inventory/InventoryScanModal.tsx
@@ -10,7 +10,7 @@ import type { Part } from '@/types';
 interface InventoryScanModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onScanComplete: (data: Partial<Part>) => void;
+  onScanComplete: (part: Part | null, init?: Partial<Part>) => void;
 }
 
 const InventoryScanModal: React.FC<InventoryScanModalProps> = ({
@@ -30,7 +30,7 @@ const InventoryScanModal: React.FC<InventoryScanModalProps> = ({
         if (cancelled) return;
         try {
           const data = JSON.parse(raw) as Partial<Part>;
-          onScanComplete(data);
+          onScanComplete(null, data);
         } catch (err) {
           console.error('Invalid QR data', err);
         } finally {
@@ -47,7 +47,7 @@ const InventoryScanModal: React.FC<InventoryScanModalProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, onClose, onScanComplete]);
+  }, [isOpen, onClose]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Scan QR Code">

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Plus, Search, Download, Upload, AlertTriangle, QrCode } from 'lucide-react';
 import Button from '@/components/common/Button';
 import InventoryTable from '@/components/inventory/InventoryTable';
@@ -39,12 +39,15 @@ const Inventory: React.FC = () => {
     fetchParts();
   }, []);
 
-  const handleOpenModal = (part: Part | null, init?: Partial<Part>) => {
-    setSelectedPart(part);
-    setInitialData(init);
-    setModalError(null);
-    setModalOpen(true);
-  };
+  const handleOpenModal = useCallback(
+    (part: Part | null, init?: Partial<Part>) => {
+      setSelectedPart(part);
+      setInitialData(init);
+      setModalError(null);
+      setModalOpen(true);
+    },
+    []
+  );
 
   const partMapper = (part: Part) => ({
     ID: part.id,
@@ -180,7 +183,7 @@ const Inventory: React.FC = () => {
         <InventoryScanModal
           isOpen={isScanOpen}
           onClose={() => setScanOpen(false)}
-          onScanComplete={(data) => handleOpenModal(null, data)}
+          onScanComplete={handleOpenModal}
         />
       </div>
   );


### PR DESCRIPTION
## Summary
- wrap `handleOpenModal` in `useCallback` to keep a stable reference
- pass the modal opener directly to `InventoryScanModal`
- adjust `InventoryScanModal` to invoke the opener with scanned data

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bd9851b88323951ef4ec6d1e5a7b