### PR TITLE
refactor: centralize cookie security

### DIFF
--- a/backend/routes/AuthRoutes.ts
+++ b/backend/routes/AuthRoutes.ts
@@ -19,6 +19,7 @@ import { assertEmail } from '../utils/assert';
 // Adjust this import path if your middleware lives elsewhere:
 import { requireAuth } from '../middleware/requireAuth';
 import logger from '../utils/logger';
+import { isCookieSecure } from '../utils/isCookieSecure';
 
 
 const FAKE_PASSWORD_HASH =
@@ -122,7 +123,7 @@ router.post('/login', loginLimiter, async (
       .cookie('token', token, {
         httpOnly: true,
         sameSite: 'strict',
-        secure: process.env.NODE_ENV === 'production',
+        secure: isCookieSecure(),
       })
       .status(200)
       .json({ token, user: { ...userObj, tenantId } });


### PR DESCRIPTION
## Summary
- import `isCookieSecure` in auth routes
- determine cookie security using `isCookieSecure()` instead of `process.env`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install --no-audit --prefer-offline` *(hangs, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c50c332d288323a8008120db2d07d9