### PR TITLE
Use passwordHash on register and test hashing

### DIFF
--- a/backend/routes/AuthRoutes.ts
+++ b/backend/routes/AuthRoutes.ts
@@ -154,7 +154,13 @@ router.post(
         return;
       }
 
-      const user = new User({ name, email, password, tenantId, employeeId });
+      const user = new User({
+        name,
+        email,
+        passwordHash: password,
+        tenantId,
+        employeeId,
+      });
       try {
         await user.save();
       } catch (err: any) {

--- a/backend/tests/authRoutes.test.ts
+++ b/backend/tests/authRoutes.test.ts
@@ -8,6 +8,7 @@ import express from 'express';
 import cookieParser from 'cookie-parser';
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import bcrypt from 'bcryptjs';
 import User from '../models/User';
 import jwt from 'jsonwebtoken';
 import authRoutes from '../routes/AuthRoutes';
@@ -35,6 +36,30 @@ beforeEach(async () => {
 });
 
 describe('Auth Routes', () => {
+  it('registers a new user with hashed password', async () => {
+    const password = 'pass123';
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({
+        name: 'New User',
+        email: 'new@example.com',
+        password,
+        tenantId: new mongoose.Types.ObjectId().toString(),
+        employeeId: 'EMP1',
+      })
+      .expect(201);
+
+    expect(res.body.message).toBe('User registered successfully');
+
+    const user = await User.findOne({ email: 'new@example.com' }).lean();
+    expect(user).toBeTruthy();
+    expect(user?.passwordHash).toBeDefined();
+    expect(user?.passwordHash).not.toBe(password);
+    const match = await bcrypt.compare(password, user!.passwordHash);
+    expect(match).toBe(true);
+  });
+
   it('logs in and sets cookie', async () => {
     await User.create({
       name: 'Test',


### PR DESCRIPTION
## Summary
- use `passwordHash` when creating a user through auth routes
- add regression test covering user registration and hashing

## Testing
- `npm test tests/authRoutes.test.ts` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c50c30d8688323b5575ec3f686703a