### PR TITLE
chore: alias express-validator ValidationError

### DIFF
--- a/backend/controllers/AssetController.ts
+++ b/backend/controllers/AssetController.ts
@@ -9,7 +9,7 @@ import Site from '../models/Site';
 import Department from '../models/Department';
 import Line from '../models/Line';
 import Station from '../models/Station';
-import { validationResult } from 'express-validator';
+import { validationResult, ValidationError as ExpressValidationError } from 'express-validator';
 import logger from '../utils/logger';
 import { filterFields } from '../utils/filterFields';
 import { writeAuditLog } from '../utils/audit';
@@ -84,7 +84,7 @@ export const createAsset: AuthedRequestHandler = async (req, res, next) => {
   try {
     const errors = validationResult(req as any);
     if (!errors.isEmpty()) {
-      res.status(400).json({ errors: errors.array() });
+      res.status(400).json({ errors: errors.array() as ExpressValidationError[] });
       return;
     }
 
@@ -142,7 +142,7 @@ export const updateAsset: AuthedRequestHandler = async (req, res, next) => {
     const errors = validationResult(req as any);
 
     if (!errors.isEmpty()) {
-      res.status(400).json({ errors: errors.array() });
+      res.status(400).json({ errors: errors.array() as ExpressValidationError[] });
       return;
     }
 


### PR DESCRIPTION
## Summary
- alias ValidationError from express-validator to avoid naming conflicts
- cast validation error arrays to ExpressValidationError

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ebc2b8cc8323a713f621f1587822