### PR TITLE
refactor: remove local InventoryUpdatePayload

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -344,11 +344,6 @@ export interface WorkOrderUpdatePayload {
   deleted?: boolean;
 }
 
-export interface InventoryUpdatePayload {
-  _id: string;
-  name?: string;
-}
-
 export interface DashboardSummary {
   totalAssets: number;
   totalWorkOrders: number;


### PR DESCRIPTION
## Summary
- rely on InventoryUpdatePayload re-export from `@shared/inventory`
- remove duplicate `InventoryUpdatePayload` interface in frontend types

## Testing
- `npm --prefix frontend test` (fails: vitest not found)
- `npm --prefix backend test` (fails: vitest not found)

------
https://chatgpt.com/codex/tasks/task_e_68c6661997788323a7f697805952c4a3