### PR TITLE
refactor: simplify WorkOrder imports

### DIFF
--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -7,13 +7,12 @@ import type { AuthedRequestHandler } from '../types/http';
 import { emitWorkOrderUpdate } from '../server';
 import notifyUser from '../utils/notify';
 import { AIAssistResult, getWorkOrderAssistance } from '../services/aiCopilot';
-import { Document, Document, Document, Document, Types } from 'mongoose';
+import { Types } from 'mongoose';
 import { WorkOrderUpdatePayload } from '../types/Payloads';
 import { filterFields } from '../utils/filterFields';
 import { writeAuditLog } from '../utils/audit';
 import type { ParamsDictionary } from 'express-serve-static-core';
 import type { WorkOrderType, WorkOrderInput } from '../types/workOrder';
-
 import { sendResponse } from '../utils/sendResponse';
 import {
   workOrderCreateSchema,
@@ -24,18 +23,6 @@ import {
   cancelWorkOrderSchema,
   type WorkOrderComplete,
 } from '../src/schemas/workOrder';
-import { Response } from 'express';
-import { Response } from 'express';
-import { Response } from 'express';
-import { Response } from 'express';
-import { Response } from 'express';
-import { Response } from 'express';
-import { Response } from 'express';
-import { ObjectId } from 'bson';
-import { ObjectId } from 'bson';
-import { ObjectId } from 'bson';
-import { ObjectId } from 'bson';
-import { Response } from 'express';
 
 
 
@@ -96,7 +83,7 @@ function toWorkOrderUpdatePayload(doc: any): WorkOrderUpdatePayload {
  *       200:
  *         description: List of work orders
  */
-export const getAllWorkOrders: AuthedRequestHandler = async (req: { tenantId: any; }, res: Response<any, Record<string, any>>, next: (arg0: unknown) => void) => {
+export const getAllWorkOrders: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -142,7 +129,7 @@ export const getAllWorkOrders: AuthedRequestHandler = async (req: { tenantId: an
  *       200:
  *         description: Filtered work orders
  */
-export const searchWorkOrders: AuthedRequestHandler = async (req: { tenantId: any; query: { startDate?: any; endDate?: any; status?: any; priority?: any; }; }, res: Response<any, Record<string, any>>, next: (arg0: unknown) => void) => {
+export const searchWorkOrders: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -197,7 +184,7 @@ export const searchWorkOrders: AuthedRequestHandler = async (req: { tenantId: an
  *       404:
  *         description: Work order not found
  */
-export const getWorkOrderById: AuthedRequestHandler = async (req: { tenantId: any; params: { id: any; }; }, res: Response<any, Record<string, any>>, next: (arg0: unknown) => void) => {
+export const getWorkOrderById: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -237,7 +224,7 @@ export const getWorkOrderById: AuthedRequestHandler = async (req: { tenantId: an
  *         description: Validation error
  */
 
-export const createWorkOrder: AuthedRequestHandler<ParamsDictionary, WorkOrderType, WorkOrderInput> = async (req: { tenantId: any; body: unknown; user: any; }, res: Response<any, Record<string, any>>, next: (arg0: unknown) => void) => {
+export const createWorkOrder: AuthedRequestHandler<ParamsDictionary, WorkOrderType, WorkOrderInput> = async (req, res, next) => {
   try {
 
     const tenantId = req.tenantId;
@@ -303,7 +290,7 @@ export const createWorkOrder: AuthedRequestHandler<ParamsDictionary, WorkOrderTy
  *       404:
  *         description: Work order not found
  */
-export const updateWorkOrder: AuthedRequestHandler = async (req: { tenantId: any; body: unknown; params: { id: any; }; user: any; }, res: Response<any, Record<string, any>>, next: (arg0: unknown) => void) => {
+export const updateWorkOrder: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -373,7 +360,7 @@ export const updateWorkOrder: AuthedRequestHandler = async (req: { tenantId: any
  *       404:
  *         description: Work order not found
  */
-export const deleteWorkOrder: AuthedRequestHandler = async (req: { tenantId: any; params: { id: any; }; user: any; }, res: Response<any, Record<string, any>>, next: (arg0: unknown) => void) => {
+export const deleteWorkOrder: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -434,7 +421,7 @@ export const deleteWorkOrder: AuthedRequestHandler = async (req: { tenantId: any
  *         description: Work order not found
  */
  
-export const approveWorkOrder: AuthedRequestHandler = async (req: { tenantId: any; user: { _id: any; id: any; }; body: { status: any; }; params: { id: any; }; }, res: Response<any, Record<string, any>>, next: (arg0: unknown) => void) => {
+export const approveWorkOrder: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -499,7 +486,7 @@ export const approveWorkOrder: AuthedRequestHandler = async (req: { tenantId: an
   }
 };
  
-export const assignWorkOrder: AuthedRequestHandler = async (req: { tenantId: any; params: { id: any; }; body: unknown; user: any; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message?: string; formErrors?: string[]; fieldErrors?: { assignees?: string[]; }; }): void; new(): any; }; }; json: (arg0: Document<unknown, {}, { createdAt: NativeDate; updatedAt: NativeDate; } & { title: string; priority: "low" | "medium" | "high" | "critical"; status: "requested" | "assigned" | "in_progress" | "completed" | "cancelled"; approvalStatus: "not-required" | "pending" | "approved" | "rejected"; assignees: Types.ObjectId[]; checklists: Types.DocumentArray<{ done: boolean; text?: string | null; }, Types.Subdocument<ObjectId, any, { done: boolean; text?: string | null; }> & { done: boolean; text?: string | null; }>; partsUsed: Types.DocumentArray<{ qty: number; cost: number; partId?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { qty: number; cost: number; partId?: Types.ObjectId | null; }> & { qty: number; cost: number; partId?: Types.ObjectId | null; }>; signatures: Types.DocumentArray<{ ts: NativeDate; by?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { ts: NativeDate; by?: Types.ObjectId | null; }> & { ts: NativeDate; by?: Types.ObjectId | null; }>; photos: string[]; tenantId: Types.ObjectId; description?: string | null; timeSpentMin?: number | null; failureCode?: string | null; teamMemberName?: string | null; completedAt?: NativeDate | null; assetId?: Types.ObjectId | null; approvalRequestedBy?: Types.ObjectId | null; approvedBy?: Types.ObjectId | null; assignedTo?: Types.ObjectId | null; pmTask?: Types.ObjectId | null; department?: Types.ObjectId | null; line?: Types.ObjectId | null; station?: Types.ObjectId | null; importance?: "low" | "medium" | "high" | "severe" | null; dueDate?: NativeDate | null; }, {}, { timestamps: true; }> & { createdAt: NativeDate; updatedAt: NativeDate; } & { title: string; priority: "low" | "medium" | "high" | "critical"; status: "requested" | "assigned" | "in_progress" | "completed" | "cancelled"; approvalStatus: "not-required" | "pending" | "approved" | "rejected"; assignees: Types.ObjectId[]; checklists: Types.DocumentArray<{ done: boolean; text?: string | null; }, Types.Subdocument<ObjectId, any, { done: boolean; text?: string | null; }> & { done: boolean; text?: string | null; }>; partsUsed: Types.DocumentArray<{ qty: number; cost: number; partId?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { qty: number; cost: number; partId?: Types.ObjectId | null; }> & { qty: number; cost: number; partId?: Types.ObjectId | null; }>; signatures: Types.DocumentArray<{ ts: NativeDate; by?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { ts: NativeDate; by?: Types.ObjectId | null; }> & { ts: NativeDate; by?: Types.ObjectId | null; }>; photos: string[]; tenantId: Types.ObjectId; description?: string | null; timeSpentMin?: number | null; failureCode?: string | null; teamMemberName?: string | null; completedAt?: NativeDate | null; assetId?: Types.ObjectId | null; approvalRequestedBy?: Types.ObjectId | null; approvedBy?: Types.ObjectId | null; assignedTo?: Types.ObjectId | null; pmTask?: Types.ObjectId | null; department?: Types.ObjectId | null; line?: Types.ObjectId | null; station?: Types.ObjectId | null; importance?: "low" | "medium" | "high" | "severe" | null; dueDate?: NativeDate | null; } & { _id: Types.ObjectId; } & { __v: number; }) => void; }, next: (arg0: unknown) => void) => {
+export const assignWorkOrder: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -543,7 +530,7 @@ export const assignWorkOrder: AuthedRequestHandler = async (req: { tenantId: any
   }
 };
 
-export const startWorkOrder: AuthedRequestHandler = async (req: { tenantId: any; body: unknown; params: { id: any; }; user: any; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message?: string; formErrors?: string[]; fieldErrors?: {}; }): void; new(): any; }; }; json: (arg0: Document<unknown, {}, { createdAt: NativeDate; updatedAt: NativeDate; } & { title: string; priority: "low" | "medium" | "high" | "critical"; status: "requested" | "assigned" | "in_progress" | "completed" | "cancelled"; approvalStatus: "not-required" | "pending" | "approved" | "rejected"; assignees: Types.ObjectId[]; checklists: Types.DocumentArray<{ done: boolean; text?: string | null; }, Types.Subdocument<ObjectId, any, { done: boolean; text?: string | null; }> & { done: boolean; text?: string | null; }>; partsUsed: Types.DocumentArray<{ qty: number; cost: number; partId?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { qty: number; cost: number; partId?: Types.ObjectId | null; }> & { qty: number; cost: number; partId?: Types.ObjectId | null; }>; signatures: Types.DocumentArray<{ ts: NativeDate; by?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { ts: NativeDate; by?: Types.ObjectId | null; }> & { ts: NativeDate; by?: Types.ObjectId | null; }>; photos: string[]; tenantId: Types.ObjectId; description?: string | null; timeSpentMin?: number | null; failureCode?: string | null; teamMemberName?: string | null; completedAt?: NativeDate | null; assetId?: Types.ObjectId | null; approvalRequestedBy?: Types.ObjectId | null; approvedBy?: Types.ObjectId | null; assignedTo?: Types.ObjectId | null; pmTask?: Types.ObjectId | null; department?: Types.ObjectId | null; line?: Types.ObjectId | null; station?: Types.ObjectId | null; importance?: "low" | "medium" | "high" | "severe" | null; dueDate?: NativeDate | null; }, {}, { timestamps: true; }> & { createdAt: NativeDate; updatedAt: NativeDate; } & { title: string; priority: "low" | "medium" | "high" | "critical"; status: "requested" | "assigned" | "in_progress" | "completed" | "cancelled"; approvalStatus: "not-required" | "pending" | "approved" | "rejected"; assignees: Types.ObjectId[]; checklists: Types.DocumentArray<{ done: boolean; text?: string | null; }, Types.Subdocument<ObjectId, any, { done: boolean; text?: string | null; }> & { done: boolean; text?: string | null; }>; partsUsed: Types.DocumentArray<{ qty: number; cost: number; partId?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { qty: number; cost: number; partId?: Types.ObjectId | null; }> & { qty: number; cost: number; partId?: Types.ObjectId | null; }>; signatures: Types.DocumentArray<{ ts: NativeDate; by?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { ts: NativeDate; by?: Types.ObjectId | null; }> & { ts: NativeDate; by?: Types.ObjectId | null; }>; photos: string[]; tenantId: Types.ObjectId; description?: string | null; timeSpentMin?: number | null; failureCode?: string | null; teamMemberName?: string | null; completedAt?: NativeDate | null; assetId?: Types.ObjectId | null; approvalRequestedBy?: Types.ObjectId | null; approvedBy?: Types.ObjectId | null; assignedTo?: Types.ObjectId | null; pmTask?: Types.ObjectId | null; department?: Types.ObjectId | null; line?: Types.ObjectId | null; station?: Types.ObjectId | null; importance?: "low" | "medium" | "high" | "severe" | null; dueDate?: NativeDate | null; } & { _id: Types.ObjectId; } & { __v: number; }) => void; }, next: (arg0: unknown) => void) => {
+export const startWorkOrder: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -582,7 +569,7 @@ export const startWorkOrder: AuthedRequestHandler = async (req: { tenantId: any;
   }
 };
 
-export const completeWorkOrder: AuthedRequestHandler = async (req: { tenantId: any; body: unknown; params: { id: any; }; user: any; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message?: string; formErrors?: string[]; fieldErrors?: { timeSpentMin?: string[]; checklists?: string[]; partsUsed?: string[]; signatures?: string[]; }; }): void; new(): any; }; }; json: (arg0: Document<unknown, {}, { createdAt: NativeDate; updatedAt: NativeDate; } & { title: string; priority: "low" | "medium" | "high" | "critical"; status: "requested" | "assigned" | "in_progress" | "completed" | "cancelled"; approvalStatus: "not-required" | "pending" | "approved" | "rejected"; assignees: Types.ObjectId[]; checklists: Types.DocumentArray<{ done: boolean; text?: string | null; }, Types.Subdocument<ObjectId, any, { done: boolean; text?: string | null; }> & { done: boolean; text?: string | null; }>; partsUsed: Types.DocumentArray<{ qty: number; cost: number; partId?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { qty: number; cost: number; partId?: Types.ObjectId | null; }> & { qty: number; cost: number; partId?: Types.ObjectId | null; }>; signatures: Types.DocumentArray<{ ts: NativeDate; by?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { ts: NativeDate; by?: Types.ObjectId | null; }> & { ts: NativeDate; by?: Types.ObjectId | null; }>; photos: string[]; tenantId: Types.ObjectId; description?: string | null; timeSpentMin?: number | null; failureCode?: string | null; teamMemberName?: string | null; completedAt?: NativeDate | null; assetId?: Types.ObjectId | null; approvalRequestedBy?: Types.ObjectId | null; approvedBy?: Types.ObjectId | null; assignedTo?: Types.ObjectId | null; pmTask?: Types.ObjectId | null; department?: Types.ObjectId | null; line?: Types.ObjectId | null; station?: Types.ObjectId | null; importance?: "low" | "medium" | "high" | "severe" | null; dueDate?: NativeDate | null; }, {}, { timestamps: true; }> & { createdAt: NativeDate; updatedAt: NativeDate; } & { title: string; priority: "low" | "medium" | "high" | "critical"; status: "requested" | "assigned" | "in_progress" | "completed" | "cancelled"; approvalStatus: "not-required" | "pending" | "approved" | "rejected"; assignees: Types.ObjectId[]; checklists: Types.DocumentArray<{ done: boolean; text?: string | null; }, Types.Subdocument<ObjectId, any, { done: boolean; text?: string | null; }> & { done: boolean; text?: string | null; }>; partsUsed: Types.DocumentArray<{ qty: number; cost: number; partId?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { qty: number; cost: number; partId?: Types.ObjectId | null; }> & { qty: number; cost: number; partId?: Types.ObjectId | null; }>; signatures: Types.DocumentArray<{ ts: NativeDate; by?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { ts: NativeDate; by?: Types.ObjectId | null; }> & { ts: NativeDate; by?: Types.ObjectId | null; }>; photos: string[]; tenantId: Types.ObjectId; description?: string | null; timeSpentMin?: number | null; failureCode?: string | null; teamMemberName?: string | null; completedAt?: NativeDate | null; assetId?: Types.ObjectId | null; approvalRequestedBy?: Types.ObjectId | null; approvedBy?: Types.ObjectId | null; assignedTo?: Types.ObjectId | null; pmTask?: Types.ObjectId | null; department?: Types.ObjectId | null; line?: Types.ObjectId | null; station?: Types.ObjectId | null; importance?: "low" | "medium" | "high" | "severe" | null; dueDate?: NativeDate | null; } & { _id: Types.ObjectId; } & { __v: number; }) => void; }, next: (arg0: unknown) => void) => {
+export const completeWorkOrder: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -629,7 +616,7 @@ export const completeWorkOrder: AuthedRequestHandler = async (req: { tenantId: a
   }
 };
 
-export const cancelWorkOrder: AuthedRequestHandler = async (req: { tenantId: any; body: unknown; params: { id: any; }; user: any; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message?: string; formErrors?: string[]; fieldErrors?: {}; }): void; new(): any; }; }; json: (arg0: Document<unknown, {}, { createdAt: NativeDate; updatedAt: NativeDate; } & { title: string; priority: "low" | "medium" | "high" | "critical"; status: "requested" | "assigned" | "in_progress" | "completed" | "cancelled"; approvalStatus: "not-required" | "pending" | "approved" | "rejected"; assignees: Types.ObjectId[]; checklists: Types.DocumentArray<{ done: boolean; text?: string | null; }, Types.Subdocument<ObjectId, any, { done: boolean; text?: string | null; }> & { done: boolean; text?: string | null; }>; partsUsed: Types.DocumentArray<{ qty: number; cost: number; partId?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { qty: number; cost: number; partId?: Types.ObjectId | null; }> & { qty: number; cost: number; partId?: Types.ObjectId | null; }>; signatures: Types.DocumentArray<{ ts: NativeDate; by?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { ts: NativeDate; by?: Types.ObjectId | null; }> & { ts: NativeDate; by?: Types.ObjectId | null; }>; photos: string[]; tenantId: Types.ObjectId; description?: string | null; timeSpentMin?: number | null; failureCode?: string | null; teamMemberName?: string | null; completedAt?: NativeDate | null; assetId?: Types.ObjectId | null; approvalRequestedBy?: Types.ObjectId | null; approvedBy?: Types.ObjectId | null; assignedTo?: Types.ObjectId | null; pmTask?: Types.ObjectId | null; department?: Types.ObjectId | null; line?: Types.ObjectId | null; station?: Types.ObjectId | null; importance?: "low" | "medium" | "high" | "severe" | null; dueDate?: NativeDate | null; }, {}, { timestamps: true; }> & { createdAt: NativeDate; updatedAt: NativeDate; } & { title: string; priority: "low" | "medium" | "high" | "critical"; status: "requested" | "assigned" | "in_progress" | "completed" | "cancelled"; approvalStatus: "not-required" | "pending" | "approved" | "rejected"; assignees: Types.ObjectId[]; checklists: Types.DocumentArray<{ done: boolean; text?: string | null; }, Types.Subdocument<ObjectId, any, { done: boolean; text?: string | null; }> & { done: boolean; text?: string | null; }>; partsUsed: Types.DocumentArray<{ qty: number; cost: number; partId?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { qty: number; cost: number; partId?: Types.ObjectId | null; }> & { qty: number; cost: number; partId?: Types.ObjectId | null; }>; signatures: Types.DocumentArray<{ ts: NativeDate; by?: Types.ObjectId | null; }, Types.Subdocument<ObjectId, any, { ts: NativeDate; by?: Types.ObjectId | null; }> & { ts: NativeDate; by?: Types.ObjectId | null; }>; photos: string[]; tenantId: Types.ObjectId; description?: string | null; timeSpentMin?: number | null; failureCode?: string | null; teamMemberName?: string | null; completedAt?: NativeDate | null; assetId?: Types.ObjectId | null; approvalRequestedBy?: Types.ObjectId | null; approvedBy?: Types.ObjectId | null; assignedTo?: Types.ObjectId | null; pmTask?: Types.ObjectId | null; department?: Types.ObjectId | null; line?: Types.ObjectId | null; station?: Types.ObjectId | null; importance?: "low" | "medium" | "high" | "severe" | null; dueDate?: NativeDate | null; } & { _id: Types.ObjectId; } & { __v: number; }) => void; }, next: (arg0: unknown) => void) => {
+export const cancelWorkOrder: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -689,7 +676,7 @@ export const cancelWorkOrder: AuthedRequestHandler = async (req: { tenantId: any
  *         description: Work order not found
 */
 
-export const assistWorkOrder: AuthedRequestHandler = async (req: { tenantId: any; params: { id: any; }; }, res: Response<any, Record<string, any>>, next: (arg0: unknown) => void) => {
+export const assistWorkOrder: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {


### PR DESCRIPTION
## Summary
- consolidate WorkOrderController imports
- remove unused Document, Response, and bson ObjectId imports
- use `Types.ObjectId` consistently

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c656ece52c832382875b6b6bda329a