### PR TITLE
Validate role ID before database operations

### DIFF
--- a/backend/controllers/RoleController.ts
+++ b/backend/controllers/RoleController.ts
@@ -21,7 +21,14 @@ export const getAllRoles = async (_req: Request, res: Response, next: NextFuncti
 
 export const getRoleById = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const role = await Role.findById(req.params.id);
+    const { id } = req.params;
+    if (!isValidObjectId(id)) {
+      res.status(400).json({ message: 'Invalid id' });
+      return;
+    }
+
+    const roleId = new Types.ObjectId(id);
+    const role = await Role.findById(roleId);
     if (!role) return res.status(404).json({ message: 'Not found' });
     res.json(role);
   } catch (err) {
@@ -62,13 +69,20 @@ export const updateRole = async (req: Request, res: Response, next: NextFunction
     }
 
     const userId = (req.user as any)?._id || (req.user as any)?.id;
-    const existing = await Role.findById(req.params.id);
+    const { id } = req.params;
+    if (!isValidObjectId(id)) {
+      res.status(400).json({ message: 'Invalid id' });
+      return;
+    }
+
+    const roleId = new Types.ObjectId(id);
+    const existing = await Role.findById(roleId);
     if (!existing) return res.status(404).json({ message: 'Not found' });
-    const role = await Role.findByIdAndUpdate(req.params.id, req.body, {
+    const role = await Role.findByIdAndUpdate(roleId, req.body, {
       new: true,
       runValidators: true,
     });
-    const entityId = new Types.ObjectId(req.params.id);
+    const entityId = roleId;
     await writeAuditLog({
       tenantId,
       userId,
@@ -93,9 +107,16 @@ export const deleteRole = async (req: Request, res: Response, next: NextFunction
     }
 
     const userId = (req.user as any)?._id || (req.user as any)?.id;
-    const role = await Role.findByIdAndDelete(req.params.id);
+    const { id } = req.params;
+    if (!isValidObjectId(id)) {
+      res.status(400).json({ message: 'Invalid id' });
+      return;
+    }
+
+    const roleId = new Types.ObjectId(id);
+    const role = await Role.findByIdAndDelete(roleId);
     if (!role) return res.status(404).json({ message: 'Not found' });
-    const entityId = new Types.ObjectId(req.params.id);
+    const entityId = roleId;
     await writeAuditLog({
       tenantId,
       userId,


### PR DESCRIPTION
## Summary
- validate and cast RoleController IDs to `Types.ObjectId`

## Testing
- `npm --prefix backend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ebca3578832397f6f3d0aed89975