### PR TITLE
Use helper to normalize entity IDs in audit logging

### DIFF
--- a/backend/controllers/AssetController.ts
+++ b/backend/controllers/AssetController.ts
@@ -13,6 +13,7 @@ import { validationResult, ValidationError } from 'express-validator';
 import logger from '../utils/logger';
 import { filterFields } from '../utils/filterFields';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 const assetCreateFields = [
   'name', 'type', 'location', 'departmentId', 'status', 'serialNumber',
@@ -104,7 +105,7 @@ export const createAsset: AuthedRequestHandler = async (req: { body: { name: any
       userId,
       action: 'create',
       entityType: 'Asset',
-      entityId: newAsset._id,
+      entityId: toEntityId(newAsset._id),
       after: assetObj,
     });
     res.status(201).json(response);
@@ -164,7 +165,7 @@ export const updateAsset: AuthedRequestHandler = async (req: { body: any; tenant
       userId,
       action: 'update',
       entityType: 'Asset',
-      entityId: new Types.ObjectId(id),
+      entityId: toEntityId(new Types.ObjectId(id)),
       before: existing.toObject(),
       after: asset?.toObject(),
     });
@@ -204,7 +205,7 @@ export const deleteAsset: AuthedRequestHandler = async (req: { tenantId: any; pa
       userId,
       action: 'delete',
       entityType: 'Asset',
-      entityId: new Types.ObjectId(id),
+      entityId: toEntityId(new Types.ObjectId(id)),
       before: asset.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/ConditionRuleController.ts
+++ b/backend/controllers/ConditionRuleController.ts
@@ -8,6 +8,7 @@ import type { AuthedRequestHandler } from '../types/http';
 
 import ConditionRule from '../models/ConditionRule';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 export const getAllConditionRules: AuthedRequestHandler<ParamsDictionary> = async (
   req,
@@ -56,7 +57,7 @@ export const createConditionRule: AuthedRequestHandler<ParamsDictionary> = async
       userId,
       action: 'create',
       entityType: 'ConditionRule',
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: saved.toObject(),
     });
     res.status(201).json(saved);
@@ -87,7 +88,7 @@ export const updateConditionRule: AuthedRequestHandler<{ id: string }> = async (
       userId,
       action: 'update',
       entityType: 'ConditionRule',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -117,7 +118,7 @@ export const deleteConditionRule: AuthedRequestHandler<{ id: string }> = async (
       userId,
       action: 'delete',
       entityType: 'ConditionRule',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/DocumentController.ts
+++ b/backend/controllers/DocumentController.ts
@@ -13,6 +13,7 @@ import Document from '../models/Document';
 import type { AuthedRequestHandler } from '../types/http';
 import { sendResponse } from '../utils/sendResponse';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 
 export const getAllDocuments: AuthedRequestHandler<ParamsDictionary> = async (
@@ -130,7 +131,7 @@ export const createDocument: AuthedRequestHandler<ParamsDictionary> = async (
       userId,
       action: 'create',
       entityType: 'Document',
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: saved.toObject(),
     });
 
@@ -216,7 +217,7 @@ export const updateDocument: AuthedRequestHandler<{ id: string }> = async (
       userId,
       action: 'update',
       entityType: 'Document',
-      entityId: objectId,
+      entityId: toEntityId(objectId),
       after: updated.toObject(),
     });
 
@@ -267,7 +268,7 @@ export const deleteDocument: AuthedRequestHandler<{ id: string }> = async (
       userId,
       action: 'delete',
       entityType: 'Document',
-      entityId: objectId,
+      entityId: toEntityId(objectId),
       before: deleted.toObject(),
     });
     sendResponse(res, { message: 'Deleted successfully' });

--- a/backend/controllers/GoodsReceiptController.ts
+++ b/backend/controllers/GoodsReceiptController.ts
@@ -11,6 +11,7 @@ import { addStock } from '../services/inventory';
 import nodemailer from 'nodemailer';
 import { assertEmail } from '../utils/assert';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 import logger from '../utils/logger';
 import { enqueueEmailRetry } from '../utils/emailQueue';
 
@@ -68,7 +69,7 @@ export const createGoodsReceipt = async (
       userId,
       action: 'create',
       entityType: 'GoodsReceipt',
-      entityId: grAny._1 as any,
+      entityId: toEntityId(grAny._1 as any),
       after: typeof grAny.toObject === 'function' ? grAny.toObject() : grAny,
     });
 

--- a/backend/controllers/InventoryController.ts
+++ b/backend/controllers/InventoryController.ts
@@ -7,6 +7,7 @@ import mongoose from "mongoose";
 import InventoryItem, { type IInventoryItem } from "../models/InventoryItem";
 import logger from "../utils/logger";
 import { writeAuditLog } from "../utils/audit";
+import { toEntityId } from "../utils/ids";
 
 const { isValidObjectId, Types } = mongoose;
 
@@ -168,7 +169,7 @@ export const createInventoryItem = async (req: Request, res: Response, next: Nex
       userId,
       action: "create",
       entityType: "InventoryItem",
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: saved.toObject(),
     });
     res.status(201).json(saved);
@@ -219,7 +220,7 @@ export const updateInventoryItem = async (req: Request, res: Response, next: Nex
       userId: userId2,
       action: "update",
       entityType: "InventoryItem",
-      entityId: new Types.ObjectId(id),
+      entityId: toEntityId(new Types.ObjectId(id)),
       before: existing.toObject(),
       after: updated.toObject(),
     });
@@ -255,7 +256,7 @@ export const deleteInventoryItem = async (req: Request, res: Response, next: Nex
       userId: userId3,
       action: "delete",
       entityType: "InventoryItem",
-      entityId: new Types.ObjectId(id),
+      entityId: toEntityId(new Types.ObjectId(id)),
       before: deleted.toObject(),
     });
     res.json({ message: "Deleted successfully" });
@@ -318,7 +319,7 @@ export const useInventoryItem = async (req: Request, res: Response, next: NextFu
       userId: userId4,
       action: "use",
       entityType: "InventoryItem",
-      entityId: new Types.ObjectId(id),
+      entityId: toEntityId(new Types.ObjectId(id)),
       before,
       after: item.toObject(),
     });

--- a/backend/controllers/MeterController.ts
+++ b/backend/controllers/MeterController.ts
@@ -6,6 +6,7 @@ import type { AuthedRequestHandler } from '../types/http';
 import Meter from '../models/Meter';
 import MeterReading from '../models/MeterReading';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 import { Document, Types, UpdateQuery } from 'mongoose';
 
 
@@ -53,7 +54,7 @@ export const createMeter: AuthedRequestHandler = async (req, res, next) => {
       userId,
       action: 'create',
       entityType: 'Meter',
-      entityId: meter._id,
+      entityId: toEntityId(meter._id),
       after: meter.toObject(),
     });
     res.status(201).json(meter);
@@ -85,7 +86,7 @@ export const updateMeter: AuthedRequestHandler = async (req, res, next) => {
       userId,
       action: 'update',
       entityType: 'Meter',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: meter?.toObject(),
     });
@@ -113,7 +114,7 @@ export const deleteMeter: AuthedRequestHandler = async (req, res, next) => {
       userId,
       action: 'delete',
       entityType: 'Meter',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: meter.toObject(),
     });
     res.json({ message: 'Deleted successfully' });
@@ -149,7 +150,7 @@ export const addMeterReading: AuthedRequestHandler = async (req, res, next) => {
       userId,
       action: 'addReading',
       entityType: 'Meter',
-      entityId: meter._id,
+      entityId: toEntityId(meter._id),
       after: meter.toObject(),
     });
     res.status(201).json(reading);

--- a/backend/controllers/NotificationController.ts
+++ b/backend/controllers/NotificationController.ts
@@ -11,6 +11,7 @@ import { assertEmail } from '../utils/assert';
 import type { AuthedRequestHandler } from '../types/http';
 import type { ParamsDictionary } from 'express-serve-static-core';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 import logger from '../utils/logger';
 import { enqueueEmailRetry } from '../utils/emailQueue';
 
@@ -91,7 +92,7 @@ export const createNotification: AuthedRequestHandler<
       userId,
       action: 'create',
       entityType: 'Notification',
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: saved.toObject(),
     });
 
@@ -167,7 +168,7 @@ export const markNotificationRead: AuthedRequestHandler<
       userId,
       action: 'markRead',
       entityType: 'Notification',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: null,
       after: updated.toObject(),
     });
@@ -213,7 +214,7 @@ export const updateNotification: AuthedRequestHandler<
       userId,
       action: 'update',
       entityType: 'Notification',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -251,7 +252,7 @@ export const deleteNotification: AuthedRequestHandler<
       userId,
       action: 'delete',
       entityType: 'Notification',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/PMTaskController.ts
+++ b/backend/controllers/PMTaskController.ts
@@ -21,6 +21,7 @@ import type {
 } from '../types/pmTask';
 import type { ParamsDictionary } from 'express-serve-static-core';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 export const getAllPMTasks: AuthedRequestHandler<ParamsDictionary, PMTaskListResponse> = async (
   req: PMTaskRequest,
@@ -87,7 +88,7 @@ export const createPMTask: AuthedRequestHandler<ParamsDictionary, PMTaskResponse
       userId,
       action: 'create',
       entityType: 'PMTask',
-      entityId: task._id,
+      entityId: toEntityId(task._id),
       after: task.toObject(),
     });
     res.status(201).json(task);
@@ -132,7 +133,7 @@ export const updatePMTask: AuthedRequestHandler<PMTaskParams, PMTaskResponse | n
       userId,
       action: 'update',
       entityType: 'PMTask',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: task?.toObject(),
     });
@@ -171,7 +172,7 @@ export const deletePMTask: AuthedRequestHandler<PMTaskParams, PMTaskDeleteRespon
       userId,
       action: 'delete',
       entityType: 'PMTask',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: task.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/PurchaseOrderController.ts
+++ b/backend/controllers/PurchaseOrderController.ts
@@ -7,6 +7,7 @@ import mongoose from 'mongoose';
 
 import PurchaseOrder from '../models/PurchaseOrder';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 const { Types, isValidObjectId } = mongoose;
 
@@ -24,7 +25,7 @@ export const createPurchaseOrder = async (
       tenantId,
     });
     const userId = (req.user as any)?._id || (req.user as any)?.id;
-    const entityId = new Types.ObjectId(po._id);
+    const entityId = toEntityId(new Types.ObjectId(po._id));
     await writeAuditLog({
       tenantId,
       userId,
@@ -114,7 +115,7 @@ export const updateVendorPurchaseOrder = async (
     po.status = status as any;
     await po.save();
     const userId = (req.user as any)?._id || (req.user as any)?.id;
-    const entityId = objectId;
+    const entityId = toEntityId(objectId);
     await writeAuditLog({
       tenantId: po.tenantId,
       userId,

--- a/backend/controllers/RoleController.ts
+++ b/backend/controllers/RoleController.ts
@@ -7,6 +7,7 @@ import mongoose from 'mongoose';
 
 import Role from '../models/Role';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 const { Types, isValidObjectId } = mongoose;
 
@@ -45,7 +46,7 @@ export const createRole = async (req: Request, res: Response, next: NextFunction
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const role = await Role.create({ ...req.body, tenantId });
-    const entityId = new Types.ObjectId(role._id);
+    const entityId = toEntityId(new Types.ObjectId(role._id));
     await writeAuditLog({
       tenantId,
       userId,
@@ -82,7 +83,7 @@ export const updateRole = async (req: Request, res: Response, next: NextFunction
       new: true,
       runValidators: true,
     });
-    const entityId = roleId;
+    const entityId = toEntityId(roleId);
     await writeAuditLog({
       tenantId,
       userId,
@@ -116,7 +117,7 @@ export const deleteRole = async (req: Request, res: Response, next: NextFunction
     const roleId = new Types.ObjectId(id);
     const role = await Role.findByIdAndDelete(roleId);
     if (!role) return res.status(404).json({ message: 'Not found' });
-    const entityId = roleId;
+    const entityId = toEntityId(roleId);
     await writeAuditLog({
       tenantId,
       userId,

--- a/backend/controllers/TeamMemberController.ts
+++ b/backend/controllers/TeamMemberController.ts
@@ -6,6 +6,7 @@ import TeamMember, { ITeamMember } from '../models/TeamMember';
 import type { Request, Response, NextFunction } from 'express';
 import { Types } from 'mongoose';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 const roleHierarchy: Record<ITeamMember['role'], ITeamMember['role'][] | null> = {
   admin: null,
@@ -103,7 +104,7 @@ export const createTeamMember = async (
       userId,
       action: 'create',
       entityType: 'TeamMember',
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: saved.toObject(),
     });
     res.status(201).json(saved);
@@ -155,7 +156,7 @@ export const updateTeamMember = async (
       userId,
       action: 'update',
       entityType: 'TeamMember',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -203,7 +204,7 @@ export const deleteTeamMember = async (
       userId,
       action: 'delete',
       entityType: 'TeamMember',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/TenantController.ts
+++ b/backend/controllers/TenantController.ts
@@ -8,6 +8,7 @@ import { ok, fail, asyncHandler } from '../src/lib/http';
 
 import Tenant from '../models/Tenant';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 export const getAllTenants = async (_req: Request, res: Response, next: NextFunction) => {
   try {
@@ -37,7 +38,7 @@ export const createTenant = async (req: Request, res: Response, next: NextFuncti
       userId,
       action: 'create',
       entityType: 'Tenant',
-      entityId: tenant._id,
+      entityId: toEntityId(tenant._id),
       after: tenant.toObject(),
     });
     res.status(201).json(tenant);
@@ -60,7 +61,7 @@ export const updateTenant = async (req: Request, res: Response, next: NextFuncti
       userId,
       action: 'update',
       entityType: 'Tenant',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: tenant?.toObject(),
     });
@@ -80,7 +81,7 @@ export const deleteTenant = async (req: Request, res: Response, next: NextFuncti
       userId,
       action: 'delete',
       entityType: 'Tenant',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: tenant.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/ThemeController.ts
+++ b/backend/controllers/ThemeController.ts
@@ -5,6 +5,7 @@
 import type { AuthedRequestHandler } from '../types/http';
 import User from '../models/User';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 export const getTheme: AuthedRequestHandler = async (req, res, next) => {
   try {
@@ -51,7 +52,7 @@ export const updateTheme: AuthedRequestHandler = async (req, res, next) => {
       userId,
       action: 'update',
       entityType: 'UserTheme',
-      entityId: req.user?._id,
+      entityId: toEntityId(req.user?._id),
       before: null,
       after: { theme: updated.theme, colorScheme: updated.colorScheme },
     });

--- a/backend/controllers/TimeSheetController.ts
+++ b/backend/controllers/TimeSheetController.ts
@@ -7,6 +7,7 @@ import { Types } from 'mongoose';
 
 import TimeSheet from '../models/TimeSheet';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
  export const getAllTimeSheets = async (
   req: Request,
@@ -62,7 +63,7 @@ export const createTimeSheet = async (
       userId,
       action: 'create',
       entityType: 'TimeSheet',
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: saved.toObject(),
     });
     res.status(201).json(saved);
@@ -99,7 +100,7 @@ export const updateTimeSheet = async (
       userId,
       action: 'update',
       entityType: 'TimeSheet',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -133,7 +134,7 @@ export const deleteTimeSheet = async (
       userId,
       action: 'delete',
       entityType: 'TimeSheet',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/UserController.ts
+++ b/backend/controllers/UserController.ts
@@ -7,6 +7,7 @@ import { filterFields } from '../utils/filterFields';
 import { Request, Response, NextFunction } from 'express';
 import { Types } from 'mongoose';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 const userCreateFields = [
   'name',
@@ -123,7 +124,7 @@ export const createUser = async (req: Request, res: Response, next: NextFunction
       userId,
       action: 'create',
       entityType: 'User',
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: safeUser,
     });
     res.status(201).json(safeUser);
@@ -186,7 +187,7 @@ export const updateUser = async (req: Request, res: Response, next: NextFunction
       userId,
       action: 'update',
       entityType: 'User',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -235,7 +236,7 @@ export const deleteUser = async (req: Request, res: Response, next: NextFunction
       userId,
       action: 'delete',
       entityType: 'User',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/VendorController.ts
+++ b/backend/controllers/VendorController.ts
@@ -7,6 +7,7 @@ import { Types } from 'mongoose';
 
 import Vendor from '../models/Vendor';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 const allowedFields = [
   'name',
@@ -96,7 +97,7 @@ export const createVendor = async (
       userId,
       action: 'create',
       entityType: 'Vendor',
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: saved.toObject(),
     });
     res.status(201).json(saved);
@@ -138,7 +139,7 @@ export const updateVendor = async (
       userId,
       action: 'update',
       entityType: 'Vendor',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -172,7 +173,7 @@ export const deleteVendor = async (
       userId,
       action: 'delete',
       entityType: 'Vendor',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/VideoController.ts
+++ b/backend/controllers/VideoController.ts
@@ -7,6 +7,7 @@ import { Types } from 'mongoose';
 
 import Video from '../models/Video';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 export const getAllVideos = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -40,7 +41,7 @@ export const createVideo = async (req: Request, res: Response, next: NextFunctio
       userId,
       action: 'create',
       entityType: 'Video',
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: saved.toObject(),
     });
     res.status(201).json(saved);
@@ -66,7 +67,7 @@ export const updateVideo = async (req: Request, res: Response, next: NextFunctio
       userId,
       action: 'update',
       entityType: 'Video',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -89,7 +90,7 @@ export const deleteVideo = async (req: Request, res: Response, next: NextFunctio
       userId,
       action: 'delete',
       entityType: 'Video',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/WorkHistoryController.ts
+++ b/backend/controllers/WorkHistoryController.ts
@@ -7,6 +7,7 @@ import { Types } from 'mongoose';
 
 import WorkHistory from '../models/WorkHistory';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
  
  export const getAllWorkHistories = async (
   req: Request,
@@ -62,7 +63,7 @@ export const createWorkHistory = async (
       userId,
       action: 'create',
       entityType: 'WorkHistory',
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: saved.toObject(),
     });
     res.status(201).json(saved);
@@ -99,7 +100,7 @@ export const updateWorkHistory = async (
       userId,
       action: 'update',
       entityType: 'WorkHistory',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: updated?.toObject(),
     });
@@ -133,7 +134,7 @@ export const deleteWorkHistory = async (
       userId,
       action: 'delete',
       entityType: 'WorkHistory',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: deleted.toObject(),
     });
     res.json({ message: 'Deleted successfully' });

--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -13,6 +13,7 @@ import { AIAssistResult, getWorkOrderAssistance } from '../services/aiCopilot';
 import { Types } from 'mongoose';
 import { WorkOrderUpdatePayload } from '../types/Payloads';
 import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
 
 import type { WorkOrderType, WorkOrderInput } from '../types/workOrder';
 
@@ -337,7 +338,7 @@ export const createWorkOrder: AuthedRequestHandler<
       userId,
       action: 'create',
       entityType: 'WorkOrder',
-      entityId: saved._id,
+      entityId: toEntityId(saved._id),
       after: saved.toObject(),
     });
     emitWorkOrderUpdate(toWorkOrderUpdatePayload(saved));
@@ -431,7 +432,7 @@ export const updateWorkOrder: AuthedRequestHandler = async (
       userId,
       action: 'update',
       entityType: 'WorkOrder',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: existing.toObject(),
       after: updated.toObject(),
     });
@@ -485,7 +486,7 @@ export const deleteWorkOrder: AuthedRequestHandler = async (
       userId,
       action: 'delete',
       entityType: 'WorkOrder',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before: deleted.toObject(),
     });
     emitWorkOrderUpdate(toWorkOrderUpdatePayload({ _id: req.params.id, deleted: true }));
@@ -573,7 +574,7 @@ export const approveWorkOrder: AuthedRequestHandler = async (
       userId: userObjectId,
       action: 'approve',
       entityType: 'WorkOrder',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before,
       after: saved.toObject(),
     });
@@ -632,7 +633,7 @@ export const assignWorkOrder: AuthedRequestHandler = async (
       userId,
       action: 'assign',
       entityType: 'WorkOrder',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before,
       after: saved.toObject(),
     });
@@ -676,7 +677,7 @@ export const startWorkOrder: AuthedRequestHandler = async (
       userId,
       action: 'start',
       entityType: 'WorkOrder',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before,
       after: saved.toObject(),
     });
@@ -740,7 +741,7 @@ export const completeWorkOrder: AuthedRequestHandler = async (
       userId,
       action: 'complete',
       entityType: 'WorkOrder',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before,
       after: saved.toObject(),
     });
@@ -784,7 +785,7 @@ export const cancelWorkOrder: AuthedRequestHandler = async (
       userId,
       action: 'cancel',
       entityType: 'WorkOrder',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(new Types.ObjectId(req.params.id)),
       before,
       after: saved.toObject(),
     });

--- a/backend/utils/ids.ts
+++ b/backend/utils/ids.ts
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Types } from 'mongoose';
+
+export function toEntityId(id: string | Types.ObjectId): string {
+  return id instanceof Types.ObjectId ? id.toString() : String(id);
+}
+


### PR DESCRIPTION
## Summary
- add `toEntityId` helper for consistent ID normalization
- wrap audit log `entityId` values with `toEntityId` across controllers

## Testing
- `npm run backend:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a8621fc83239544ed412d8309d0