### PR TITLE
feat: make labor rate configurable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -56,6 +56,8 @@ VITE_SOCKET_PATH=/socket.io
 # SEED_TENANT_ID=
 # Default tenant id for new records
 # DEFAULT_TENANT_ID=
+# Hourly labor rate used for cost calculations
+# LABOR_RATE=50
 # Password assigned to seeded admin user
 # ADMIN_DEFAULT_PASSWORD=admin123
 # AI Copilot service API key

--- a/backend/README.md
+++ b/backend/README.md
@@ -291,6 +291,7 @@ below along with its default value if one exists.
 | `CORS_ORIGIN` | Allowed origins for CORS, comma separated. | `http://localhost:5173` |
 | `PM_SCHEDULER_CRON` | Cron expression controlling the PM scheduler. | `*/5 * * * *` |
 | `PM_SCHEDULER_TASK` | Path to the task module run on each scheduler tick. | `./tasks/PMSchedulerTask` |
+| `LABOR_RATE` | Hourly labor rate used for cost calculations. | `50` |
 | `SMTP_HOST` | SMTP server hostname for email notifications. | *(none)* |
 | `SMTP_PORT` | SMTP server port. | `587` |
 | `SMTP_USER` | Username for SMTP authentication. | *(none)* |

--- a/backend/config/env.ts
+++ b/backend/config/env.ts
@@ -8,3 +8,4 @@ dotenv.config();
 
 export const DEFAULT_TENANT_ID = process.env.DEFAULT_TENANT_ID;
 export const PREDICTIVE_MODEL = process.env.PREDICTIVE_MODEL;
+export const LABOR_RATE = Number(process.env.LABOR_RATE ?? '50');

--- a/backend/config/validateEnv.ts
+++ b/backend/config/validateEnv.ts
@@ -10,6 +10,7 @@ const envSchema = z.object({
   MONGO_URI: z.string().default('mongodb://localhost:27017/platinum_cmms'),
   CORS_ORIGIN: z.string().default('http://localhost:5173'),
   PORT: z.string().default('5010'),
+  LABOR_RATE: z.string().default('50'),
   RATE_LIMIT_WINDOW_MS: z.string().default('900000'),
   RATE_LIMIT_MAX: z.string().default('100'),
   NODE_ENV: z.string().default('development'),

--- a/backend/controllers/SummaryController.ts
+++ b/backend/controllers/SummaryController.ts
@@ -10,6 +10,7 @@ import WorkHistory from '../models/WorkHistory';
 import TimeSheet from '../models/TimeSheet';
 import Asset from '../models/Asset';
 import { sendResponse } from '../utils/sendResponse';
+import { LABOR_RATE } from '../config/env';
 
 /**
  * Helper to resolve the tenant id from the request. It checks the `tenantId`
@@ -78,7 +79,7 @@ const calculateSummary = async (
 
   const pmCompliance = pmTotal ? pmCompleted / pmTotal : 0;
   const downtimeThisMonth = maintenanceHours;
-  const costMTD = maintenanceHours * 50;
+  const costMTD = maintenanceHours * LABOR_RATE;
   const cmVsPmRatio = pmTotal ? cmCount / pmTotal : 0;
   const wrenchTimePct = totalHours ? (maintenanceHours / totalHours) * 100 : 0;
 

--- a/backend/tests/reportMetrics.test.ts
+++ b/backend/tests/reportMetrics.test.ts
@@ -22,6 +22,7 @@ let base: Date;
 
 beforeAll(async () => {
   process.env.JWT_SECRET = 'testsecret';
+  process.env.LABOR_RATE = '50';
   mongo = await MongoMemoryServer.create();
   await mongoose.connect(mongo.getUri());
 });
@@ -76,10 +77,11 @@ describe('Reports metrics', () => {
     expect(res.body).toHaveLength(1);
     const expectedPeriod = base.toISOString().slice(0, 7);
     expect(res.body[0].period).toBe(expectedPeriod);
-    expect(res.body[0].laborCost).toBeCloseTo(400);
-    expect(res.body[0].maintenanceCost).toBeCloseTo(200);
+    const laborRate = Number(process.env.LABOR_RATE);
+    expect(res.body[0].laborCost).toBeCloseTo(8 * laborRate);
+    expect(res.body[0].maintenanceCost).toBeCloseTo(4 * laborRate);
     expect(res.body[0].materialCost).toBeCloseTo(5);
-    expect(res.body[0].totalCost).toBeCloseTo(605);
+    expect(res.body[0].totalCost).toBeCloseTo(12 * laborRate + 5);
   });
 
   it('aggregates downtime data', async () => {

--- a/backend/tests/summaryController.test.ts
+++ b/backend/tests/summaryController.test.ts
@@ -25,6 +25,7 @@ let tenantId: mongoose.Types.ObjectId;
 
 beforeAll(async () => {
   process.env.JWT_SECRET = 'testsecret';
+  process.env.LABOR_RATE = '50';
   mongo = await MongoMemoryServer.create();
   await mongoose.connect(mongo.getUri());
 });
@@ -93,12 +94,13 @@ describe('Summary KPIs', () => {
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
+    const laborRate = Number(process.env.LABOR_RATE);
     expect(res.body).toMatchObject({
       data: {
         pmCompliance: 0.5,
         woBacklog: 2,
         downtimeThisMonth: 8,
-        costMTD: 400,
+        costMTD: 8 * laborRate,
         cmVsPmRatio: 0.5,
         wrenchTimePct: 40,
       },

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -16,6 +16,7 @@ The application uses the following environment variables. All names use `UPPER_S
 | `COOKIE_SECURE` | Enable secure cookies | optional |
 | `PM_SCHEDULER_CRON` | CRON schedule for PM tasks | `*/5 * * * *` |
 | `PM_SCHEDULER_TASK` | Path to PM scheduler task | `./tasks/PMSchedulerTask` |
+| `LABOR_RATE` | Hourly labor rate for cost calculations | `50` |
 | `DEFAULT_TENANT_ID` | Default tenant identifier | optional |
 
 ## Frontend


### PR DESCRIPTION
## Summary
- add `LABOR_RATE` env variable with default 50
- use configurable labor rate in cost calculations
- document `LABOR_RATE` in env docs and sample file

## Testing
- `npm --prefix backend test` *(fails: vitest not found)*
- `npm --prefix backend install --no-audit --no-fund` *(fails: ENOTEMPTY directory rename)*

------
https://chatgpt.com/codex/tasks/task_e_68c66d28899c83239e9d06465a3b5ecb