### PR TITLE
fix: clean up meter controller errors

### DIFF
--- a/backend/controllers/MeterController.ts
+++ b/backend/controllers/MeterController.ts
@@ -40,7 +40,7 @@ export const createMeter: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return res.status(400).json({ error: 'Tenant ID required' });
     const meter = await Meter.create({
       ...req.body,
       tenantId,
@@ -124,12 +124,12 @@ export const addMeterReading: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return res.status(400).json({ error: 'Tenant ID required' });
     const filter: any = { _id: req.params.id, tenantId };
     if (req.siteId) filter.siteId = req.siteId;
     const meter = await Meter.findOne(filter);
     if (!meter) {
-      res.status(404).json({ message: 'Not found' });
+      res.status(404).json({ error: 'Not found' });
       return;
     }
 


### PR DESCRIPTION
## Summary
- fix mismatched error keys in meter controller

## Testing
- `npm --prefix backend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ebc72b088323a504feba93fb6256