### PR TITLE
chore: type express handler params

### DIFF
--- a/backend/controllers/TenantController.ts
+++ b/backend/controllers/TenantController.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Request, Response } from 'express';
+import type { Request, Response, NextFunction } from 'express';
 import { ok, fail, asyncHandler } from '../src/lib/http';
 
 import Tenant from '../models/Tenant';


### PR DESCRIPTION
## Summary
- import Request, Response, NextFunction from express as types in tenant controller
- ensure tenant handlers use typed express params

## Testing
- `npm --prefix backend test` *(fails: vitest not found)*
- `npm --prefix backend install vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d92b913c8323bcb59db48276e915