### PR TITLE
feat: normalize audit logging

### DIFF
--- a/backend/utils/audit.ts
+++ b/backend/utils/audit.ts
@@ -3,31 +3,39 @@
  */
 
 import type { Request } from 'express';
+import { Types } from 'mongoose';
 import AuditLog from '../models/AuditLog';
 import logger from './logger';
+
+type AuditVal = unknown;
+
+const normalize = (v: AuditVal): AuditVal => JSON.parse(JSON.stringify(v));
 
 export async function logAudit(
   req: Request,
   action: string,
   entityType: string,
-  entityId: string | unknown,
-  before?: Record<string, unknown> | null,
-  after?: Record<string, unknown> | null,
+  targetId: string | Types.ObjectId,
+  before?: AuditVal,
+  after?: AuditVal,
 ): Promise<void> {
   try {
     const tenantId = req.tenantId;
+    const siteId = req.siteId;
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     if (!tenantId) return;
-    await AuditLog.create({
+    const payload = {
       tenantId,
+      siteId,
       userId,
       action,
       entityType,
-      entityId,
-      before,
-      after,
+      entityId: String(targetId),
+      before: before === undefined ? undefined : normalize(before),
+      after: after === undefined ? undefined : normalize(after),
       ts: new Date(),
-    });
+    };
+    await AuditLog.create(payload);
   } catch (err) {
     logger.error('audit log error', err);
   }


### PR DESCRIPTION
## Summary
- normalize audit log payloads to strip mongoose metadata
- include tenant, site, and user context with stringified target ids

## Testing
- `npm test` *(fails: vitest: not found; npm install 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c56b9879488323bf20566f1aa87bb5