### PR TITLE
feat: add keyboard-driven global search

### DIFF
--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Search, Package, ClipboardList } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface Asset { id: string; name: string }
+interface WorkOrder { id: string; title: string }
+
+type Result =
+  | { type: 'asset'; id: string; name: string }
+  | { type: 'workorder'; id: string; title: string };
+
+export default function GlobalSearch({ open, onOpenChange }: Props) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Result[]>([]);
+  const [selected, setSelected] = useState(0);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!query.trim()) {
+      setResults([]);
+      return;
+    }
+    let active = true;
+    async function load() {
+      try {
+        const [assetsRes, workRes] = await Promise.all([
+          fetch(`/api/assets?search=${encodeURIComponent(query)}`).then(r => r.json()),
+          fetch(`/api/workorders?search=${encodeURIComponent(query)}`).then(r => r.json()),
+        ]);
+        if (!active) return;
+        const assets = (assetsRes as Asset[]).map(a => ({ type: 'asset', id: a.id, name: a.name }));
+        const works = (workRes as WorkOrder[]).map(w => ({ type: 'workorder', id: w.id, title: w.title }));
+        setResults([...assets, ...works]);
+        setSelected(0);
+      } catch {
+        // ignore
+      }
+    }
+    load();
+    return () => {
+      active = false;
+    };
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setResults([]);
+      setSelected(0);
+    }
+  }, [open]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelected(s => Math.min(s + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelected(s => Math.max(s - 1, 0));
+    } else if (e.key === 'Enter' && results[selected]) {
+      const r = results[selected];
+      if (r.type === 'asset') navigate(`/assets/${r.id}`);
+      else navigate(`/work-orders/${r.id}`);
+      onOpenChange(false);
+    } else if (e.key === 'Escape') {
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="space-y-4" onKeyDown={handleKeyDown}>
+        <DialogHeader>
+          <DialogTitle>Search</DialogTitle>
+        </DialogHeader>
+        <div className="flex items-center border rounded px-2 py-1">
+          <Search size={16} />
+          <input
+            autoFocus
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search..."
+            className="ml-2 flex-1 bg-transparent outline-none"
+          />
+        </div>
+        <ul className="max-h-60 overflow-y-auto">
+          {results.map((r, idx) => (
+            <li
+              key={`${r.type}-${r.id}`}
+              className={`flex items-center px-2 py-1 cursor-pointer ${idx === selected ? 'bg-neutral-100 dark:bg-neutral-700' : ''}`}
+            >
+              {r.type === 'asset' ? <Package size={16} className="mr-2" /> : <ClipboardList size={16} className="mr-2" />}
+              <span>{r.type === 'asset' ? r.name : r.title}</span>
+            </li>
+          ))}
+          {query && results.length === 0 && (
+            <li className="px-2 py-1 text-sm text-neutral-500">No results</li>
+          )}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -7,6 +7,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 
 import { Search, Bell, HelpCircle, Menu, Book, Video, MessageCircle, FileText, ExternalLink, Database } from 'lucide-react';
+import GlobalSearch from '@/components/GlobalSearch';
 import { useToast } from '../../context/ToastContext';
  
 import ThemeToggle from '@common/ThemeToggle';
@@ -42,6 +43,7 @@ const Header: React.FC<HeaderProps> = ({ onToggleSidebar, title }) => {
   const [showHelpMenu, setShowHelpMenu] = useState(false);
   const [showMobileSearch, setShowMobileSearch] = useState(false);
   const [showNotifications, setShowNotifications] = useState(false);
+  const [showGlobalSearch, setShowGlobalSearch] = useState(false);
 
   const notificationsButtonRef = useRef<HTMLButtonElement>(null);
   const notificationsMenuRef = useRef<HTMLDivElement>(null);
@@ -92,6 +94,17 @@ const Header: React.FC<HeaderProps> = ({ onToggleSidebar, title }) => {
       helpButtonRef.current?.focus();
     }
   }, [showHelpMenu]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setShowGlobalSearch(true);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
  
  
@@ -201,6 +214,7 @@ const Header: React.FC<HeaderProps> = ({ onToggleSidebar, title }) => {
   const toggleNotifications = () => setShowNotifications(prev => !prev);
 
   return (
+    <>
     <header className="relative h-16 bg-white dark:bg-neutral-800 border-b border-neutral-200 dark:border-neutral-700 flex items-center justify-between px-2 sm:px-4 lg:px-6">
       <div className="flex items-center">
         <button
@@ -423,6 +437,8 @@ const Header: React.FC<HeaderProps> = ({ onToggleSidebar, title }) => {
         </div>
       )}
     </header>
+    <GlobalSearch open={showGlobalSearch} onOpenChange={setShowGlobalSearch} />
+  </>
   );
 };
 

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { useEffect, useRef } from 'react';
+import { cn } from '@/utils/cn';
+
+interface DialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+export function Dialog({ open, onOpenChange, children }: DialogProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    if (open) {
+      dialog.showModal();
+    } else if (dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    const handler = () => onOpenChange(false);
+    dialog.addEventListener('close', handler);
+    return () => dialog.removeEventListener('close', handler);
+  }, [onOpenChange]);
+
+  return (
+    <dialog ref={ref} className="rounded-lg p-0 w-full max-w-lg backdrop:bg-black/50">
+      {children}
+    </dialog>
+  );
+}
+
+export function DialogContent({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('p-6', className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function DialogHeader({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('mb-4', className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function DialogTitle({ children, className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h2 className={cn('text-lg font-semibold', className)} {...props}>
+      {children}
+    </h2>
+  );
+}
+
+export function DialogDescription({ children, className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return (
+    <p className={cn('text-sm text-neutral-600', className)} {...props}>
+      {children}
+    </p>
+  );
+}
+
+export default Dialog;

--- a/frontend/src/test/globalSearch.test.tsx
+++ b/frontend/src/test/globalSearch.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import GlobalSearch from '@/components/GlobalSearch';
+
+function Wrapper() {
+  const [open, setOpen] = React.useState(false);
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+  return (
+    <MemoryRouter>
+      <GlobalSearch open={open} onOpenChange={setOpen} />
+    </MemoryRouter>
+  );
+}
+
+describe('GlobalSearch', () => {
+  it('opens with keyboard and performs search', async () => {
+    const user = userEvent.setup();
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ json: async () => [{ id: 'a1', name: 'Pump' }] })
+      .mockResolvedValueOnce({ json: async () => [{ id: 'w1', title: 'Fix Pump' }] });
+
+    render(<Wrapper />);
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+
+    const input = await screen.findByPlaceholderText('Search...');
+    await user.type(input, 'pump');
+
+    expect(fetch).toHaveBeenCalledWith('/api/assets?search=pump');
+    expect(fetch).toHaveBeenCalledWith('/api/workorders?search=pump');
+
+    expect(await screen.findByText('Pump')).toBeInTheDocument();
+    expect(await screen.findByText('Fix Pump')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add global search dialog with keyboard navigation
- hook meta/ctrl+k shortcut into header
- cover search with a simple smoke test

## Testing
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e3c0c9e08323a56564e088d68b4b