### PR TITLE
feat: improve resilience for email sending

### DIFF
--- a/backend/utils/emailQueue.ts
+++ b/backend/utils/emailQueue.ts
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { SendMailOptions } from 'nodemailer';
+import { sendKafkaEvent } from './kafka';
+
+export const enqueueEmailRetry = async (mailOptions: SendMailOptions) => {
+  await sendKafkaEvent('emailRetries', mailOptions);
+};
+
+export default enqueueEmailRetry;


### PR DESCRIPTION
## Summary
- wrap nodemailer sends in try/catch blocks and log failures
- enqueue failed emails to Kafka `emailRetries` topic for later processing

## Testing
- `npx vitest run` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c66d246d108323b018b15021b4de06