### PR TITLE
Wrap public request responses

### DIFF
--- a/backend/routes/publicRequestRoutes.ts
+++ b/backend/routes/publicRequestRoutes.ts
@@ -27,20 +27,29 @@ router.post('/request-work', async (req, res) => {
     });
 
     logger.info('Work request submitted', { code });
-    res.status(201).json({ code });
+    res.status(201).json({ data: { code }, error: null });
   } catch (err) {
     logger.error('Work request submission failed', err);
-    res.status(500).json({ message: 'Failed to submit work request' });
+    res
+      .status(500)
+      .json({ data: null, error: 'Failed to submit work request' });
   }
 });
 
 router.get('/request-work/:code', async (req, res) => {
   const { code } = req.params;
-  const request = await WorkRequest.findOne({ code });
-  if (!request) {
-    return res.status(404).json({ message: 'Not found' });
+  try {
+    const request = await WorkRequest.findOne({ code });
+    if (!request) {
+      return res.status(404).json({ data: null, error: 'Not found' });
+    }
+    res.json({ data: { status: request.status }, error: null });
+  } catch (err) {
+    logger.error('Work request retrieval failed', err);
+    res
+      .status(500)
+      .json({ data: null, error: 'Failed to fetch work request' });
   }
-  res.json({ status: request.status });
 });
 
 export default router;

--- a/frontend/src/pages/RequestWork.tsx
+++ b/frontend/src/pages/RequestWork.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useState } from 'react';
 import { useForm, type Resolver } from 'react-hook-form';
 import { z } from 'zod';
+import http from '@/lib/http';
 
 const requestWorkSchema = z.object({
   assetId: z.string().optional(),
@@ -48,11 +49,9 @@ const RequestWork = () => {
     if (!code) return;
     const interval = setInterval(async () => {
       try {
-        const res = await fetch(`/api/public/request-work/${code}`);
-        if (!res.ok) throw new Error('Failed to fetch status');
-        const data = await res.json();
-        setStatus(data.status);
-        if (data.status && data.status !== 'pending') {
+        const res = await http.get(`/public/request-work/${code}`);
+        setStatus(res.data.data.status);
+        if (res.data.data.status && res.data.data.status !== 'pending') {
           clearInterval(interval);
         }
       } catch (err) {
@@ -67,14 +66,8 @@ const RequestWork = () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch('/api/public/request-work', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(values),
-      });
-      if (!res.ok) throw new Error('Failed to submit');
-      const data = await res.json();
-      setCode(data.code);
+      const res = await http.post('/public/request-work', values);
+      setCode(res.data.data.code);
       setStatus('pending');
     } catch (err) {
       setError('Failed to submit request');


### PR DESCRIPTION
## Summary
- nest public request POST/GET responses under data and error fields
- poll and submit work requests via axios and access nested data

## Testing
- `npm test` (backend) *(fails: vitest not found)*
- `npm run lint` (backend) *(fails: ESLint couldn't find configuration)*
- `npm test` (frontend) *(fails: missing script "test")*
- `npm run lint` (frontend) *(fails: missing @eslint/js package)*

------
https://chatgpt.com/codex/tasks/task_e_68c52bb22f608323aa153e498a4863e4