### PR TITLE
fix: replace manager auth selector with supervisor

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -14,7 +14,7 @@ import ThemeToggle from '@common/ThemeToggle';
 import Avatar from '@common/Avatar';
 import Card from '@common/Card';
 import { Button } from '@/components/ui/button';
-import { useAuthStore, type AuthState, isAdmin as selectIsAdmin, isManager as selectIsManager } from '@/store/authStore';
+import { useAuthStore, type AuthState, isAdmin as selectIsAdmin, isSupervisor as selectIsSupervisor } from '@/store/authStore';
 
 import { useDataStore } from '@/store/dataStore';
 import { useNavigate } from 'react-router-dom';


### PR DESCRIPTION
## Summary
- replace manager selector with supervisor in header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-dialog)*

------
https://chatgpt.com/codex/tasks/task_e_68c56423fd708323af1b4502a64520bc