### PR TITLE
chore(frontend): add react types

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -11,7 +11,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "types": ["vite/client"]
+    "types": ["vite/client", "react", "react-dom"]
   },
   "include": ["src", "src/types/globals.d.ts"]
 }


### PR DESCRIPTION
## Summary
- include React and ReactDOM types in frontend tsconfig

## Testing
- ⚠️ `npm install --save-dev @types/react @types/react-dom` (403 Forbidden)
- ⚠️ `npm test` (Missing script: "test")
- ⚠️ `npm run lint` (Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c5c00695588323bac68ce79b41722a