### PR TITLE
feat: add KPI grid and sample table to dashboard

### DIFF
--- a/frontend/src/components/common/StatusBadge.tsx
+++ b/frontend/src/components/common/StatusBadge.tsx
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import Badge from '@common/Badge';
+
+interface StatusBadgeProps {
+  /** Status text to display */
+  status: string;
+  /** Visual size of the badge */
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+export default function StatusBadge({ status, size = 'md', className }: StatusBadgeProps) {
+  return <Badge text={status} type="status" size={size} className={className} />;
+}
+


### PR DESCRIPTION
## Summary
- Simplify dashboard page with static KPI tiles and sample status table
- Introduce StatusBadge component wrapping existing Badge for status styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68c5aa93119c83239b71f3b364358520