### PR TITLE
refactor: handle unauthorized via router callback

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,13 +2,34 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Routes, Route } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Routes, Route, useNavigate } from 'react-router-dom';
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import Layout from './components/layout/Layout';
 import ErrorBoundary from './components/common/ErrorBoundary';
+import { useAuth } from '@/context/AuthContext';
+import {
+  setUnauthorizedCallback,
+  TOKEN_KEY,
+  TENANT_KEY,
+  SITE_KEY,
+} from '@/lib/http';
 
 export default function App() {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  useEffect(() => {
+    setUnauthorizedCallback(() => {
+      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(TENANT_KEY);
+      localStorage.removeItem(SITE_KEY);
+      logout();
+      navigate('/login');
+    });
+  }, [logout, navigate]);
+
   return (
     <ErrorBoundary>
       <Routes>

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -11,9 +11,16 @@ const http = axios.create({
   withCredentials: true,
 });
 
-const TOKEN_KEY = 'auth:token';
-const TENANT_KEY = 'auth:tenantId';
-const SITE_KEY = 'auth:siteId';
+export const TOKEN_KEY = 'auth:token';
+export const TENANT_KEY = 'auth:tenantId';
+export const SITE_KEY = 'auth:siteId';
+
+type UnauthorizedCallback = () => void;
+let unauthorizedCallback: UnauthorizedCallback | null = null;
+
+export const setUnauthorizedCallback = (cb: UnauthorizedCallback) => {
+  unauthorizedCallback = cb;
+};
 
 
 http.interceptors.request.use((config) => {
@@ -36,7 +43,7 @@ http.interceptors.response.use(
   (r) => r,
   (err) => {
     if (err?.response?.status === 401) {
-      window.location.href = '/login';
+      unauthorizedCallback?.();
     }
     return Promise.reject(err);
   }


### PR DESCRIPTION
## Summary
- replace window.location redirects with configurable unauthorized callback
- register global handler to clear auth tokens and navigate to login

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c50c34190c8323bd9cfbcbb1e2151c