### PR TITLE
feat: add dark mode styling to login

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -117,8 +117,8 @@ const Login: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
-      <div className="space-y-4 w-full max-w-md">
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-neutral-900 p-4">
+      <div className="space-y-4 w-full max-w-md text-gray-900 dark:text-white">
         {showInstall && (
           <div className="flex justify-center">
             <button
@@ -131,14 +131,14 @@ const Login: React.FC = () => {
         )}
 
         {!mfaUser ? (
-          <form onSubmit={handleLogin} className="space-y-4 bg-white p-6 rounded shadow">
-            <h2 className="text-xl font-bold">{t('auth.login', 'Login')}</h2>
+          <form onSubmit={handleLogin} className="space-y-4 bg-white dark:bg-neutral-800 p-6 rounded shadow">
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">{t('auth.login', 'Login')}</h2>
             <input
               type="email"
               placeholder={t('auth.email', 'Email')}
               value={email}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
-              className="w-full p-2 border rounded"
+              className="w-full p-2 border rounded bg-white dark:bg-neutral-700 dark:border-neutral-600 dark:text-white"
               autoComplete="email"
               required
             />
@@ -147,39 +147,39 @@ const Login: React.FC = () => {
               placeholder={t('auth.password', 'Password')}
               value={password}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
-              className="w-full p-2 border rounded"
+              className="w-full p-2 border rounded bg-white dark:bg-neutral-700 dark:border-neutral-600 dark:text-white"
               autoComplete="current-password"
               required
             />
-            {error && <div className="text-red-500">{error}</div>}
+            {error && <div className="text-red-600 dark:text-red-400">{error}</div>}
             <button type="submit" className="bg-primary-600 text-white px-4 py-2 rounded w-full">
               {t('auth.login', 'Login')}
             </button>
 
             {/* OAuth shortcuts */}
             <div className="flex flex-col space-y-2 pt-2">
-              <a href="/api/auth/oauth/google" className="text-primary-600">
+              <a href="/api/auth/oauth/google" className="text-primary-600 dark:text-primary-400">
                 {t('auth.loginWithGoogle', 'Login with Google')}
               </a>
-              <a href="/api/auth/oauth/github" className="text-primary-600">
+              <a href="/api/auth/oauth/github" className="text-primary-600 dark:text-primary-400">
                 {t('auth.loginWithGitHub', 'Login with GitHub')}
               </a>
             </div>
           </form>
         ) : (
-          <form onSubmit={handleVerify} className="space-y-4 bg-white p-6 rounded shadow">
-            <h2 className="text-xl font-bold">{t('auth.mfaVerification', 'MFA Verification')}</h2>
+          <form onSubmit={handleVerify} className="space-y-4 bg-white dark:bg-neutral-800 p-6 rounded shadow">
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">{t('auth.mfaVerification', 'MFA Verification')}</h2>
             <input
               type="text"
               placeholder={t('auth.oneTimeCode', 'One-time code')}
               value={code}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCode(e.target.value)}
-              className="w-full p-2 border rounded"
+              className="w-full p-2 border rounded bg-white dark:bg-neutral-700 dark:border-neutral-600 dark:text-white"
               inputMode="numeric"
               autoComplete="one-time-code"
               required
             />
-            {error && <div className="text-red-500">{error}</div>}
+            {error && <div className="text-red-600 dark:text-red-400">{error}</div>}
             <button type="submit" className="bg-primary-600 text-white px-4 py-2 rounded w-full">
               {t('auth.verify', 'Verify')}
             </button>
@@ -187,10 +187,10 @@ const Login: React.FC = () => {
         )}
 
         <div className="flex justify-between text-sm">
-          <Link to="/register" className="text-primary-600">
+          <Link to="/register" className="text-primary-600 dark:text-primary-400">
             {t('auth.register', 'Register')}
           </Link>
-          <Link to="/forgot-password" className="text-primary-600">
+          <Link to="/forgot-password" className="text-primary-600 dark:text-primary-400">
             {t('auth.forgotPassword', 'Forgot Password?')}
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- add dark backgrounds and text colors to login and MFA forms
- support dark theme links and inputs
- meet WCAG contrast ratios for all text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden)*
- `node contrast-check.js` (inline script)

------
https://chatgpt.com/codex/tasks/task_e_68c51343f39c8323a63f706256d334c9