### PR TITLE
feat: add public request-work submission page

### DIFF
--- a/frontend/src/pages/RequestWork.tsx
+++ b/frontend/src/pages/RequestWork.tsx
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { useEffect, useState } from 'react';
+import { useForm, type Resolver } from 'react-hook-form';
+import { z } from 'zod';
+
+const requestWorkSchema = z.object({
+  assetId: z.string().optional(),
+  locationText: z.string().optional(),
+  description: z.string().min(1, 'Description is required'),
+  contact: z.string().min(1, 'Contact is required'),
+});
+
+export type RequestWorkForm = z.infer<typeof requestWorkSchema>;
+
+const POLL_INTERVAL = 1000;
+
+const RequestWork = () => {
+  const resolver: Resolver<RequestWorkForm> = async (values) => {
+    const result = requestWorkSchema.safeParse(values);
+    if (result.success) {
+      return { values: result.data, errors: {} };
+    }
+    const fieldErrors = result.error.flatten().fieldErrors;
+    const errors = Object.fromEntries(
+      Object.entries(fieldErrors).map(([key, value]) => [
+        key,
+        { type: 'validation', message: value?.[0] ?? 'Invalid value' },
+      ]),
+    );
+    return { values: {}, errors } as any;
+  };
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RequestWorkForm>({ resolver });
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [code, setCode] = useState<string | null>(null);
+  const [status, setStatus] = useState<string>('');
+
+  useEffect(() => {
+    if (!code) return;
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/public/request-work/${code}`);
+        if (!res.ok) throw new Error('Failed to fetch status');
+        const data = await res.json();
+        setStatus(data.status);
+        if (data.status && data.status !== 'pending') {
+          clearInterval(interval);
+        }
+      } catch (err) {
+        setError('Failed to fetch status');
+        clearInterval(interval);
+      }
+    }, POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [code]);
+
+  const onSubmit = async (values: RequestWorkForm) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/public/request-work', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (!res.ok) throw new Error('Failed to submit');
+      const data = await res.json();
+      setCode(data.code);
+      setStatus('pending');
+    } catch (err) {
+      setError('Failed to submit request');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Request Work</h1>
+      {error && <p role="alert" className="text-red-500">{error}</p>}
+      {!code && (
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label htmlFor="assetId" className="block text-sm font-medium">Asset ID</label>
+            <input id="assetId" className="border p-2 w-full" {...register('assetId')} />
+          </div>
+          <div>
+            <label htmlFor="locationText" className="block text-sm font-medium">Location</label>
+            <input id="locationText" className="border p-2 w-full" {...register('locationText')} />
+          </div>
+          <div>
+            <label htmlFor="description" className="block text-sm font-medium">Description</label>
+            <textarea
+              id="description"
+              className="border p-2 w-full"
+              {...register('description')}
+            />
+            {errors.description && <p className="text-red-500">{errors.description.message}</p>}
+          </div>
+          <div>
+            <label htmlFor="contact" className="block text-sm font-medium">Contact</label>
+            <input id="contact" className="border p-2 w-full" {...register('contact')} />
+            {errors.contact && <p className="text-red-500">{errors.contact.message}</p>}
+          </div>
+          <button type="submit" className="bg-primary-500 text-white px-4 py-2 rounded" disabled={loading}>
+            {loading ? 'Submitting...' : 'Submit'}
+          </button>
+        </form>
+      )}
+      {code && (
+        <div className="space-y-2">
+          <p>
+            Code: <span className="font-mono" data-testid="code">{code}</span>
+          </p>
+          <p>
+            Status: <span data-testid="status">{status}</span>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RequestWork;
+

--- a/frontend/src/portal/index.tsx
+++ b/frontend/src/portal/index.tsx
@@ -4,6 +4,8 @@
 
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import type { RouteObject } from 'react-router-dom';
+import { lazy } from 'react';
 
 interface Field {
   name: string;
@@ -11,7 +13,7 @@ interface Field {
   type?: string;
 }
 
-const Portal: React.FC = () => {
+export const RequestPortal: React.FC = () => {
   const { slug = 'default' } = useParams();
   const [fields, setFields] = useState<Field[]>([]);
   const [formData, setFormData] = useState<Record<string, any>>({});
@@ -73,4 +75,11 @@ const Portal: React.FC = () => {
   );
 };
 
-export default Portal;
+const RequestWork = lazy(() => import('../pages/RequestWork'));
+
+const routes: RouteObject[] = [
+  { path: '/portal/:slug', element: <RequestPortal /> },
+  { path: '/request', element: <RequestWork /> },
+];
+
+export default routes;

--- a/frontend/src/test/requestWork.test.tsx
+++ b/frontend/src/test/requestWork.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, afterAll, afterEach, vi } from 'vitest';
+import RequestWork from '../pages/RequestWork';
+
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  vi.clearAllTimers();
+});
+afterAll(() => server.close());
+
+test('submits request and polls for status', async () => {
+  vi.useFakeTimers();
+  server.use(
+    rest.post('/api/public/request-work', (_req, res, ctx) => res(ctx.json({ code: 'ABC123' }))),
+    rest.get('/api/public/request-work/ABC123', (_req, res, ctx) => res(ctx.json({ status: 'done' }))),
+  );
+
+  render(<RequestWork />);
+
+  await userEvent.type(screen.getByLabelText(/Description/i), 'Need help');
+  await userEvent.type(screen.getByLabelText(/Contact/i), 'me@example.com');
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+  expect(await screen.findByTestId('code')).toHaveTextContent('ABC123');
+
+  vi.advanceTimersByTime(1000);
+
+  await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('done'));
+});
+
+test('shows error on failed submit', async () => {
+  server.use(rest.post('/api/public/request-work', (_req, res, ctx) => res(ctx.status(500))));
+
+  render(<RequestWork />);
+
+  await userEvent.type(screen.getByLabelText(/Description/i), 'Need help');
+  await userEvent.type(screen.getByLabelText(/Contact/i), 'me@example.com');
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+  expect(await screen.findByRole('alert')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- add RequestWork page with form validation and status polling
- expose /request route in portal
- test RequestWork page with mocked backend

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest-axe)*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e3c26a588323a3efb25bf3c8ea93