### PR TITLE
fix: resolve type export conflicts

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,5 @@
-export type { Asset } from '@shared/asset';
-export type { WorkOrder, NewWorkOrder } from '@shared/workOrder';
+export type { Asset as SharedAsset } from '@shared/asset';
+export type { WorkOrder as SharedWorkOrder } from '@shared/workOrder';
 export type { InventoryItem, InventoryUpdatePayload } from '@shared/inventory';
 export type { UploadedFile, UploadResponse } from '@shared/uploads';
 export type { ApiResult } from '@shared/http';


### PR DESCRIPTION
## Summary
- alias shared Asset and WorkOrder exports to avoid name collisions
- drop invalid NewWorkOrder re-export

## Testing
- `npm --prefix frontend test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ebd3692c8323abd382f18c1dcf97