### PR TITLE
refactor controllers for type inference and audit logging

### DIFF
--- a/backend/controllers/AssetController.ts
+++ b/backend/controllers/AssetController.ts
@@ -3,7 +3,7 @@
  */
 
 import type { AuthedRequestHandler } from '../types/http';
-import mongoose from 'mongoose';
+import mongoose, { Types } from 'mongoose';
 import Asset from '../models/Asset';
 import Site from '../models/Site';
 import Department from '../models/Department';
@@ -164,7 +164,7 @@ export const updateAsset: AuthedRequestHandler = async (req: { body: any; tenant
       userId,
       action: 'update',
       entityType: 'Asset',
-      entityId: id,
+      entityId: new Types.ObjectId(id),
       before: existing.toObject(),
       after: asset?.toObject(),
     });
@@ -204,7 +204,7 @@ export const deleteAsset: AuthedRequestHandler = async (req: { tenantId: any; pa
       userId,
       action: 'delete',
       entityType: 'Asset',
-      entityId: id,
+      entityId: new Types.ObjectId(id),
       before: asset.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/ConditionRuleController.ts
+++ b/backend/controllers/ConditionRuleController.ts
@@ -3,7 +3,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
-
+import { Types } from 'mongoose';
 
 import ConditionRule from '../models/ConditionRule';
 import { writeAuditLog } from '../utils/audit';
@@ -86,7 +86,7 @@ export const updateConditionRule = async (
       userId,
       action: 'update',
       entityType: 'ConditionRule',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -116,7 +116,7 @@ export const deleteConditionRule = async (
       userId,
       action: 'delete',
       entityType: 'ConditionRule',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/DocumentController.ts
+++ b/backend/controllers/DocumentController.ts
@@ -4,24 +4,14 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
-import type { Response as ExpressResponse } from 'express';
 import { Types } from 'mongoose';
 import Document from '../models/Document';
 import type { AuthedRequestHandler } from '../types/http';
 import { sendResponse } from '../utils/sendResponse';
 import { writeAuditLog } from '../utils/audit';
-import { Response } from 'express';
-import { Response } from 'express';
-import { Response } from 'express';
-import { Response } from 'express';
-import { Response } from 'express';
 
 
-export const getAllDocuments: AuthedRequestHandler = async (
-  _req,
-  res: ExpressResponse,
-  next,
-) => {
+export const getAllDocuments: AuthedRequestHandler = async (_req, res, next) => {
   try {
     const items = await Document.find();
     sendResponse(res, items);
@@ -32,11 +22,7 @@ export const getAllDocuments: AuthedRequestHandler = async (
   }
 };
 
-export const getDocumentById: AuthedRequestHandler = async (
-  req,
-  res: ExpressResponse,
-  next,
-) => {
+export const getDocumentById: AuthedRequestHandler = async (req, res, next) => {
   try {
     const item = await Document.findById(req.params.id);
     if (!item) {
@@ -51,11 +37,7 @@ export const getDocumentById: AuthedRequestHandler = async (
   }
 };
 
-export const createDocument: AuthedRequestHandler = async (
-  req,
-  res: ExpressResponse,
-  next,
-) => {
+export const createDocument: AuthedRequestHandler = async (req, res, next) => {
   try {
     const { base64, url, name } = req.body as {
       base64?: string;
@@ -102,11 +84,7 @@ export const createDocument: AuthedRequestHandler = async (
   }
 };
 
-export const updateDocument: AuthedRequestHandler = async (
-  req,
-  res: ExpressResponse,
-  next,
-) => {
+export const updateDocument: AuthedRequestHandler = async (req, res, next) => {
   try {
     const { base64, url, name } = req.body as {
       base64?: string;
@@ -159,11 +137,7 @@ export const updateDocument: AuthedRequestHandler = async (
   }
 };
 
-export const deleteDocument: AuthedRequestHandler = async (
-  req,
-  res: ExpressResponse,
-  next,
-) => {
+export const deleteDocument: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     const userId = (req.user as any)?._id || (req.user as any)?.id;

--- a/backend/controllers/InventoryController.ts
+++ b/backend/controllers/InventoryController.ts
@@ -219,7 +219,7 @@ export const updateInventoryItem = async (req: Request, res: Response, next: Nex
       userId: userId2,
       action: "update",
       entityType: "InventoryItem",
-      entityId: id,
+      entityId: new Types.ObjectId(id),
       before: existing.toObject(),
       after: updated.toObject(),
     });
@@ -255,7 +255,7 @@ export const deleteInventoryItem = async (req: Request, res: Response, next: Nex
       userId: userId3,
       action: "delete",
       entityType: "InventoryItem",
-      entityId: id,
+      entityId: new Types.ObjectId(id),
       before: deleted.toObject(),
     });
     res.json({ message: "Deleted successfully" });
@@ -318,7 +318,7 @@ export const useInventoryItem = async (req: Request, res: Response, next: NextFu
       userId: userId4,
       action: "use",
       entityType: "InventoryItem",
-      entityId: id,
+      entityId: new Types.ObjectId(id),
       before,
       after: item.toObject(),
     });

--- a/backend/controllers/MeterController.ts
+++ b/backend/controllers/MeterController.ts
@@ -6,12 +6,8 @@ import type { AuthedRequestHandler } from '../types/http';
 import Meter from '../models/Meter';
 import MeterReading from '../models/MeterReading';
 import { writeAuditLog } from '../utils/audit';
-import { Document, Types } from 'mongoose';
-import { Document, Types } from 'mongoose';
-import { Document, Types } from 'mongoose';
-import { UpdateQuery, Types, Document } from 'mongoose';
-import { Document, Types } from 'mongoose';
-import { Document, Types } from 'mongoose';
+import { Types } from 'mongoose';
+import type { Document, UpdateQuery } from 'mongoose';
 
 export const getMeters: AuthedRequestHandler = async (req: { tenantId: any; siteId: any; query: { asset: any; }; }, res: { json: (arg0: (Document<unknown, {}, { createdAt: NativeDate; updatedAt: NativeDate; } & { name: string; tenantId: Types.ObjectId; unit: string; asset: Types.ObjectId; currentValue: number; pmInterval: number; lastWOValue: number; siteId?: Types.ObjectId | null; }, {}, { timestamps: true; }> & { createdAt: NativeDate; updatedAt: NativeDate; } & { name: string; tenantId: Types.ObjectId; unit: string; asset: Types.ObjectId; currentValue: number; pmInterval: number; lastWOValue: number; siteId?: Types.ObjectId | null; } & { _id: Types.ObjectId; } & { __v: number; })[]) => void; }, next: (arg0: unknown) => any) => {
   try {
@@ -87,7 +83,7 @@ export const updateMeter: AuthedRequestHandler = async (req: { tenantId: any; pa
       userId,
       action: 'update',
       entityType: 'Meter',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: meter?.toObject(),
     });
@@ -116,7 +112,7 @@ export const deleteMeter: AuthedRequestHandler = async (req: { tenantId: any; pa
       userId,
       action: 'delete',
       entityType: 'Meter',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: meter.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/NotificationController.ts
+++ b/backend/controllers/NotificationController.ts
@@ -175,7 +175,7 @@ export const markNotificationRead: AuthedRequestHandler<
       userId,
       action: 'markRead',
       entityType: 'Notification',
-      entityId: req.params.id as unknown as string | Types.ObjectId,
+      entityId: new Types.ObjectId(req.params.id),
       before: null,
       after: updated.toObject(),
     });
@@ -225,7 +225,7 @@ export const updateNotification: AuthedRequestHandler<
       userId,
       action: 'update',
       entityType: 'Notification',
-      entityId: req.params.id as unknown as string | Types.ObjectId,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -267,7 +267,7 @@ export const deleteNotification: AuthedRequestHandler<
       userId,
       action: 'delete',
       entityType: 'Notification',
-      entityId: req.params.id as unknown as string | Types.ObjectId,
+      entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/PMTaskController.ts
+++ b/backend/controllers/PMTaskController.ts
@@ -105,7 +105,7 @@ export const updatePMTask: AuthedRequestHandler = async (req: { tenantId: any; p
       userId,
       action: 'update',
       entityType: 'PMTask',
-      entityId: req.params.id as string | Types.ObjectId,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: task?.toObject(),
     });
@@ -140,7 +140,7 @@ export const deletePMTask: AuthedRequestHandler = async (req: { tenantId: any; p
       userId,
       action: 'delete',
       entityType: 'PMTask',
-      entityId: req.params.id as string | Types.ObjectId,
+      entityId: new Types.ObjectId(req.params.id),
       before: task.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/TeamMemberController.ts
+++ b/backend/controllers/TeamMemberController.ts
@@ -4,6 +4,7 @@
 
 import TeamMember, { ITeamMember } from '../models/TeamMember';
 import type { Request, Response, NextFunction } from 'express';
+import { Types } from 'mongoose';
 import { writeAuditLog } from '../utils/audit';
 
 const roleHierarchy: Record<ITeamMember['role'], ITeamMember['role'][] | null> = {
@@ -154,7 +155,7 @@ export const updateTeamMember = async (
       userId,
       action: 'update',
       entityType: 'TeamMember',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -202,7 +203,7 @@ export const deleteTeamMember = async (
       userId,
       action: 'delete',
       entityType: 'TeamMember',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/TenantController.ts
+++ b/backend/controllers/TenantController.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Request, Response, NextFunction } from 'express';
+import { Types } from 'mongoose';
 import { ok, fail, asyncHandler } from '../src/lib/http';
 
 import Tenant from '../models/Tenant';
@@ -59,7 +60,7 @@ export const updateTenant = async (req: Request, res: Response, next: NextFuncti
       userId,
       action: 'update',
       entityType: 'Tenant',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: tenant?.toObject(),
     });
@@ -79,7 +80,7 @@ export const deleteTenant = async (req: Request, res: Response, next: NextFuncti
       userId,
       action: 'delete',
       entityType: 'Tenant',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: tenant.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/TimeSheetController.ts
+++ b/backend/controllers/TimeSheetController.ts
@@ -3,6 +3,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { Types } from 'mongoose';
 
 import TimeSheet from '../models/TimeSheet';
 import { writeAuditLog } from '../utils/audit';
@@ -98,7 +99,7 @@ export const updateTimeSheet = async (
       userId,
       action: 'update',
       entityType: 'TimeSheet',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -132,7 +133,7 @@ export const deleteTimeSheet = async (
       userId,
       action: 'delete',
       entityType: 'TimeSheet',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/UserController.ts
+++ b/backend/controllers/UserController.ts
@@ -5,6 +5,7 @@
 import User from '../models/User';
 import { filterFields } from '../utils/filterFields';
 import { Request, Response, NextFunction } from 'express';
+import { Types } from 'mongoose';
 import { writeAuditLog } from '../utils/audit';
 
 const userCreateFields = [
@@ -185,7 +186,7 @@ export const updateUser = async (req: Request, res: Response, next: NextFunction
       userId,
       action: 'update',
       entityType: 'User',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -234,7 +235,7 @@ export const deleteUser = async (req: Request, res: Response, next: NextFunction
       userId,
       action: 'delete',
       entityType: 'User',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/VendorController.ts
+++ b/backend/controllers/VendorController.ts
@@ -3,6 +3,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { Types } from 'mongoose';
 
 import Vendor from '../models/Vendor';
 import { writeAuditLog } from '../utils/audit';
@@ -137,7 +138,7 @@ export const updateVendor = async (
       userId,
       action: 'update',
       entityType: 'Vendor',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -171,7 +172,7 @@ export const deleteVendor = async (
       userId,
       action: 'delete',
       entityType: 'Vendor',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/VideoController.ts
+++ b/backend/controllers/VideoController.ts
@@ -3,6 +3,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { Types } from 'mongoose';
 
 import Video from '../models/Video';
 import { writeAuditLog } from '../utils/audit';
@@ -65,7 +66,7 @@ export const updateVideo = async (req: Request, res: Response, next: NextFunctio
       userId,
       action: 'update',
       entityType: 'Video',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -88,7 +89,7 @@ export const deleteVideo = async (req: Request, res: Response, next: NextFunctio
       userId,
       action: 'delete',
       entityType: 'Video',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/WorkHistoryController.ts
+++ b/backend/controllers/WorkHistoryController.ts
@@ -3,6 +3,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { Types } from 'mongoose';
 
 import WorkHistory from '../models/WorkHistory';
 import { writeAuditLog } from '../utils/audit';
@@ -98,7 +99,7 @@ export const updateWorkHistory = async (
       userId,
       action: 'update',
       entityType: 'WorkHistory',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -132,7 +133,7 @@ export const deleteWorkHistory = async (
       userId,
       action: 'delete',
       entityType: 'WorkHistory',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -380,7 +380,7 @@ export const updateWorkOrder: AuthedRequestHandler = async (req, res, next) => {
       userId,
       action: 'update',
       entityType: 'WorkOrder',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: existing.toObject(),
       after: updated.toObject(),
     });
@@ -430,7 +430,7 @@ export const deleteWorkOrder: AuthedRequestHandler = async (req, res, next) => {
       userId,
       action: 'delete',
       entityType: 'WorkOrder',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
     emitWorkOrderUpdate(toWorkOrderUpdatePayload({ _id: req.params.id, deleted: true }));
@@ -514,7 +514,7 @@ export const approveWorkOrder: AuthedRequestHandler = async (req, res, next) => 
       userId: userObjectId,
       action: 'approve',
       entityType: 'WorkOrder',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before,
       after: saved.toObject(),
     });
@@ -567,7 +567,7 @@ export const assignWorkOrder: AuthedRequestHandler = async (req, res, next) => {
       userId,
       action: 'assign',
       entityType: 'WorkOrder',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before,
       after: saved.toObject(),
     });
@@ -607,7 +607,7 @@ export const startWorkOrder: AuthedRequestHandler = async (req, res, next) => {
       userId,
       action: 'start',
       entityType: 'WorkOrder',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before,
       after: saved.toObject(),
     });
@@ -655,7 +655,7 @@ export const completeWorkOrder: AuthedRequestHandler = async (req, res, next) =>
       userId,
       action: 'complete',
       entityType: 'WorkOrder',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before,
       after: saved.toObject(),
     });
@@ -695,7 +695,7 @@ export const cancelWorkOrder: AuthedRequestHandler = async (req, res, next) => {
       userId,
       action: 'cancel',
       entityType: 'WorkOrder',
-      entityId: req.params.id,
+      entityId: new Types.ObjectId(req.params.id),
       before,
       after: saved.toObject(),
     });


### PR DESCRIPTION
## Summary
- remove redundant express Response imports and rely on AuthedRequestHandler for document handlers
- convert audit log entity IDs to `Types.ObjectId` across controllers to satisfy `AuditPayload`

## Testing
- `npm --prefix backend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c66610722483239949c754c7dce9ea