### PR TITLE
feat: add attachments upload endpoint

### DIFF
--- a/backend/routes/AttachmentRoutes.ts
+++ b/backend/routes/AttachmentRoutes.ts
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import express from 'express';
+import { body, validationResult } from 'express-validator';
+import { randomUUID } from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+import { requireAuth } from '../middleware/authMiddleware';
+import { sendResponse } from '../utils/sendResponse';
+import type { AttachmentInput, Attachment } from '../../shared/types/uploads';
+
+const router = express.Router();
+
+const validators = [
+  body('kind').isIn(['base64', 'url']),
+  body('filename').optional().isString(),
+  body('contentType').optional().isString(),
+  body('data').if(body('kind').equals('base64')).isString().notEmpty(),
+  body('filename').if(body('kind').equals('base64')).isString().notEmpty(),
+  body('url')
+    .if(body('kind').equals('url'))
+    .isString()
+    .custom((val) => {
+      try {
+        // eslint-disable-next-line no-new
+        new URL(val);
+        return true;
+      } catch {
+        return false;
+      }
+    }),
+];
+
+router.use(requireAuth);
+
+router.post('/', validators, async (req, res) => {
+  const errors = validationResult(req as any);
+  if (!errors.isEmpty()) {
+    sendResponse(res, null, errors.array(), 400);
+    return;
+  }
+
+  const tenantId = req.tenantId;
+  if (!tenantId) {
+    sendResponse(res, null, 'Tenant ID required', 400);
+    return;
+  }
+
+  const input = req.body as AttachmentInput;
+  let result: Attachment;
+
+  const uploadRoot = path.join(process.cwd(), 'uploads');
+  if (input.kind === 'base64') {
+    const uuid = randomUUID();
+    const dir = path.join(uploadRoot, tenantId.toString());
+    await fs.mkdir(dir, { recursive: true });
+    const buffer = Buffer.from(input.data, 'base64');
+    const storedName = `${uuid}-${input.filename}`;
+    await fs.writeFile(path.join(dir, storedName), buffer);
+    result = {
+      url: `/static/uploads/${tenantId}/${storedName}`,
+      filename: input.filename,
+      contentType: input.contentType,
+    };
+  } else {
+    let contentType = input.contentType;
+    if (!contentType) {
+      try {
+        const head = await fetch(input.url, { method: 'HEAD' });
+        contentType = head.headers.get('content-type') ?? undefined;
+      } catch {
+        // ignore network errors
+      }
+    }
+    const filename = input.filename || path.basename(new URL(input.url).pathname) || 'file';
+    result = { url: input.url, filename, contentType };
+  }
+
+  sendResponse(res, result, null, 201);
+});
+
+export default router;
+

--- a/backend/routes/index.ts
+++ b/backend/routes/index.ts
@@ -32,6 +32,7 @@ export { default as workHistoryRoutes } from './WorkHistoryRoutes';
 export { default as vendorPortalRoutes } from './VendorPortalRoutes';
 export { default as documentRoutes } from './DocumentRoutes';
 export { default as predictiveRoutes } from './PredictiveRoutes';
+export { default as attachmentRoutes } from './AttachmentRoutes';
 export { default as TenantRoutes } from './TenantRoutes';
 export { default as workOrdersRoutes } from './WorkOrderRoutes';
 export { default as webhooksRoutes } from './WebhooksRoutes';

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -13,6 +13,7 @@ import { createServer } from "http";
 import { Server } from "socket.io";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
+import path from "path";
 
 import { initKafka, sendKafkaEvent } from "./utils/kafka";
 import { initMQTTFromConfig } from "./iot/mqttClient";
@@ -46,6 +47,7 @@ import {
   IntegrationRoutes,
   summaryRoutes,
   auditRoutes,
+  attachmentRoutes,
 } from "./routes";
 
 import { startPMScheduler } from "./utils/PMScheduler";
@@ -137,6 +139,8 @@ app.get("/", (_req: Request, res: Response) => {
   res.send("PLTCMMS backend is running");
 });
 
+app.use("/static/uploads", express.static(path.join(process.cwd(), "uploads")));
+
 if (env.NODE_ENV === "test") {
   app.post("/test/sanitize", (req, res) => {
     res.json(req.body);
@@ -185,6 +189,7 @@ app.use("/api/webhooks", webhooksRoutes);
 app.use("/api/calendar", calendarRoutes);
 app.use("/api/integrations", IntegrationRoutes);
 
+app.use("/api/attachments", attachmentRoutes);
 app.use("/api/summary", summaryRoutes);
 app.use("/api/audit", auditRoutes);
 

--- a/backend/tests/attachments.test.ts
+++ b/backend/tests/attachments.test.ts
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import fs from 'fs/promises';
+import path from 'path';
+
+import AttachmentRoutes from '../routes/AttachmentRoutes';
+import WorkOrderRoutes from '../routes/WorkOrderRoutes';
+import User from '../models/User';
+import Department from '../models/Department';
+
+const app = express();
+app.use(express.json());
+app.use('/api/attachments', AttachmentRoutes);
+app.use('/api/workorders', WorkOrderRoutes);
+
+let mongo: MongoMemoryServer;
+let token: string;
+let user: Awaited<ReturnType<typeof User.create>>;
+let department: Awaited<ReturnType<typeof Department.create>>;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db?.dropDatabase();
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  user = await User.create({
+    name: 'Tester',
+    email: 'tester@example.com',
+    passwordHash: 'pass123',
+    roles: ['supervisor'],
+    tenantId: new mongoose.Types.ObjectId(),
+  });
+  token = jwt.sign({ id: user._id.toString(), roles: user.roles }, process.env.JWT_SECRET!);
+  department = await Department.create({ name: 'Dept', tenantId: user.tenantId });
+});
+
+describe('attachments API', () => {
+  it('saves base64 attachment and persists URL in work order', async () => {
+    const data = Buffer.from('hello world').toString('base64');
+    const res = await request(app)
+      .post('/api/attachments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ kind: 'base64', filename: 'hello.txt', data, contentType: 'text/plain' })
+      .expect(201);
+
+    const url: string = res.body.data.url;
+    expect(url).toMatch(new RegExp(`/static/uploads/${user.tenantId}/`));
+
+    const woRes = await request(app)
+      .post('/api/workorders')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'With photo',
+        description: 'desc',
+        priority: 'medium',
+        status: 'requested',
+        departmentId: department._id,
+        department: department._id,
+        photos: [url],
+      })
+      .expect(201);
+
+    expect(woRes.body.photos).toEqual([url]);
+  });
+
+  it('accepts URL attachment and persists in work order', async () => {
+    const urlInput = 'https://example.com/test.png';
+    const res = await request(app)
+      .post('/api/attachments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ kind: 'url', url: urlInput })
+      .expect(201);
+
+    expect(res.body.data.url).toBe(urlInput);
+
+    const woRes = await request(app)
+      .post('/api/workorders')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'URL photo',
+        description: 'desc',
+        priority: 'medium',
+        status: 'requested',
+        departmentId: department._id,
+        department: department._id,
+        photos: [urlInput],
+      })
+      .expect(201);
+
+    expect(woRes.body.photos).toEqual([urlInput]);
+  });
+});
+

--- a/backend/validators/workOrderValidators.ts
+++ b/backend/validators/workOrderValidators.ts
@@ -31,7 +31,9 @@ export const workOrderValidators = [
   body('partsUsed.*').isMongoId(),
   body('timeSpentMin').optional().isNumeric(),
   body('photos').optional().isArray(),
-  body('photos.*').isString(),
+  body('photos.*')
+    .isString()
+    .custom((val) => /^https?:\/\//.test(val) || val.startsWith('/static/')),
   body('failureCode').optional().isString(),
   body('scheduledDate').optional().isISO8601().toDate(),
   body('asset').optional().isMongoId(),

--- a/shared/types/uploads.ts
+++ b/shared/types/uploads.ts
@@ -1,0 +1,19 @@
+export type AttachmentInput =
+  | {
+      kind: 'base64';
+      filename: string;
+      data: string;
+      contentType?: string;
+    }
+  | {
+      kind: 'url';
+      url: string;
+      filename?: string;
+      contentType?: string;
+    };
+
+export interface Attachment {
+  url: string;
+  filename: string;
+  contentType?: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,10 @@
     "target": "ES2020",
     "module": "commonjs"
   },
-  "include": ["backend/**/*.ts", "backend/types/**/*.d.ts", "dev-server/**/*.ts"]
+  "include": [
+    "backend/**/*.ts",
+    "backend/types/**/*.d.ts",
+    "dev-server/**/*.ts",
+    "shared/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- add shared Attachment types
- support base64 and URL uploads via /api/attachments
- serve saved files from /static/uploads and validate work order photo URLs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cfe97f6483239c019cb819170d20