### PR TITLE
Centralize work order array validation

### DIFF
--- a/backend/utils/validateItems.ts
+++ b/backend/utils/validateItems.ts
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { Response } from 'express';
+import { sendResponse } from './sendResponse';
+
+export function validateItems<T>(
+  res: Response,
+  items: T[] | undefined,
+  isValid: (item: T) => boolean,
+  label: string,
+): T[] | undefined {
+  if (!items) return undefined;
+  const invalid = items.find((item) => !isValid(item));
+  if (invalid) {
+    sendResponse(res, null, { message: `Invalid ${label}`, item: invalid }, 400);
+    return undefined;
+  }
+  return items;
+}
+
+export default validateItems;


### PR DESCRIPTION
## Summary
- add reusable `validateItems` utility for arrays
- validate parts, assignees, checklists, and signatures before mapping

## Testing
- `npm --prefix backend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c66d2adda883239100d8ae3c982efe