### PR TITLE
Add public work request API

### DIFF
--- a/backend/models/WorkRequest.ts
+++ b/backend/models/WorkRequest.ts
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import mongoose from 'mongoose';
+
+const workRequestSchema = new mongoose.Schema(
+  {
+    tenantId: { type: mongoose.Schema.Types.ObjectId, index: true },
+    assetId: { type: mongoose.Schema.Types.ObjectId, ref: 'Asset' },
+    locationText: String,
+    description: { type: String, required: true },
+    contact: { type: String, required: true },
+    status: {
+      type: String,
+      enum: ['new', 'closed'],
+      default: 'new',
+    },
+    code: { type: String, required: true, unique: true },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('WorkRequest', workRequestSchema);

--- a/backend/routes/index.ts
+++ b/backend/routes/index.ts
@@ -32,3 +32,4 @@ export { default as predictiveRoutes } from './PredictiveRoutes';
 export { default as TenantRoutes } from './TenantRoutes';
 export { default as workOrdersRoutes } from './WorkOrderRoutes';
 export { default as webhooksRoutes } from './WebhooksRoutes';
+export { default as publicRequestRoutes } from './publicRequestRoutes';

--- a/backend/routes/publicRequestRoutes.ts
+++ b/backend/routes/publicRequestRoutes.ts
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Router } from 'express';
+import WorkRequest from '../models/WorkRequest';
+
+const router = Router();
+
+router.post('/request-work', async (req, res) => {
+  const { tenantId, assetId, locationText, description, contact } = req.body;
+  const code = Math.random().toString(36).substring(2, 8).toUpperCase();
+
+  await WorkRequest.create({
+    tenantId,
+    assetId,
+    locationText,
+    description,
+    contact,
+    code,
+    status: 'new',
+  });
+
+  console.log(`Work request submitted: ${code}`);
+
+  res.status(201).json({ code });
+});
+
+router.get('/request-work/:code', async (req, res) => {
+  const { code } = req.params;
+  const request = await WorkRequest.findOne({ code });
+  if (!request) {
+    return res.status(404).json({ message: 'Not found' });
+  }
+  res.json({ status: request.status });
+});
+
+export default router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -36,6 +36,7 @@ import {
   teamRoutes,
   ThemeRoutes,
   requestPortalRoutes,
+  publicRequestRoutes,
   vendorPortalRoutes,
   chatRoutes,
   webhooksRoutes,
@@ -139,6 +140,8 @@ if (env.NODE_ENV === "test") {
     res.json(req.query);
   });
 }
+
+app.use("/api/public", publicRequestRoutes);
 
 // --- Routes (order matters for the limiter) ---
 app.use("/api/auth", authRoutes);

--- a/backend/tests/publicRequestRoutes.test.ts
+++ b/backend/tests/publicRequestRoutes.test.ts
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, it, beforeAll, afterAll, beforeEach, expect, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import publicRequestRoutes from '../routes/publicRequestRoutes';
+
+const app = express();
+app.use(express.json());
+app.use('/api/public', publicRequestRoutes);
+
+let mongo: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+});
+
+describe('Public work requests', () => {
+  it('creates a work request without auth and returns code', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const res = await request(app)
+      .post('/api/public/request-work')
+      .send({ description: 'Need help', contact: 'user@example.com' })
+      .expect(201);
+    expect(res.body.code).toBeDefined();
+    expect(typeof res.body.code).toBe('string');
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('retrieves status by code', async () => {
+    const {
+      body: { code },
+    } = await request(app)
+      .post('/api/public/request-work')
+      .send({ description: 'Need help', contact: 'user@example.com' })
+      .expect(201);
+    const getRes = await request(app)
+      .get(`/api/public/request-work/${code}`)
+      .expect(200);
+    expect(getRes.body.status).toBe('new');
+  });
+});


### PR DESCRIPTION
## Summary
- add WorkRequest mongoose model
- expose public request-work endpoints
- test public work request flow

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e3bc32fc83238e2b006d7af6257b