### PR TITLE
refactor: standardize meter controller responses

### DIFF
--- a/backend/controllers/MeterController.ts
+++ b/backend/controllers/MeterController.ts
@@ -6,7 +6,9 @@ import type { AuthedRequestHandler } from '../types/http';
 import Meter from '../models/Meter';
 import MeterReading from '../models/MeterReading';
 import { writeAuditLog } from '../utils/audit';
-import { Document, Types, UpdateQuery } from 'mongoose';
+import { Types, Error as MongooseError } from 'mongoose';
+import type { UpdateQuery } from 'mongoose';
+import { sendResponse } from '../utils/sendResponse';
 
 
 export const getMeters: AuthedRequestHandler = async (req, res, next) => {
@@ -15,9 +17,19 @@ export const getMeters: AuthedRequestHandler = async (req, res, next) => {
     if (req.siteId) filter.siteId = req.siteId;
     if (req.query.asset) filter.asset = req.query.asset;
     const meters = await Meter.find(filter);
-    res.json(meters);
+    sendResponse(res, meters);
     return;
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      const verr = err as MongooseError.ValidationError;
+      sendResponse(
+        res,
+        null,
+        { errors: Object.values(verr.errors).map((e) => e.message) },
+        400,
+      );
+      return;
+    }
     return next(err);
   }
 };
@@ -28,12 +40,22 @@ export const getMeterById: AuthedRequestHandler = async (req, res, next) => {
     if (req.siteId) filter.siteId = req.siteId;
     const meter = await Meter.findOne(filter);
     if (!meter) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json(meter);
+    sendResponse(res, meter);
     return;
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      const verr = err as MongooseError.ValidationError;
+      sendResponse(
+        res,
+        null,
+        { errors: Object.values(verr.errors).map((e) => e.message) },
+        400,
+      );
+      return;
+    }
     return next(err);
   }
 };
@@ -41,7 +63,10 @@ export const getMeterById: AuthedRequestHandler = async (req, res, next) => {
 export const createMeter: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
-    if (!tenantId) return res.status(400).json({ message: 'Tenant ID required' });
+    if (!tenantId) {
+      sendResponse(res, null, 'Tenant ID required', 400);
+      return;
+    }
     const meter = await Meter.create({
       ...req.body,
       tenantId,
@@ -56,9 +81,19 @@ export const createMeter: AuthedRequestHandler = async (req, res, next) => {
       entityId: meter._id,
       after: meter.toObject(),
     });
-    res.status(201).json(meter);
+    sendResponse(res, meter, null, 201);
     return;
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      const verr = err as MongooseError.ValidationError;
+      sendResponse(
+        res,
+        null,
+        { errors: Object.values(verr.errors).map((e) => e.message) },
+        400,
+      );
+      return;
+    }
     return next(err);
   }
 };
@@ -66,18 +101,21 @@ export const createMeter: AuthedRequestHandler = async (req, res, next) => {
 export const updateMeter: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
-    if (!tenantId) return res.status(400).json({ message: 'Tenant ID required' });
+    if (!tenantId) {
+      sendResponse(res, null, 'Tenant ID required', 400);
+      return;
+    }
     const filter: any = { _id: req.params.id, tenantId };
     if (req.siteId) filter.siteId = req.siteId;
     const existing = await Meter.findOne(filter);
     if (!existing) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const meter = await Meter.findOneAndUpdate(
       filter,
-      req.body as UpdateQuery<Document>,
-      { new: true }
+      req.body as UpdateQuery<any>,
+      { new: true },
     );
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     await writeAuditLog({
@@ -89,9 +127,19 @@ export const updateMeter: AuthedRequestHandler = async (req, res, next) => {
       before: existing.toObject(),
       after: meter?.toObject(),
     });
-    res.json(meter);
+    sendResponse(res, meter);
     return;
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      const verr = err as MongooseError.ValidationError;
+      sendResponse(
+        res,
+        null,
+        { errors: Object.values(verr.errors).map((e) => e.message) },
+        400,
+      );
+      return;
+    }
     return next(err);
   }
 };
@@ -99,12 +147,15 @@ export const updateMeter: AuthedRequestHandler = async (req, res, next) => {
 export const deleteMeter: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
-    if (!tenantId) return res.status(400).json({ message: 'Tenant ID required' });
+    if (!tenantId) {
+      sendResponse(res, null, 'Tenant ID required', 400);
+      return;
+    }
     const filter: any = { _id: req.params.id, tenantId };
     if (req.siteId) filter.siteId = req.siteId;
     const meter = await Meter.findOneAndDelete(filter);
     if (!meter) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
@@ -116,9 +167,19 @@ export const deleteMeter: AuthedRequestHandler = async (req, res, next) => {
       entityId: new Types.ObjectId(req.params.id),
       before: meter.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
     return;
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      const verr = err as MongooseError.ValidationError;
+      sendResponse(
+        res,
+        null,
+        { errors: Object.values(verr.errors).map((e) => e.message) },
+        400,
+      );
+      return;
+    }
     return next(err);
   }
 };
@@ -126,12 +187,15 @@ export const deleteMeter: AuthedRequestHandler = async (req, res, next) => {
 export const addMeterReading: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
-    if (!tenantId) return res.status(400).json({ message: 'Tenant ID required' });
+    if (!tenantId) {
+      sendResponse(res, null, 'Tenant ID required', 400);
+      return;
+    }
     const filter: any = { _id: req.params.id, tenantId };
     if (req.siteId) filter.siteId = req.siteId;
     const meter = await Meter.findOne(filter);
     if (!meter) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
 
@@ -152,9 +216,19 @@ export const addMeterReading: AuthedRequestHandler = async (req, res, next) => {
       entityId: meter._id,
       after: meter.toObject(),
     });
-    res.status(201).json(reading);
+    sendResponse(res, reading, null, 201);
     return;
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      const verr = err as MongooseError.ValidationError;
+      sendResponse(
+        res,
+        null,
+        { errors: Object.values(verr.errors).map((e) => e.message) },
+        400,
+      );
+      return;
+    }
     return next(err);
   }
 };
@@ -165,7 +239,7 @@ export const getMeterReadings: AuthedRequestHandler = async (req, res, next) => 
     if (req.siteId) filter.siteId = req.siteId;
     const meter = await Meter.findOne(filter);
     if (!meter) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const readingFilter: any = { meter: meter._id, tenantId: req.tenantId };
@@ -173,9 +247,19 @@ export const getMeterReadings: AuthedRequestHandler = async (req, res, next) => 
     const readings = await MeterReading.find(readingFilter)
       .sort({ timestamp: -1 })
       .limit(100);
-    res.json(readings);
+    sendResponse(res, readings);
     return;
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      const verr = err as MongooseError.ValidationError;
+      sendResponse(
+        res,
+        null,
+        { errors: Object.values(verr.errors).map((e) => e.message) },
+        400,
+      );
+      return;
+    }
     return next(err);
   }
 };


### PR DESCRIPTION
## Summary
- refactor MeterController to use sendResponse for all responses
- handle Mongoose validation errors and expose messages
- remove Document import by casting update queries with UpdateQuery<any>

## Testing
- `npm --prefix backend test` *(fails: vitest: not found)*
- `npm --prefix frontend test` *(fails: vitest: not found)*
- `npm --prefix backend run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a8542e88323b1173a1a5b91bc19