### PR TITLE
Normalize audit log payloads

### DIFF
--- a/backend/utils/audit.ts
+++ b/backend/utils/audit.ts
@@ -3,16 +3,25 @@
  */
 
 import type { Request } from 'express';
+import { Types } from 'mongoose';
 import AuditLog from '../models/AuditLog';
 import logger from './logger';
+
+function normalize(value: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return null;
+  }
+}
 
 export async function logAudit(
   req: Request,
   action: string,
   entityType: string,
-  entityId: string | unknown,
-  before?: Record<string, unknown> | null,
-  after?: Record<string, unknown> | null,
+  entityId: string | Types.ObjectId,
+  before?: unknown,
+  after?: unknown,
 ): Promise<void> {
   try {
     const tenantId = req.tenantId;
@@ -24,8 +33,8 @@ export async function logAudit(
       action,
       entityType,
       entityId,
-      before,
-      after,
+      before: normalize(before),
+      after: normalize(after),
       ts: new Date(),
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- normalize audit `before`/`after` payloads to ensure plain JSON storage
- broaden audit types for `entityId`, `before`, and `after`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: E403 Forbidden - GET https://registry.npmjs.org/csv-parse)*

------
https://chatgpt.com/codex/tasks/task_e_68c56b18c68483238ef0148cfbc70b88