### PR TITLE
refactor: improve work order typing

### DIFF
--- a/backend/types/workOrder.ts
+++ b/backend/types/workOrder.ts
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Types } from 'mongoose';
+import type { WorkOrderCreate } from '../src/schemas/workOrder';
+
+export type WorkOrderInput = Omit<WorkOrderCreate, 'assignees'> & {
+  assignees?: Types.ObjectId[];
+};
+
+export interface WorkOrderType extends WorkOrderInput {
+  _id: Types.ObjectId;
+  tenantId: Types.ObjectId;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+


### PR DESCRIPTION
## Summary
- import stricter types for work order controller
- convert string assignee ids to ObjectId instances
- add work order type definitions

## Testing
- `npm --prefix backend test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d92c5700832393149842efcbc10d