### PR TITLE
feat: add pm generation endpoint and scheduler

### DIFF
--- a/backend/controllers/PMTaskController.ts
+++ b/backend/controllers/PMTaskController.ts
@@ -5,6 +5,9 @@
 import mongoose from 'mongoose';
 import { validationResult } from 'express-validator';
 import PMTask from '../models/PMTask';
+import WorkOrder from '../models/WorkOrder';
+import Meter from '../models/Meter';
+import { nextCronOccurrenceWithin } from '../services/PMScheduler';
 import type { AuthedRequestHandler } from '../types/http';
 
 export const getAllPMTasks: AuthedRequestHandler = async (req, res, next) => {
@@ -106,6 +109,63 @@ export const deletePMTask: AuthedRequestHandler = async (req, res, next) => {
     }
 
     res.json({ message: 'Deleted successfully' });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const generatePMWorkOrders: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const now = new Date();
+    const tasks = await PMTask.find({ tenantId: req.tenantId, active: true });
+    let count = 0;
+    for (const task of tasks) {
+      if (task.rule?.type === 'calendar' && task.rule.cron) {
+        const next = nextCronOccurrenceWithin(task.rule.cron, now, 7);
+        if (next) {
+          await WorkOrder.create({
+            title: `PM: ${task.title}`,
+            description: task.notes || '',
+            status: 'open',
+            asset: task.asset,
+            pmTask: task._id,
+            department: task.department,
+            dueDate: next,
+            priority: 'medium',
+            tenantId: task.tenantId,
+          });
+          task.lastGeneratedAt = now;
+          await task.save();
+          count++;
+        }
+      } else if (task.rule?.type === 'meter' && task.rule.meterName) {
+        const meter = await Meter.findOne({
+          name: task.rule.meterName,
+          tenantId: task.tenantId,
+        });
+        if (!meter) continue;
+        const sinceLast = meter.currentValue - (meter.lastWOValue || 0);
+        if (sinceLast >= (task.rule.threshold || 0)) {
+          await WorkOrder.create({
+            title: `Meter PM: ${task.title}`,
+            description: task.notes || '',
+            status: 'open',
+            asset: meter.asset,
+            pmTask: task._id,
+            department: task.department,
+            dueDate: now,
+            priority: 'medium',
+            tenantId: task.tenantId,
+          });
+          meter.lastWOValue = meter.currentValue;
+          await meter.save();
+          task.lastGeneratedAt = now;
+          await task.save();
+          count++;
+        }
+      }
+    }
+    res.json({ generated: count });
   } catch (err) {
     next(err);
   }

--- a/backend/models/PMTask.ts
+++ b/backend/models/PMTask.ts
@@ -4,39 +4,43 @@
 
 import mongoose, { Document, Schema } from 'mongoose';
 
+interface Rule {
+  type: 'calendar' | 'meter';
+  cron?: string;
+  meterName?: string;
+  threshold?: number;
+}
+
 export interface PmTaskDocument extends Document {
   title: string;
-  isActive: boolean;
   tenantId: Schema.Types.ObjectId;
-  lastRun?: Date;
-  nextDue?: Date;
-  frequency:
-    | 'daily'
-    | 'weekly'
-    | 'monthly'
-    | 'quarterly'
-    | 'biannually'
-    | 'annually';
   notes?: string;
   asset?: mongoose.Schema.Types.ObjectId;
   department?: string; // optional, for summary use
+  rule: Rule;
+  lastGeneratedAt?: Date;
+  active: boolean;
 }
 
 const PmTaskSchema = new Schema<PmTaskDocument>(
   {
     title: { type: String, required: true },
     tenantId: { type: Schema.Types.ObjectId, ref: 'Tenant', required: true, index: true },
-    isActive: { type: Boolean, default: true },
-    lastRun: { type: Date },
-    nextDue: { type: Date },
-    frequency: {
-      type: String,
-      enum: ['daily', 'weekly', 'monthly', 'quarterly', 'biannually', 'annually'],
-      required: true,
-    },
     notes: String,
     asset: { type: mongoose.Schema.Types.ObjectId, ref: 'Asset' },
     department: String,
+    rule: {
+      type: {
+        type: String,
+        enum: ['calendar', 'meter'],
+        required: true,
+      },
+      cron: String,
+      meterName: String,
+      threshold: Number,
+    },
+    lastGeneratedAt: { type: Date },
+    active: { type: Boolean, default: true },
   },
   { timestamps: true }
 );

--- a/backend/routes/PMTaskRoutes.ts
+++ b/backend/routes/PMTaskRoutes.ts
@@ -8,7 +8,8 @@ import {
   getPMTaskById,
   createPMTask,
   updatePMTask,
-  deletePMTask
+  deletePMTask,
+  generatePMWorkOrders,
 } from '../controllers/PMTaskController';
 import { requireAuth } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validationMiddleware';
@@ -22,5 +23,6 @@ router.get('/:id', getPMTaskById);
 router.post('/', pmTaskValidators, validate, createPMTask);
 router.put('/:id', pmTaskValidators, validate, updatePMTask);
 router.delete('/:id', deletePMTask);
+router.post('/generate', generatePMWorkOrders);
 
 export default router;

--- a/backend/seed.ts
+++ b/backend/seed.ts
@@ -167,9 +167,8 @@ mongoose.connect(mongoUri).then(async () => {
   const pmTask = await PMTask.create({
     title: 'Monthly Lubrication',
     asset: asset._id,
-    frequency: 'monthly',
-    lastRun: new Date(),
-    nextDue: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    rule: { type: 'calendar', cron: '0 0 1 * *' },
+    lastGeneratedAt: new Date(),
     notes: 'Check oil level and apply grease.',
     tenantId,
   });

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -157,6 +157,7 @@ app.use("/api/meters", meterRoutes);
 app.use("/api/condition-rules", conditionRuleRoutes);
 app.use("/api/tenants", TenantRoutes);
 app.use("/api/pm-tasks", pmTasksRoutes);
+app.use("/api/pm", pmTasksRoutes);
 app.use("/api/reports", reportsRoutes);
 app.use("/api/lines", LineRoutes);
 app.use("/api/stations", StationRoutes);

--- a/backend/tests/PMGenerator.test.ts
+++ b/backend/tests/PMGenerator.test.ts
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import PMTaskRoutes from '../routes/PMTaskRoutes';
+import User from '../models/User';
+import PMTask from '../models/PMTask';
+import WorkOrder from '../models/WorkOrder';
+
+const app = express();
+app.use(express.json());
+app.use('/api/pm', PMTaskRoutes);
+
+let mongo: MongoMemoryServer;
+let token: string;
+let user: Awaited<ReturnType<typeof User.create>>;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+  user = await User.create({
+    name: 'Tester',
+    email: 'tester@example.com',
+    passwordHash: 'pass123',
+    roles: ['manager'],
+    tenantId: new mongoose.Types.ObjectId(),
+  });
+  token = jwt.sign({ id: user._id.toString(), roles: user.roles }, process.env.JWT_SECRET!);
+});
+
+describe('PM generation endpoint', () => {
+  it('creates work orders for tasks due in next 7 days', async () => {
+    await PMTask.create({
+      title: 'Daily check',
+      tenantId: user.tenantId,
+      rule: { type: 'calendar', cron: '0 0 * * *' },
+    });
+
+    const res = await request(app)
+      .post('/api/pm/generate')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(res.body.generated).toBe(1);
+    expect(await WorkOrder.countDocuments()).toBe(1);
+  });
+});

--- a/backend/tests/meterPM.test.ts
+++ b/backend/tests/meterPM.test.ts
@@ -10,6 +10,7 @@ import Asset from '../models/Asset';
 import Meter from '../models/Meter';
 import MeterReading from '../models/MeterReading';
 import WorkOrder from '../models/WorkOrder';
+import PMTask from '../models/PMTask';
 import { runPMScheduler } from '../services/PMScheduler';
 
 let mongo: MongoMemoryServer;
@@ -50,6 +51,12 @@ describe('meter based PM generation', () => {
       lastWOValue: 0,
       tenantId,
       siteId,
+    });
+    await PMTask.create({
+      title: 'Meter Task',
+      tenantId,
+      rule: { type: 'meter', meterName: 'Run Hours', threshold: 100 },
+      asset: asset._id,
     });
     await MeterReading.create({ meter: meter._id, value: 120, tenantId, siteId });
     meter.currentValue = 120;

--- a/backend/tests/pmTaskRoutes.test.ts
+++ b/backend/tests/pmTaskRoutes.test.ts
@@ -14,6 +14,7 @@ import User from '../models/User';
 const app = express();
 app.use(express.json());
 app.use('/api/pm-tasks', PMTaskRoutes);
+app.use('/api/pm', PMTaskRoutes);
 
 let mongo: MongoMemoryServer;
 let token: string;
@@ -53,7 +54,7 @@ describe('PM Task Routes', () => {
     const createRes = await request(app)
       .post('/api/pm-tasks')
       .set('Authorization', `Bearer ${token}`)
-      .send({ title: 'PM1', frequency: 'monthly' })
+      .send({ title: 'PM1', rule: { type: 'calendar', cron: '0 0 * * *' } })
       .expect(201);
 
     const id = createRes.body._id;
@@ -69,7 +70,7 @@ describe('PM Task Routes', () => {
     const updateRes = await request(app)
       .put(`/api/pm-tasks/${id}`)
       .set('Authorization', `Bearer ${token}`)
-      .send({ title: 'Updated PM', frequency: 'monthly' })
+      .send({ title: 'Updated PM', rule: { type: 'calendar', cron: '0 0 * * *' } })
       .expect(200);
 
     expect(updateRes.body.title).toBe('Updated PM');

--- a/backend/tests/workOrderRoutes.test.ts
+++ b/backend/tests/workOrderRoutes.test.ts
@@ -69,8 +69,8 @@ beforeEach(async () => {
   stationId = department.lines[0].stations[0]._id;
   pmTask = await PMTask.create({
     title: 'PM1',
-    frequency: 'monthly',
     tenantId: user.tenantId,
+    rule: { type: 'calendar', cron: '0 0 * * *' },
   });
 });
 

--- a/backend/validators/pmTaskValidators.ts
+++ b/backend/validators/pmTaskValidators.ts
@@ -6,13 +6,24 @@ import { body } from 'express-validator';
 
 export const pmTaskValidators = [
   body('title').notEmpty().withMessage('title is required'),
-  body('frequency')
+  body('rule.type')
     .notEmpty()
-    .withMessage('frequency is required')
-    .isIn(['daily', 'weekly', 'monthly', 'quarterly', 'biannually', 'annually']),
+    .withMessage('rule.type is required')
+    .isIn(['calendar', 'meter']),
+  body('rule.cron')
+    .if(body('rule.type').equals('calendar'))
+    .notEmpty()
+    .withMessage('cron is required for calendar tasks'),
+  body('rule.meterName')
+    .if(body('rule.type').equals('meter'))
+    .notEmpty()
+    .withMessage('meterName is required for meter tasks'),
+  body('rule.threshold')
+    .if(body('rule.type').equals('meter'))
+    .isNumeric()
+    .withMessage('threshold must be a number'),
   body('active').optional().isBoolean(),
-  body('lastRun').optional().isISO8601().toDate(),
-  body('nextDue').optional().isISO8601().toDate(),
+  body('lastGeneratedAt').optional().isISO8601().toDate(),
   body('asset').optional().isMongoId(),
   body('notes').optional().isString(),
   body('department').optional().isString(),

--- a/frontend/src/pages/PMScheduler.tsx
+++ b/frontend/src/pages/PMScheduler.tsx
@@ -2,149 +2,33 @@
  * SPDX-License-Identifier: MIT
  */
 
-import React, { useMemo, useState } from 'react';
-import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
-import type { Event as RBCEvent, SlotInfo } from 'react-big-calendar';
-import { format, parse, startOfWeek, getDay } from 'date-fns';
-import { enUS } from 'date-fns/locale';
-import 'react-big-calendar/lib/css/react-big-calendar.css';
+import React, { useState } from 'react';
 import Button from '@/components/common/Button';
-import AssetSelector from '@/pm/AssetSelector';
-import RecurrenceRuleForm from '@/pm/RecurrenceRuleForm';
-
-interface Plan {
-  asset: string;
-  nextDue: string;
-}
-
-interface CalendarEvent {
-  title: string;
-  start: Date;
-  end: Date;
-}
-
-const locales = {
-  'en-US': enUS,
-};
-
-const localizer = dateFnsLocalizer({
-  format,
-  parse,
-  startOfWeek,
-  getDay,
-  locales,
-});
+import { useToast } from '@/context/ToastContext';
+import api from '@/lib/api';
 
 const PMScheduler: React.FC = () => {
-  const [view, setView] = useState<'calendar' | 'list'>('calendar');
-  const [assets, setAssets] = useState<string[]>([]);
-  const [rule, setRule] = useState('');
-  const [plans, setPlans] = useState<Plan[]>([]);
-  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [notice, setNotice] = useState('');
- 
+  const { addToast } = useToast();
+  const [loading, setLoading] = useState(false);
 
-  const generate = () => {
-    const next = new Date().toISOString().slice(0, 10);
-    const newPlans = assets.map(a => ({ asset: a, nextDue: next }));
-    setPlans(prev => [...prev, ...newPlans]);
-    setNotice(`Generated ${newPlans.length} plan${newPlans.length !== 1 ? 's' : ''}`);
-    setAssets([]);
-    setRule('');
+  const generate = async () => {
+    try {
+      setLoading(true);
+      const res = await api.post('/pm/generate');
+      addToast({ type: 'success', message: `Generated ${res.data.generated} work orders` });
+    } catch (err) {
+      addToast({ type: 'error', message: 'Failed to generate work orders' });
+    } finally {
+      setLoading(false);
+    }
   };
-
-  const events = useMemo(
-    () =>
-      plans.map(p => ({
-        title: p.asset,
-        start: new Date(p.nextDue),
-        end: new Date(p.nextDue),
-      })),
-    [plans]
-  );
 
   return (
     <div className="p-6 space-y-4">
-      <div className="flex justify-between items-center">
-        <h1 className="text-2xl font-bold">PM Scheduler</h1>
-        <div className="space-x-2">
-          <Button
-            variant={view === 'calendar' ? 'primary' : 'outline'}
-            onClick={() => setView('calendar')}
-          >
-            Calendar
-          </Button>
-          <Button
-            variant={view === 'list' ? 'primary' : 'outline'}
-            onClick={() => setView('list')}
-          >
-            List
-          </Button>
-        </div>
-      </div>
-
-      <div className="space-y-2">
-        <AssetSelector value={assets} onChange={setAssets} />
-        <RecurrenceRuleForm value={rule} onChange={setRule} />
-        <Button
-          variant="primary"
-          onClick={generate}
-          disabled={!assets.length || !rule}
-        >
-          Generate Plans
-        </Button>
-        {notice && <p className="text-sm text-success-700">{notice}</p>}
-      </div>
-
-      {view === 'calendar' ? (
-        <div className="border p-4">
-          <Calendar
-            localizer={localizer}
-            events={events}
-            startAccessor="start"
-            endAccessor="end"
-            style={{ height: 500 }}
-            selectable
-            onSelectEvent={(e: RBCEvent) => {
-              setSelectedEvent({
-                title: e.title as string,
-                start: e.start as Date,
-                end: e.end as Date,
-              });
-              setSelectedDate(null);
-            }}
-            onSelectSlot={(slot: SlotInfo) => {
-              setSelectedDate(slot.start as Date);
-              setSelectedEvent(null);
-            }}
-          />
-          {selectedEvent && (
-            <div className="mt-4 p-2 border rounded">
-              <p className="font-semibold">{selectedEvent.title}</p>
-              <p>{selectedEvent.start.toDateString()}</p>
-            </div>
-          )}
-          {selectedDate && (
-            <div className="mt-4 p-2 border rounded">
-              <p className="font-semibold">Selected Date</p>
-              <p>{selectedDate.toDateString()}</p>
-            </div>
-          )}
-        </div>
-      ) : (
-        <ul className="divide-y divide-neutral-200">
-          {plans.map((p, i) => (
-            <li key={i} className="py-2 flex justify-between">
-              <span>{p.asset}</span>
-              <span>{p.nextDue}</span>
-            </li>
-          ))}
-          {plans.length === 0 && (
-            <li className="py-2 text-neutral-500">No plans</li>
-          )}
-        </ul>
-      )}
+      <h1 className="text-2xl font-bold">PM Scheduler</h1>
+      <Button variant="primary" onClick={generate} disabled={loading}>
+        Generate WOs
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- refactor PMTask model to use rule object with calendar/meter support
- add `/api/pm/generate` endpoint to create due work orders
- add PM scheduler page with Generate WOs action
- include unit test for PM generation

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm test` in frontend *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68c52bb5e0c083239bd57de359f956db