### PR TITLE
feat(frontend): add navy theme tailwind config

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,44 +5,27 @@ export default {
   theme: {
     extend: {
       colors: {
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
-        primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))'
+        navy: {
+          DEFAULT: '#001f3f',
+          light: '#405173',
+          dark: '#000a1a'
         },
-        secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))'
-        },
-        destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))'
-        },
-        muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))'
-        },
-        accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))'
-        },
-        popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))'
-        },
-        card: {
-          DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))'
-        }
+        accent: '#4f6d7a'
       },
-      borderRadius: {
-        lg: 'var(--radius)',
-        md: 'calc(var(--radius) - 2px)',
-        sm: 'calc(var(--radius) - 4px)'
+      boxShadow: {
+        navy: '0 4px 6px -1px rgba(0, 31, 63, 0.1), 0 2px 4px -2px rgba(0, 31, 63, 0.05)',
+        'navy-md': '0 8px 12px -3px rgba(0, 31, 63, 0.2), 0 4px 6px -4px rgba(0, 31, 63, 0.1)',
+        'navy-lg': '0 20px 25px -5px rgba(0, 31, 63, 0.25), 0 10px 10px -5px rgba(0, 31, 63, 0.1)'
+      },
+      blur: {
+        xs: '2px'
+      },
+      backdropBlur: {
+        xs: '2px',
+        sm: '4px',
+        md: '8px',
+        lg: '12px',
+        xl: '16px'
       }
     }
   },


### PR DESCRIPTION
## Summary
- replace Tailwind config with navy-themed setup
- add custom colors, shadows, and blur utilities

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5aa83f0dc8323bef5c9fdea4aaf18