### PR TITLE
Expand dashboard metrics and add Recharts charts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "react-dropzone": "^14.3.8",
     "react-i18next": "15.7.3",
     "react-router-dom": "^6.22.3",
+    "recharts": "^2.12.0",
     "socket.io-client": "^4.8.1",
     "workbox-precaching": "^7.0.0",
     "workbox-routing": "^7.0.0",

--- a/frontend/src/components/dashboard/AssetsStatusChart.tsx
+++ b/frontend/src/components/dashboard/AssetsStatusChart.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import Card from '@common/Card';
-import ProgressBar from '@common/ProgressBar';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from 'recharts';
 import type { AssetStatusMap } from '@/types';
  
 
@@ -13,40 +13,38 @@ interface AssetsStatusChartProps {
 }
 
 const AssetsStatusChart: React.FC<AssetsStatusChartProps> = ({ data }) => {
-  const total = Object.values(data || {}).reduce(
-    (sum: number, v: number) => sum + (v || 0),
-    0,
-  );
+  const chartData = Object.entries(data || {}).map(([name, value]) => ({
+    name,
+    value: value ?? 0,
+  }));
+  const total = chartData.reduce((sum, d) => sum + d.value, 0);
+  const COLORS = [
+    '#3b82f6',
+    '#f97316',
+    '#10b981',
+    '#ef4444',
+    '#6366f1',
+    '#8b5cf6',
+  ];
 
   return (
     <Card title="Assets by Status" subtitle="Current asset distribution">
-      <div className="space-y-4">
-        {Object.entries(data || {}).map(([status, value]) => (
-          <div key={status} className="flex items-center justify-between">
-            <ProgressBar
-              value={value ?? 0}
-              max={total}
-              className="max-w-xs bg-neutral-100 h-2.5"
-              barClassName="bg-primary-600"
-              label={status}
-            />
-            <div className="ml-4 min-w-[80px]">
-              <div className="flex items-center">
-                <span className="text-sm font-medium capitalize">{status}</span>
-              </div>
-              <span className="text-lg font-semibold">{value}</span>
-            </div>
-          </div>
-        ))}
+      <div className="h-64">
+        <ResponsiveContainer>
+          <PieChart>
+            <Pie data={chartData} dataKey="value" nameKey="name" innerRadius={60} outerRadius={80} paddingAngle={4}>
+              {chartData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+            <Legend />
+          </PieChart>
+        </ResponsiveContainer>
       </div>
-
       <div className="mt-6 pt-6 border-t border-neutral-200">
-        <div className="flex justify-between">
-          <div>
-            <p className="text-sm text-neutral-500">Total Assets</p>
-            <p className="text-xl font-semibold">{total}</p>
-          </div>
-        </div>
+        <p className="text-sm text-neutral-500">Total Assets</p>
+        <p className="text-xl font-semibold">{total}</p>
       </div>
     </Card>
   );

--- a/frontend/src/components/dashboard/RecentActivity.tsx
+++ b/frontend/src/components/dashboard/RecentActivity.tsx
@@ -29,6 +29,8 @@ const RecentActivity: React.FC<Props> = ({ logs, loading, error, onRefresh }) =>
       </div>
     ) : error ? (
       <div className="text-sm text-error-700 bg-error-50 p-2 rounded">{error}</div>
+    ) : logs.length === 0 ? (
+      <div className="text-sm text-neutral-500">No recent activity.</div>
     ) : (
       <ul className="space-y-2 text-sm">
         {logs.map((log) => (

--- a/frontend/src/components/dashboard/WorkOrdersChart.tsx
+++ b/frontend/src/components/dashboard/WorkOrdersChart.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import Card from '@common/Card';
-import ProgressBar from '@common/ProgressBar';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 
 interface WorkOrdersChartProps {
   data?: {
@@ -16,91 +16,28 @@ interface WorkOrdersChartProps {
 }
 
 const WorkOrdersChart: React.FC<WorkOrdersChartProps> = ({ data }) => {
-  const total =
-    (data?.open ?? 0) +
-    (data?.inProgress ?? 0) +
-    (data?.onHold ?? 0) +
-    (data?.completed ?? 0);
-
-  const calculatePercentage = (value: number) => {
-    if (total === 0) {
-      return 0;
-    }
-    return Math.round((value / total) * 100);
-  };
+  const chartData = [
+    { name: 'Open', value: data?.open ?? 0 },
+    { name: 'In Progress', value: data?.inProgress ?? 0 },
+    { name: 'On Hold', value: data?.onHold ?? 0 },
+    { name: 'Completed', value: data?.completed ?? 0 },
+  ];
+  const total = chartData.reduce((sum, d) => sum + d.value, 0);
+  const completionRate = total === 0 ? 0 : Math.round(((data?.completed ?? 0) / total) * 100);
 
   return (
     <Card title="Work Orders by Status" subtitle="Last 30 days performance">
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <ProgressBar
-            value={data?.open ?? 0}
-            max={total}
-            className="max-w-xs bg-neutral-100 h-2.5"
-            barClassName="bg-primary-600"
-            label="Open work orders"
-          />
-          <div className="ml-4 min-w-[80px]">
-            <div className="flex items-center">
-              <div className="w-3 h-3 bg-primary-600 rounded-full mr-2"></div>
-              <span className="text-sm font-medium">Open</span>
-            </div>
-            <span className="text-lg font-semibold">{data?.open ?? 0}</span>
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <ProgressBar
-            value={data?.inProgress ?? 0}
-            max={total}
-            className="max-w-xs bg-neutral-100 h-2.5"
-            barClassName="bg-accent-500"
-            label="In progress work orders"
-          />
-          <div className="ml-4 min-w-[80px]">
-            <div className="flex items-center">
-              <div className="w-3 h-3 bg-accent-500 rounded-full mr-2"></div>
-              <span className="text-sm font-medium">In Progress</span>
-            </div>
-            <span className="text-lg font-semibold">{data?.inProgress ?? 0}</span>
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <ProgressBar
-            value={data?.onHold ?? 0}
-            max={total}
-            className="max-w-xs bg-neutral-100 h-2.5"
-            barClassName="bg-warning-500"
-            label="On hold work orders"
-          />
-          <div className="ml-4 min-w-[80px]">
-            <div className="flex items-center">
-              <div className="w-3 h-3 bg-warning-500 rounded-full mr-2"></div>
-              <span className="text-sm font-medium">On Hold</span>
-            </div>
-            <span className="text-lg font-semibold">{data?.onHold ?? 0}</span>
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <ProgressBar
-            value={data?.completed ?? 0}
-            max={total}
-            className="max-w-xs bg-neutral-100 h-2.5"
-            barClassName="bg-success-500"
-            label="Completed work orders"
-          />
-          <div className="ml-4 min-w-[80px]">
-            <div className="flex items-center">
-              <div className="w-3 h-3 bg-success-500 rounded-full mr-2"></div>
-              <span className="text-sm font-medium">Completed</span>
-            </div>
-            <span className="text-lg font-semibold">{data?.completed ?? 0}</span>
-          </div>
-        </div>
+      <div className="h-64">
+        <ResponsiveContainer>
+          <BarChart data={chartData}>
+            <XAxis dataKey="name" />
+            <YAxis allowDecimals={false} />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey="value" fill="#3b82f6" />
+          </BarChart>
+        </ResponsiveContainer>
       </div>
-
       <div className="mt-6 pt-6 border-t border-neutral-200">
         <div className="flex justify-between">
           <div>
@@ -109,7 +46,7 @@ const WorkOrdersChart: React.FC<WorkOrdersChartProps> = ({ data }) => {
           </div>
           <div>
             <p className="text-sm text-neutral-500">Completion Rate</p>
-            <p className="text-xl font-semibold">{calculatePercentage(data?.completed ?? 0)}%</p>
+            <p className="text-xl font-semibold">{completionRate}%</p>
           </div>
         </div>
       </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -215,7 +215,7 @@ const Header: React.FC<HeaderProps> = ({ onToggleSidebar, title }) => {
 
   return (
     <>
-    <header className="relative h-16 bg-white dark:bg-neutral-800 border-b border-neutral-200 dark:border-neutral-700 flex items-center justify-between px-2 sm:px-4 lg:px-6">
+    <header className="relative h-16 bg-gradient-to-r from-primary-600 to-accent-600 text-white flex items-center justify-between px-2 sm:px-4 lg:px-6">
       <div className="flex items-center">
         <button
           onClick={onToggleSidebar} aria-label="Toggle sidebar"
@@ -223,7 +223,7 @@ const Header: React.FC<HeaderProps> = ({ onToggleSidebar, title }) => {
         >
           <Menu size={20} className="dark:text-white" />
         </button>
-        <h1 className="text-xl font-semibold text-neutral-900 dark:text-white ml-2 lg:ml-0">{title ?? t('nav.dashboard')}</h1>
+        <h1 className="text-xl font-semibold text-white ml-2 lg:ml-0">{title ?? t('nav.dashboard')}</h1>
         <button
           onClick={() => setShowMobileSearch(!showMobileSearch)} aria-label="Search"
           className="md:hidden ml-2 p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-700 focus:outline-none"

--- a/frontend/src/pages/dashboard/DashboardHome.tsx
+++ b/frontend/src/pages/dashboard/DashboardHome.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import http from "@/lib/http";
 import { useToast } from "@/context/ToastContext";
+import RecentActivity, { AuditLog } from "@/components/dashboard/RecentActivity";
 import {
   ClipboardList,
   Timer,
@@ -13,6 +14,8 @@ import {
   Activity,
   ChevronRight,
   Plus,
+  AlertTriangle,
+  PieChart as PieChartIcon,
 } from "lucide-react";
 
 /** ---- Types ---- */
@@ -39,6 +42,9 @@ export default function DashboardHome() {
   const [summary, setSummary] = useState<Summary | null>(null);
   const [recent, setRecent] = useState<RecentWorkOrder[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [activityLogs, setActivityLogs] = useState<AuditLog[]>([]);
+  const [activityLoading, setActivityLoading] = useState(true);
+  const [activityError, setActivityError] = useState<string | null>(null);
   const { addToast } = useToast();
 
   useEffect(() => {
@@ -76,6 +82,24 @@ export default function DashboardHome() {
     };
   }, [addToast]);
 
+  const fetchActivity = async () => {
+    try {
+      setActivityError(null);
+      setActivityLoading(true);
+      const res = await http.get<AuditLog[]>("/api/audit", { params: { limit: 10 } });
+      setActivityLogs(res.data);
+    } catch (e) {
+      setActivityError("Failed to load activity");
+      addToast("Failed to load activity", "error");
+    } finally {
+      setActivityLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchActivity();
+  }, []);
+
   return (
     <div className="space-y-6">
       {error && (
@@ -83,84 +107,109 @@ export default function DashboardHome() {
           {error}
         </div>
       )}
- 
-      {/* Header */}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
-          <p className="text-sm text-muted-foreground">
-            Quick view of health, workload, and recent activity.
-          </p>
-        </div>
 
-        {/* Quick actions */}
-        <div className="flex items-center gap-2">
-          <Link
-            to="/dashboard/work-orders/new"
-            className="inline-flex items-center gap-2 rounded-xl px-3 py-2 border hover:bg-muted transition"
-          >
-            <Plus className="h-4 w-4" />
-            Create Work Order
-          </Link>
-          <Link
-            to="/dashboard/assets/new"
-            className="inline-flex items-center gap-2 rounded-xl px-3 py-2 border hover:bg-muted transition"
-          >
-            <Plus className="h-4 w-4" />
-            Add Asset
-          </Link>
-        </div>
-      </div>
-
-      {/* Stat cards */}
-      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <StatCard
-          loading={loading}
-          title="PM Compliance"
-          value={summary?.pmCompliance.toFixed(2)}
-          icon={<Timer className="h-5 w-5" />}
-        />
-        <StatCard
-          loading={loading}
-          title="WO Backlog"
-          value={summary?.woBacklog}
-          icon={<ClipboardList className="h-5 w-5" />}
-        />
-        <StatCard
-          loading={loading}
-          title="Cost MTD"
-          value={summary?.costMTD}
-          icon={<Boxes className="h-5 w-5" />}
-        />
-        <StatCard
-          loading={loading}
-          title="Wrench Time"
-          value={summary ? `${summary.wrenchTimePct.toFixed(1)}%` : undefined}
-          icon={<Activity className="h-5 w-5" />}
-        />
-      </div>
-
-      {/* Recent work orders */}
-      <div className="rounded-2xl border">
-        <div className="flex items-center justify-between p-4">
-          <h2 className="text-lg font-semibold">Recent Work Orders</h2>
-          <Link
-            to="/dashboard/work-orders"
-            className="inline-flex items-center gap-1 text-sm"
-          >
-            View all <ChevronRight className="h-4 w-4" />
-          </Link>
-        </div>
-        <div className="divide-y">
-          {loading ? (
-            <SkeletonRows rows={5} />
-          ) : recent.length === 0 ? (
-            <div className="p-6 text-sm text-muted-foreground">
-              No recent work orders.
+      <div className="lg:grid lg:grid-cols-3 lg:gap-6">
+        <div className="space-y-6 lg:col-span-2">
+          {/* Header */}
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
+              <p className="text-sm text-muted-foreground">
+                Quick view of health, workload, and recent activity.
+              </p>
             </div>
-          ) : (
-            recent.map((wo) => <RecentWOItem key={wo.id} wo={wo} />)
-          )}
+
+            {/* Quick actions */}
+            <div className="flex items-center gap-2">
+              <Link
+                to="/dashboard/work-orders/new"
+                className="inline-flex items-center gap-2 rounded-xl px-3 py-2 border hover:bg-muted transition"
+              >
+                <Plus className="h-4 w-4" />
+                Create Work Order
+              </Link>
+              <Link
+                to="/dashboard/assets/new"
+                className="inline-flex items-center gap-2 rounded-xl px-3 py-2 border hover:bg-muted transition"
+              >
+                <Plus className="h-4 w-4" />
+                Add Asset
+              </Link>
+            </div>
+          </div>
+
+          {/* Stat cards */}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+            <StatCard
+              loading={loading}
+              title="PM Compliance"
+              value={summary?.pmCompliance.toFixed(2)}
+              icon={<Timer className="h-5 w-5" />}
+            />
+            <StatCard
+              loading={loading}
+              title="WO Backlog"
+              value={summary?.woBacklog}
+              icon={<ClipboardList className="h-5 w-5" />}
+            />
+            <StatCard
+              loading={loading}
+              title="Downtime (This Month)"
+              value={summary?.downtimeThisMonth}
+              icon={<AlertTriangle className="h-5 w-5" />}
+            />
+            <StatCard
+              loading={loading}
+              title="Cost MTD"
+              value={summary?.costMTD}
+              icon={<Boxes className="h-5 w-5" />}
+            />
+            <StatCard
+              loading={loading}
+              title="CM vs PM Ratio"
+              value={summary?.cmVsPmRatio.toFixed(2)}
+              icon={<PieChartIcon className="h-5 w-5" />}
+            />
+            <StatCard
+              loading={loading}
+              title="Wrench Time"
+              value={summary ? `${summary.wrenchTimePct.toFixed(1)}%` : undefined}
+              icon={<Activity className="h-5 w-5" />}
+            />
+          </div>
+
+          {/* Recent work orders */}
+          <div className="rounded-2xl border">
+            <div className="flex items-center justify-between p-4">
+              <h2 className="text-lg font-semibold">Recent Work Orders</h2>
+              <Link
+                to="/dashboard/work-orders"
+                className="inline-flex items-center gap-1 text-sm"
+              >
+                View all <ChevronRight className="h-4 w-4" />
+              </Link>
+            </div>
+            <div className="divide-y">
+              {loading ? (
+                <SkeletonRows rows={5} />
+              ) : recent.length === 0 ? (
+                <div className="p-6 text-sm text-muted-foreground">
+                  No recent work orders.
+                </div>
+              ) : (
+                recent.map((wo) => <RecentWOItem key={wo.id} wo={wo} />)
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-6 mt-6 lg:mt-0">
+          <RecentActivity
+            logs={activityLogs}
+            loading={activityLoading}
+            error={activityError}
+            onRefresh={fetchActivity}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Render all six KPI values on Dashboard home and add recent activity rail
- Replace dashboard charts with Recharts components and add dependency
- Style header with a gradient using Tailwind

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')


------
https://chatgpt.com/codex/tasks/task_e_68c52bb423f08323836b444d4b69b729