### PR TITLE
Conditional auth token response

### DIFF
--- a/backend/routes/AuthRoutes.ts
+++ b/backend/routes/AuthRoutes.ts
@@ -125,7 +125,7 @@ router.post('/login', loginLimiter, async (
         secure: process.env.NODE_ENV === 'production',
       })
       .status(200)
-      .json({ token, user: { ...userObj, tenantId } });
+      .json(responseBody);
     return;
   } catch (err) {
     logger.error('Login error:', err);

--- a/backend/tests/authRoutes.test.ts
+++ b/backend/tests/authRoutes.test.ts
@@ -82,6 +82,24 @@ describe('Auth Routes', () => {
     delete process.env.INCLUDE_AUTH_TOKEN;
   });
 
+  it('excludes token when INCLUDE_AUTH_TOKEN is unset', async () => {
+    delete process.env.INCLUDE_AUTH_TOKEN;
+    await User.create({
+      name: 'NoToken',
+      email: 'notoken@example.com',
+      passwordHash: 'pass123',
+      roles: ['admin'],
+      tenantId: new mongoose.Types.ObjectId(),
+    });
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'notoken@example.com', password: 'pass123' })
+      .expect(200);
+
+    expect(res.body.token).toBeUndefined();
+  });
+
   it('gets current user with cookie and logs out', async () => {
     await User.create({
       name: 'Me',


### PR DESCRIPTION
## Summary
- send responseBody in login route so token is optional
- add test ensuring no token in response when INCLUDE_AUTH_TOKEN is unset

## Testing
- `npm test` (fails: sh: 1: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c50c2f42cc8323b5b451bded455aee