### PR TITLE
feat(frontend): add semantic color palettes

### DIFF
--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -12,6 +12,9 @@ export default {
     extend: {
       colors: {
         primary: colors.blue,
+        success: colors.green,
+        error: colors.red,
+        warning: colors.amber,
       },
     },
   },


### PR DESCRIPTION
## Summary
- extend Tailwind theme with success, error, and warning color palettes

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c51344e050832392cf9ee7b54dfcc0