### PR TITLE
Remove invalid @types/react-dropzone dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,7 +61,6 @@
     "@types/react": "^18.2.0",
     "@types/react-big-calendar": "^1.16.2",
     "@types/react-dom": "^18.2.0",
-    "@types/react-dropzone": "^14.3.8",
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.0.3",
     "autoprefixer": "^10",


### PR DESCRIPTION
## Summary
- remove unpublished `@types/react-dropzone` dev dependency

## Testing
- `npm install --no-fund --no-audit` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-dialog)*

------
https://chatgpt.com/codex/tasks/task_e_68c5554657e483239b1e7d143c05c2b8