### PR TITLE
refactor: use logger for kafka utils

### DIFF
--- a/backend/utils/kafka.ts
+++ b/backend/utils/kafka.ts
@@ -24,7 +24,7 @@ const consumer: Consumer | null = kafka ? kafka.consumer({ groupId }) : null;
 
 export const initKafka = async (io?: SocketIOServer) => {
   if (!enabled || !producer || !consumer) {
-    console.log('Kafka is disabled, skipping initKafka');
+    logger.info('Kafka disabled; skipping initKafka');
     return;
   }
   await producer.connect();
@@ -48,7 +48,7 @@ export const initKafka = async (io?: SocketIOServer) => {
 
 export const sendKafkaEvent = async (topic: string, payload: unknown) => {
   if (!enabled || !producer) {
-    console.log('Kafka is disabled, skipping sendKafkaEvent');
+    logger.warn('Kafka disabled; skipping sendKafkaEvent');
     return;
   }
   try {


### PR DESCRIPTION
## Summary
- use shared logger for Kafka utility
- add context to messages when Kafka is disabled

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c50c2df7c883239026e7507553c153