### PR TITLE
feat: add global command palette and dashboard trends

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -2,38 +2,51 @@
  * SPDX-License-Identifier: MIT
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Search } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import Avatar from '@common/Avatar';
 import NotificationMenu from './NotificationMenu';
 import { useAuthStore, type AuthState } from '@/store/authStore';
+import GlobalSearch from './GlobalSearch';
 
 const Header: React.FC = () => {
   const { t } = useTranslation();
   const user = useAuthStore((s: AuthState) => s.user);
   const [showNotifications, setShowNotifications] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setSearchOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   return (
-    <header className="flex h-16 items-center justify-between border-b bg-white px-4 dark:bg-neutral-900">
-      <div className="flex-1 max-w-md">
-        <div className="relative">
-          <Search
-            size={18}
-            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400"
-          />
-          <input
-            type="text"
-            placeholder={t('header.searchPlaceholder')}
-            className="w-full rounded-md border border-neutral-300 bg-transparent py-2 pl-9 pr-3 text-sm text-neutral-900 outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white"
-          />
-        </div>
-      </div>
+    <header className="flex h-16 items-center justify-between border-b bg-gradient-to-r from-white to-neutral-100 px-4 dark:from-neutral-900 dark:to-neutral-800">
+      <button
+        onClick={() => setSearchOpen(true)}
+        className="flex max-w-md flex-1 items-center rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-600 shadow-sm dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200"
+      >
+        <Search size={18} className="text-neutral-500 dark:text-neutral-400" />
+        <span className="ml-2 hidden flex-1 text-left md:block">
+          {t('header.searchPlaceholder')}
+        </span>
+        <kbd className="ml-auto hidden rounded bg-neutral-200 px-1 text-xs md:inline dark:bg-neutral-700">
+          ⌘K
+        </kbd>
+      </button>
       <div className="ml-4 flex items-center gap-4">
         <NotificationMenu open={showNotifications} onOpenChange={setShowNotifications} />
         <Avatar name={user?.name || ''} size="sm" />
       </div>
+      <GlobalSearch open={searchOpen} onOpenChange={setSearchOpen} />
     </header>
   );
 };

--- a/frontend/src/pages/dashboard/DashboardHome.tsx
+++ b/frontend/src/pages/dashboard/DashboardHome.tsx
@@ -7,6 +7,7 @@ import { Link } from "react-router-dom";
 import http from "@/lib/http";
 import { useToast } from "@/context/ToastContext";
 import RecentActivity, { AuditLog } from "@/components/dashboard/RecentActivity";
+import { ResponsiveContainer, LineChart, Line } from "recharts";
 import {
   ClipboardList,
   Timer,
@@ -26,6 +27,8 @@ type Summary = {
   costMTD: number;
   cmVsPmRatio: number;
   wrenchTimePct: number;
+  pmComplianceTrend: number[];
+  woBacklogTrend: number[];
 };
 
 type RecentWorkOrder = {
@@ -170,11 +173,27 @@ export default function DashboardHome() {
               value={summary?.cmVsPmRatio.toFixed(2)}
               icon={<PieChartIcon className="h-5 w-5" />}
             />
-            <StatCard
+          <StatCard
               loading={loading}
               title="Wrench Time"
               value={summary ? `${summary.wrenchTimePct.toFixed(1)}%` : undefined}
               icon={<Activity className="h-5 w-5" />}
+            />
+          </div>
+
+          {/* Trend charts */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <TrendChart
+              loading={loading}
+              title="PM Compliance Trend"
+              data={summary?.pmComplianceTrend}
+              color="#3b82f6"
+            />
+            <TrendChart
+              loading={loading}
+              title="WO Backlog Trend"
+              data={summary?.woBacklogTrend}
+              color="#ef4444"
             />
           </div>
 
@@ -240,6 +259,35 @@ function StatCard(props: {
         </div>
       </div>
       {footer ? <div className="mt-3 text-muted-foreground">{footer}</div> : null}
+    </div>
+  );
+}
+
+function TrendChart({
+  loading,
+  title,
+  data,
+  color,
+}: {
+  loading: boolean;
+  title: string;
+  data?: number[];
+  color: string;
+}) {
+  return (
+    <div className="rounded-2xl border p-4">
+      <p className="text-sm text-muted-foreground mb-2">{title}</p>
+      {loading ? (
+        <div className="h-16 w-full animate-pulse rounded bg-muted" />
+      ) : data && data.length > 0 ? (
+        <ResponsiveContainer width="100%" height={60}>
+          <LineChart data={data.map((v, i) => ({ i, v }))}>
+            <Line type="monotone" dataKey="v" stroke={color} strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      ) : (
+        <p className="text-sm text-muted-foreground">No data</p>
+      )}
     </div>
   );
 }

--- a/frontend/src/test/globalSearch.test.tsx
+++ b/frontend/src/test/globalSearch.test.tsx
@@ -7,7 +7,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import GlobalSearch from '@/components/GlobalSearch';
+import GlobalSearch from '@/components/layout/GlobalSearch';
 
 function Wrapper() {
   const [open, setOpen] = React.useState(false);
@@ -43,7 +43,7 @@ describe('GlobalSearch', () => {
     await user.type(input, 'pump');
 
     expect(fetch).toHaveBeenCalledWith('/api/assets?search=pump');
-    expect(fetch).toHaveBeenCalledWith('/api/workorders?search=pump');
+    expect(fetch).toHaveBeenCalledWith('/api/work-orders?search=pump');
 
     expect(await screen.findByText('Pump')).toBeInTheDocument();
     expect(await screen.findByText('Fix Pump')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- replace header search box with global search trigger and gradient styling
- add command palette querying assets and work orders
- show summary trends via responsive Recharts sparklines

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c5d09ae6bc832385ec2b405193a0a7