### PR TITLE
Add navigation bar initializer module

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
   </head>
   <body class="min-h-screen">
     <div id="root"></div>
+    <script type="module" src="/src/components/navBar.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/src/components/navBar.js
+++ b/frontend/src/components/navBar.js
@@ -1,0 +1,15 @@
+export function initNavBar() {
+  const nav = document.createElement('nav');
+  nav.id = 'nav-bar';
+  nav.innerHTML = `
+    <ul class="nav-menu">
+      <li><a href="/">Home</a></li>
+    </ul>
+  `;
+  document.body.prepend(nav);
+  console.log('Navigation bar initialized');
+}
+
+if (typeof window !== 'undefined') {
+  window.initNavBar = initNavBar;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,14 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
+declare global {
+  interface Window {
+    initNavBar: () => void;
+  }
+}
+
+window.initNavBar();
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <BrowserRouter>
     <App />


### PR DESCRIPTION
## Summary
- add `navBar.js` module exporting `initNavBar`
- ensure `navBar.js` loads before main script and initialize navigation bar on startup

## Testing
- `npm run test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68c5bf83ccec8323b5d788939507cf10