### PR TITLE
Add hidden labels to login form inputs for accessibility

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -35,22 +35,30 @@ const LoginForm = () => {
   return (
     <form onSubmit={handleSubmit} className="max-w-md mx-auto mt-10 space-y-4">
       <h2 className="text-xl font-bold">Login</h2>
-      <input
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
-        className="w-full p-2 border rounded"
-        autoComplete="email"
-      />
-      <input
-        type="password"
-        placeholder="Password"
-        value={password}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
-        className="w-full p-2 border rounded"
-        autoComplete="current-password"
-      />
+      <label htmlFor="email" className="block">
+        <span className="sr-only">Email</span>
+        <input
+          id="email"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+          className="w-full p-2 border rounded"
+          autoComplete="email"
+        />
+      </label>
+      <label htmlFor="password" className="block">
+        <span className="sr-only">Password</span>
+        <input
+          id="password"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+          className="w-full p-2 border rounded"
+          autoComplete="current-password"
+        />
+      </label>
       {error && <div className="text-red-500">{error}</div>}
       <button type="submit" className="bg-primary-600 text-white px-4 py-2 rounded">
         Login


### PR DESCRIPTION
## Summary
- add visually hidden labels for email and password fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest package)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c51341c1bc8323be08f73fe12b5932