### PR TITLE
chore: type complete work order body

### DIFF
--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -22,6 +22,7 @@ import {
   startWorkOrderSchema,
   completeWorkOrderSchema,
   cancelWorkOrderSchema,
+  type WorkOrderComplete,
 } from '../src/schemas/workOrder';
 
 
@@ -55,6 +56,11 @@ const workOrderCreateFields = [
 ];
 
 const workOrderUpdateFields = [...workOrderCreateFields];
+
+interface CompleteWorkOrderBody extends WorkOrderComplete {
+  photos?: string[];
+  failureCode?: string;
+}
 
 function toWorkOrderUpdatePayload(doc: any): WorkOrderUpdatePayload {
   const plain = typeof doc.toObject === "function"
@@ -581,14 +587,15 @@ export const completeWorkOrder: AuthedRequestHandler = async (req, res, next) =>
       res.status(404).json({ message: 'Not found' });
       return;
     }
+    const body = req.body as CompleteWorkOrderBody;
     const before = workOrder.toObject();
     workOrder.status = 'completed';
-    if (req.body.timeSpentMin !== undefined) workOrder.timeSpentMin = req.body.timeSpentMin;
-    if (Array.isArray(req.body.partsUsed)) workOrder.partsUsed = req.body.partsUsed;
-    if (Array.isArray(req.body.checklists)) workOrder.checklists = req.body.checklists;
-    if (Array.isArray(req.body.signatures)) workOrder.signatures = req.body.signatures;
-    if (Array.isArray(req.body.photos)) workOrder.photos = req.body.photos;
-    if (req.body.failureCode !== undefined) workOrder.failureCode = req.body.failureCode;
+    if (body.timeSpentMin !== undefined) workOrder.timeSpentMin = body.timeSpentMin;
+    if (Array.isArray(body.partsUsed)) workOrder.partsUsed = body.partsUsed;
+    if (Array.isArray(body.checklists)) workOrder.checklists = body.checklists;
+    if (Array.isArray(body.signatures)) workOrder.signatures = body.signatures;
+    if (Array.isArray(body.photos)) workOrder.photos = body.photos;
+    if (body.failureCode !== undefined) workOrder.failureCode = body.failureCode;
 
     const saved = await workOrder.save();
     const userId = (req.user as any)?._id || (req.user as any)?.id;


### PR DESCRIPTION
## Summary
- add explicit CompleteWorkOrderBody interface
- cast complete work order request body to typed interface before property access

## Testing
- `npm test tests/workOrderRoutes.test.ts` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ebd12c1c83238de9b5dc608525e2