### PR TITLE
feat: add http helpers

### DIFF
--- a/backend/controllers/TenantController.ts
+++ b/backend/controllers/TenantController.ts
@@ -2,60 +2,53 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response } from 'express';
+import { ok, fail, asyncHandler } from '../src/lib/http';
 
 import Tenant from '../models/Tenant';
 
-export const getAllTenants = async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const tenants = await Tenant.find();
-    res.json(tenants);
-  } catch (err) {
-    next(err);
-  }
-};
+export const getAllTenants = asyncHandler(async (_req: Request, res: Response) => {
+  const tenants = await Tenant.find();
+  ok(res, tenants);
+});
 
-export const getTenantById = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const tenant = await Tenant.findById(req.params.id);
-    if (!tenant) return res.status(404).json({ message: 'Not found' });
-    res.json(tenant);
-  } catch (err) {
-    next(err);
-  }
-};
+export const getTenantById = asyncHandler(async (
+  req: Request,
+  res: Response,
+) => {
+  const tenant = await Tenant.findById(req.params.id);
+  if (!tenant) return fail(res, 'Not found', 404);
+  ok(res, tenant);
+});
 
-export const createTenant = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const tenant = await Tenant.create(req.body);
-    res.status(201).json(tenant);
-  } catch (err) {
-    next(err);
-  }
-};
+export const createTenant = asyncHandler(async (
+  req: Request,
+  res: Response,
+) => {
+  const tenant = await Tenant.create(req.body);
+  ok(res, tenant, 201);
+});
 
-export const updateTenant = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const tenant = await Tenant.findByIdAndUpdate(req.params.id, req.body, {
-      new: true,
-      runValidators: true,
-    });
-    if (!tenant) return res.status(404).json({ message: 'Not found' });
-    res.json(tenant);
-  } catch (err) {
-    next(err);
-  }
-};
+export const updateTenant = asyncHandler(async (
+  req: Request,
+  res: Response,
+) => {
+  const tenant = await Tenant.findByIdAndUpdate(req.params.id, req.body, {
+    new: true,
+    runValidators: true,
+  });
+  if (!tenant) return fail(res, 'Not found', 404);
+  ok(res, tenant);
+});
 
-export const deleteTenant = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const tenant = await Tenant.findByIdAndDelete(req.params.id);
-    if (!tenant) return res.status(404).json({ message: 'Not found' });
-    res.json({ message: 'Deleted successfully' });
-  } catch (err) {
-    next(err);
-  }
-};
+export const deleteTenant = asyncHandler(async (
+  req: Request,
+  res: Response,
+) => {
+  const tenant = await Tenant.findByIdAndDelete(req.params.id);
+  if (!tenant) return fail(res, 'Not found', 404);
+  ok(res, { message: 'Deleted successfully' });
+});
 
 export default {
   getAllTenants,

--- a/backend/middleware/cache.ts
+++ b/backend/middleware/cache.ts
@@ -26,15 +26,13 @@ export const cache = (keyPrefix: string, ttl = 60) => {
         return;
       }
 
-       const originalJson: Response['json'] = res.json.bind(res);
+      const originalJson: Response['json'] = res.json.bind(res);
       res.json = <T>(body: T): Response<T> => {
         redis
           .set(key, JSON.stringify(body), 'EX', ttl)
           .catch((err: unknown) => logger.error('Redis set error:', err));
         return originalJson(body);
- 
       };
-      res.send = sendResponse;
     } catch (err) {
       logger.error('Redis error:', err);
     }

--- a/backend/middleware/errorHandler.ts
+++ b/backend/middleware/errorHandler.ts
@@ -4,7 +4,7 @@
 
 import type { Request, Response, NextFunction } from 'express';
 import logger from '../utils/logger';
-import { sendResponse } from '../utils/sendResponse';
+import { fail } from '../src/lib/http';
 
 const errorHandler = (
   err: unknown,
@@ -18,11 +18,11 @@ const errorHandler = (
     const status =
       (err as { status?: number }).status ||
       (err.name === 'ValidationError' || err.name === 'CastError' ? 400 : 500);
-    sendResponse(res, null, err.message || 'Internal Server Error', status);
+    fail(res, err.message || 'Internal Server Error', status);
     return;
   }
 
-  sendResponse(res, null, 'Internal Server Error', 500);
+  fail(res, 'Internal Server Error', 500);
 };
 
 export default errorHandler;

--- a/backend/middleware/requireAuth.ts
+++ b/backend/middleware/requireAuth.ts
@@ -5,7 +5,7 @@
 import jwt from 'jsonwebtoken';
 import { getJwtSecret } from '../utils/getJwtSecret';
 import type { AuthedRequestHandler } from '../types/http';
-import { sendResponse } from '../utils/sendResponse';
+import { fail } from '../src/lib/http';
 
 export interface AuthPayload {
   id: string;
@@ -30,7 +30,7 @@ export const requireAuth: AuthedRequestHandler = (req, res, next) => {
 
   const token = bearer ?? cookieToken;
   if (!token) {
-    sendResponse(res, null, 'Unauthorized', 401);
+    fail(res, 'Unauthorized', 401);
     return;
   }
 
@@ -38,7 +38,7 @@ export const requireAuth: AuthedRequestHandler = (req, res, next) => {
   try {
     secret = getJwtSecret();
   } catch {
-    sendResponse(res, null, 'Server configuration issue', 500);
+    fail(res, 'Server configuration issue', 500);
     return;
   }
 
@@ -59,7 +59,7 @@ export const requireAuth: AuthedRequestHandler = (req, res, next) => {
     next();
     return;
   } catch {
-    sendResponse(res, null, 'Invalid or expired token', 401);
+    fail(res, 'Invalid or expired token', 401);
     return;
   }
 };

--- a/backend/src/lib/http.ts
+++ b/backend/src/lib/http.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { RequestHandler, Response } from 'express';
+import type { ApiSuccess, ApiError } from '../../../shared/types/http';
+
+export const ok = <T>(res: Response, data: T, status = 200) => {
+  return res.status(status).json({ data, error: null } as ApiSuccess<T>);
+};
+
+export const fail = (
+  res: Response,
+  error: unknown,
+  status = 400,
+) => {
+  const message = error instanceof Error ? error.message : String(error);
+  return res
+    .status(status)
+    .json({ data: null, error: message } as ApiError);
+};
+
+export const asyncHandler = (fn: RequestHandler): RequestHandler => {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+};
+
+export default { ok, fail, asyncHandler };

--- a/backend/tests/httpEnvelope.test.ts
+++ b/backend/tests/httpEnvelope.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { ok, fail, asyncHandler } from '../src/lib/http';
+import errorHandler from '../middleware/errorHandler';
+
+const app = express();
+app.use(express.json());
+
+app.get(
+  '/hello',
+  asyncHandler(async (_req, res) => {
+    ok(res, { greeting: 'hi' });
+  }),
+);
+
+app.get(
+  '/boom',
+  asyncHandler(async () => {
+    throw new Error('boom');
+  }),
+);
+
+app.post(
+  '/echo',
+  asyncHandler(async (req, res) => {
+    ok(res, req.body, 201);
+  }),
+);
+
+app.post(
+  '/reject',
+  asyncHandler(async (_req, res) => {
+    fail(res, 'Bad request', 400);
+  }),
+);
+
+app.use(errorHandler);
+
+describe('http envelope helpers', () => {
+  it('handles successful GET', async () => {
+    const res = await request(app).get('/hello');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: { greeting: 'hi' }, error: null });
+  });
+
+  it('handles error GET via errorHandler', async () => {
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ data: null, error: 'boom' });
+  });
+
+  it('handles successful POST', async () => {
+    const res = await request(app).post('/echo').send({ a: 1 });
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ data: { a: 1 }, error: null });
+  });
+
+  it('handles failed POST', async () => {
+    const res = await request(app).post('/reject').send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ data: null, error: 'Bad request' });
+  });
+});

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -4,6 +4,7 @@
 
 import axios from 'axios';
 import type { AxiosRequestHeaders } from 'axios';
+import type { ApiResult } from '../../shared/types/http';
 
 const baseUrl = (import.meta.env.VITE_API_URL ?? 'http://localhost:5010').replace(/\/+$/, '');
 
@@ -36,7 +37,7 @@ http.interceptors.request.use((config) => {
 
 http.interceptors.response.use(
   (r) => {
-    const { data, error } = r.data ?? {};
+    const { data, error } = (r.data as ApiResult<unknown>) ?? {};
     if (error) {
       return Promise.reject(error);
     }

--- a/shared/types/http.ts
+++ b/shared/types/http.ts
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+export interface ApiSuccess<T> {
+  data: T;
+  error: null;
+}
+
+export interface ApiError<E = string> {
+  data: null;
+  error: E;
+}
+
+export type ApiResult<T, E = string> = ApiSuccess<T> | ApiError<E>;


### PR DESCRIPTION
## Summary
- add shared HTTP envelope helpers and async handler
- normalize errors via middleware using fail helper
- update auth and cache middleware and tenant controller to use helpers
- type frontend HTTP client with shared ApiResult
- add tests for GET and POST envelopes

## Testing
- `npm test tests/httpEnvelope.test.ts` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cfe8d22483239122643749ca4b82