### PR TITLE
refactor chat handlers

### DIFF
--- a/backend/controllers/ChatController.ts
+++ b/backend/controllers/ChatController.ts
@@ -2,13 +2,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Document, Types } from 'mongoose';
-import Channel, { ChannelDocument } from '../models/Channel';
-import ChatMessage, { ChatMessageDocument }, { ChatMessageDocument }, { ChatMessageDocument }, { ChatMessageDocument }, { ChatMessageDocument } from '../models/ChatMessage';
+import Channel from '../models/Channel';
+import ChatMessage, { ChatMessageDocument } from '../models/ChatMessage';
 import type { AuthedRequestHandler } from '../types/http';
 
 // Channel controllers
-export const getChannels: AuthedRequestHandler = async (req: { user: { id: any; }; tenantId: any; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): void; new(): any; }; }; json: (arg0: (Document<unknown, {}, ChannelDocument, {}, {}> & ChannelDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; })[]) => void; }, next: (arg0: unknown) => void) => {
+export const getChannels: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
@@ -33,7 +32,7 @@ export const getChannels: AuthedRequestHandler = async (req: { user: { id: any; 
   }
 };
 
-export const createChannel: AuthedRequestHandler = async (req: { user: { id: any; }; tenantId: any; body: { name: any; description: any; members?: never[] | undefined; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: Document<unknown, {}, ChannelDocument, {}, {}> & ChannelDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; }): void; new(): any; }; }; }, next: (arg0: unknown) => void) => {
+export const createChannel: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
@@ -62,7 +61,7 @@ export const createChannel: AuthedRequestHandler = async (req: { user: { id: any
   }
 };
 
-export const updateChannel: AuthedRequestHandler = async (req: { user: { id: any; }; tenantId: any; body: { name: any; description: any; members: any; }; params: { channelId: any; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): void; new(): any; }; end: { (): void; new(): any; }; }; json: (arg0: Document<unknown, {}, ChannelDocument, {}, {}> & ChannelDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; }) => void; }, next: (arg0: unknown) => void) => {
+export const updateChannel: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
@@ -101,7 +100,7 @@ export const updateChannel: AuthedRequestHandler = async (req: { user: { id: any
   }
 };
 
-export const deleteChannel: AuthedRequestHandler = async (req: { tenantId: any; params: { channelId: any; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): void; new(): any; }; end: { (): void; new(): any; }; }; }, next: (arg0: unknown) => void) => {
+export const deleteChannel: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
@@ -122,7 +121,7 @@ export const deleteChannel: AuthedRequestHandler = async (req: { tenantId: any; 
   }
 };
 
-export const getChannelMessages: AuthedRequestHandler = async (req: { params: { channelId: any; }; }, res: { json: (arg0: (Document<unknown, {}, ChatMessageDocument, {}, {}> & ChatMessageDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; })[]) => void; }, next: (arg0: unknown) => void) => {
+export const getChannelMessages: AuthedRequestHandler = async (req, res, next) => {
   try {
     const messages = await ChatMessage.find({ channelId: req.params.channelId }).sort({ createdAt: 1 });
     res.json(messages);
@@ -133,7 +132,7 @@ export const getChannelMessages: AuthedRequestHandler = async (req: { params: { 
   }
 };
 
-export const sendChannelMessage: AuthedRequestHandler = async (req: { user: { id: any; }; body: { content: any; }; params: { channelId: any; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: Document<unknown, {}, ChatMessageDocument, {}, {}> & ChatMessageDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; }): void; new(): any; }; }; }, next: (arg0: unknown) => void) => {
+export const sendChannelMessage: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
@@ -155,7 +154,7 @@ export const sendChannelMessage: AuthedRequestHandler = async (req: { user: { id
 };
 
 // Message controllers shared between channel and direct messages
-export const updateMessage: AuthedRequestHandler = async (req: { user: { id: any; }; params: { messageId: any; }; body: { content: any; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): void; new(): any; }; end: { (): void; new(): any; }; }; json: (arg0: Document<unknown, {}, ChatMessageDocument, {}, {}> & ChatMessageDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; }) => void; }, next: (arg0: unknown) => void) => {
+export const updateMessage: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
@@ -179,7 +178,7 @@ export const updateMessage: AuthedRequestHandler = async (req: { user: { id: any
   }
 };
 
-export const deleteMessage: AuthedRequestHandler = async (req: { user: { id: any; }; params: { messageId: any; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): void; new(): any; }; end: { (): void; new(): any; }; }; }, next: (arg0: unknown) => void) => {
+export const deleteMessage: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
@@ -196,7 +195,7 @@ export const deleteMessage: AuthedRequestHandler = async (req: { user: { id: any
 };
 
 // Direct message controllers
-export const getDirectMessages: AuthedRequestHandler = async (req: { user: { id: any; }; tenantId: any; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): void; new(): any; }; }; json: (arg0: (Document<unknown, {}, ChannelDocument, {}, {}> & ChannelDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; })[]) => void; }, next: (arg0: unknown) => void) => {
+export const getDirectMessages: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
@@ -221,7 +220,7 @@ export const getDirectMessages: AuthedRequestHandler = async (req: { user: { id:
   }
 };
 
-export const createDirectMessage: AuthedRequestHandler = async (req: { user: { id: any; }; tenantId: any; body: { userId: any; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: Document<unknown, {}, ChannelDocument, {}, {}> & ChannelDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; }): void; new(): any; }; }; json: (arg0: Document<unknown, {}, ChannelDocument, {}, {}> & ChannelDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; }) => void; }, next: (arg0: unknown) => void) => {
+export const createDirectMessage: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
@@ -259,7 +258,7 @@ export const createDirectMessage: AuthedRequestHandler = async (req: { user: { i
   }
 };
 
-export const deleteDirectMessage: AuthedRequestHandler = async (req: { user: { id: any; }; tenantId: any; params: { conversationId: any; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): void; new(): any; }; end: { (): void; new(): any; }; }; }, next: (arg0: unknown) => void) => {
+export const deleteDirectMessage: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
@@ -286,7 +285,7 @@ export const deleteDirectMessage: AuthedRequestHandler = async (req: { user: { i
   }
 };
 
-export const getDirectMessagesForUser: AuthedRequestHandler = async (req: { user: { id: any; }; tenantId: any; params: { conversationId: any; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): void; new(): any; }; end: { (): void; new(): any; }; }; json: (arg0: (Document<unknown, {}, ChatMessageDocument, {}, {}> & ChatMessageDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; })[]) => void; }, next: (arg0: unknown) => void) => {
+export const getDirectMessagesForUser: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
@@ -317,7 +316,7 @@ export const getDirectMessagesForUser: AuthedRequestHandler = async (req: { user
   }
 };
 
-export const sendDirectMessage: AuthedRequestHandler = async (req: { user: { id: any; }; tenantId: any; params: { conversationId: any; }; body: { content: any; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: Document<unknown, {}, ChatMessageDocument, {}, {}> & ChatMessageDocument & Required<{ _id: Types.ObjectId; }> & { __v: number; }): void; new(): any; }; end: { (): void; new(): any; }; }; }, next: (arg0: unknown) => void) => {
+export const sendDirectMessage: AuthedRequestHandler = async (req, res, next) => {
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {


### PR DESCRIPTION
## Summary
- fix ChatMessage import
- simplify AuthedRequestHandler signatures

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c66610d9508323800bc6e7a21976b1