### PR TITLE
refactor: simplify report download handler

### DIFF
--- a/backend/controllers/ReportsController.ts
+++ b/backend/controllers/ReportsController.ts
@@ -118,7 +118,7 @@ export const getAnalyticsReport: AuthedRequestHandler = async (req: { query: { r
   }
 };
 
-export const downloadReport: AuthedRequestHandler = async (req: { query: { format: any; role: any; }; tenantId: any; }, res: { header: (arg0: string, arg1: string) => void; attachment: (arg0: string) => void; send: (arg0: string) => void; setHeader: (arg0: string, arg1: string) => void; }, next: (arg0: unknown) => any) => {
+export const downloadReport: AuthedRequestHandler = async (req, res, next) => {
  
   try {
     const format = String(req.query.format || 'pdf').toLowerCase();


### PR DESCRIPTION
## Summary
- simplify downloadReport handler signature to use AuthedRequestHandler params

## Testing
- `npm --prefix backend test` *(fails: vitest not found)*
- `npm --prefix backend run lint` *(fails: ESLint configuration file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c66616611483238a7eab625f6331a9