### PR TITLE
Cast entity IDs before audit logging

### DIFF
--- a/backend/controllers/PurchaseOrderController.ts
+++ b/backend/controllers/PurchaseOrderController.ts
@@ -3,9 +3,12 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import mongoose from 'mongoose';
 
 import PurchaseOrder from '../models/PurchaseOrder';
 import { writeAuditLog } from '../utils/audit';
+
+const { Types, isValidObjectId } = mongoose;
 
 export const createPurchaseOrder = async (
   req: Request,
@@ -19,12 +22,13 @@ export const createPurchaseOrder = async (
       ...(tenantId ? { tenantId } : {}),
     });
     const userId = (req.user as any)?._id || (req.user as any)?.id;
+    const entityId = new Types.ObjectId(po._id);
     await writeAuditLog({
       tenantId,
       userId,
       action: 'create',
       entityType: 'PurchaseOrder',
-      entityId: po._id,
+      entityId,
       after: po.toObject(),
     });
     res.status(201).json(po);
@@ -42,6 +46,10 @@ export const getPurchaseOrder = async (
 ): Promise<Response | void> => {
   try {
     const { id } = req.params;
+    if (!isValidObjectId(id)) {
+      res.status(400).json({ message: 'Invalid id' });
+      return;
+    }
     const po = await PurchaseOrder.findById(id).lean();
     if (!po) {
       res.status(404).json({ message: 'Not found' });
@@ -85,6 +93,10 @@ export const updateVendorPurchaseOrder = async (
       res.status(400).json({ message: 'Invalid status' });
       return;
     }
+    if (!isValidObjectId(id)) {
+      res.status(400).json({ message: 'Invalid id' });
+      return;
+    }
     const po = await PurchaseOrder.findById(id);
     if (!po) {
       res.status(404).json({ message: 'Not found' });
@@ -98,12 +110,13 @@ export const updateVendorPurchaseOrder = async (
     po.status = status as any;
     await po.save();
     const userId = (req.user as any)?._id || (req.user as any)?.id;
+    const entityId = new Types.ObjectId(id);
     await writeAuditLog({
       tenantId: po.tenantId,
       userId,
       action: 'update',
       entityType: 'PurchaseOrder',
-      entityId: id,
+      entityId,
       before,
       after: po.toObject(),
     });


### PR DESCRIPTION
## Summary
- validate and cast IDs with `Types.ObjectId` before calling `writeAuditLog`
- ensure `writeAuditLog` uses `Types.ObjectId` in RoleController and PurchaseOrderController

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d92bcb6c83238abb69080151f810