### PR TITLE
fix: prevent auth fetch loop

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -53,7 +53,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       }
     };
     fetchUser();
-  }, [handleSetUser]);
+    // handleSetUser is intentionally omitted from the dependency array to
+    // avoid re-fetching on every render when it updates state
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const login = useCallback(
     async (email: string, password: string) => {


### PR DESCRIPTION
## Summary
- ensure auth context user lookup runs once and doesn't re-trigger on state updates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c5553ff61083238810e3a22b119fc5