### PR TITLE
Refactor notification controller to use sendResponse

### DIFF
--- a/backend/controllers/NotificationController.ts
+++ b/backend/controllers/NotificationController.ts
@@ -13,6 +13,7 @@ import type { ParamsDictionary } from 'express-serve-static-core';
 import { writeAuditLog } from '../utils/audit';
 import logger from '../utils/logger';
 import { enqueueEmailRetry } from '../utils/emailQueue';
+import { sendResponse } from '../utils/sendResponse';
 
 type IdParams = { id: string };
 
@@ -23,12 +24,12 @@ export const getAllNotifications: AuthedRequestHandler<
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const items = await Notification.find({ tenantId });
- 
-    res.json(items);
+
+    sendResponse(res, items);
     return;
   } catch (err) {
     next(err);
@@ -44,15 +45,15 @@ export const getNotificationById: AuthedRequestHandler<
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const item = await Notification.findOne({ _id: req.params.id, tenantId });
     if (!item) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json(item);
+    sendResponse(res, item);
     return;
   } catch (err) {
     next(err);
@@ -68,23 +69,19 @@ export const createNotification: AuthedRequestHandler<
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
-
     const { title, message, type, assetId, user, read } = req.body;
-    const notification: NotificationDocument = {
+    const saved = await Notification.create({
       title,
       message,
       type,
       tenantId: tenantId as unknown as Types.ObjectId,
       ...(assetId ? { assetId } : {}),
       ...(user ? { user } : {}),
-      read: read ?? false,
-      createdAt: new Date(),
-    } as NotificationDocument;
-
-    const saved = await Notification.create(notification);
+      ...(read !== undefined ? { read } : {}),
+    });
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     await writeAuditLog({
       tenantId,
@@ -128,7 +125,7 @@ export const createNotification: AuthedRequestHandler<
       }
     }
 
-    res.status(201).json(saved);
+    sendResponse(res, saved, null, 201);
     return;
   } catch (err) {
     next(err);
@@ -142,14 +139,14 @@ export const markNotificationRead: AuthedRequestHandler<
 > = async (req, res, next) => {
 
   if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
-    res.status(400).json({ message: 'Invalid ID' });
+    sendResponse(res, null, 'Invalid ID', 400);
     return;
   }
 
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const updated = await Notification.findOneAndUpdate(
@@ -158,7 +155,7 @@ export const markNotificationRead: AuthedRequestHandler<
       { new: true },
     );
     if (!updated) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
@@ -171,7 +168,7 @@ export const markNotificationRead: AuthedRequestHandler<
       before: null,
       after: updated.toObject(),
     });
-    res.json(updated);
+    sendResponse(res, updated);
     return;
   } catch (err) {
     next(err);
@@ -185,19 +182,19 @@ export const updateNotification: AuthedRequestHandler<
 > = async (req, res, next) => {
 
   if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
-    res.status(400).json({ message: 'Invalid ID' });
+    sendResponse(res, null, 'Invalid ID', 400);
     return;
   }
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const existing = await Notification.findOne({ _id: req.params.id, tenantId });
     if (!existing) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const updated = await Notification.findOneAndUpdate(
@@ -217,7 +214,7 @@ export const updateNotification: AuthedRequestHandler<
       before: existing.toObject(),
       after: updated?.toObject(),
     });
-    res.json(updated);
+    sendResponse(res, updated);
     return;
   } catch (err) {
     next(err);
@@ -231,19 +228,19 @@ export const deleteNotification: AuthedRequestHandler<
 > = async (req, res, next) => {
 
   if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
-    res.status(400).json({ message: 'Invalid ID' });
+    sendResponse(res, null, 'Invalid ID', 400);
     return;
   }
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const deleted = await Notification.findOneAndDelete({ _id: req.params.id, tenantId });
     if (!deleted) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     await writeAuditLog({
@@ -254,7 +251,7 @@ export const deleteNotification: AuthedRequestHandler<
       entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
     return;
   } catch (err) {
     next(err);

--- a/backend/tests/notificationRoutes.test.ts
+++ b/backend/tests/notificationRoutes.test.ts
@@ -86,29 +86,32 @@ describe('Notification Routes', () => {
     const res = await request(app)
       .post('/api/notifications')
       .set('Authorization', `Bearer ${tokenA}`)
-      .send({ message: 'hello' })
+      .send({ title: 'hi', message: 'hello', type: 'info' })
       .expect(201);
 
-    expect(res.body.message).toBe('hello');
-    expect(res.body.tenantId).toBe(tenantA.toString());
-    expect(io.emit).toHaveBeenCalledWith('notification', expect.objectContaining({ _id: res.body._id }));
+    expect(res.body.data.message).toBe('hello');
+    expect(res.body.data.tenantId).toBe(tenantA.toString());
+    expect(io.emit).toHaveBeenCalledWith(
+      'notification',
+      expect.objectContaining({ _id: res.body.data._id }),
+    );
   });
 
   it('retrieves notifications scoped to tenant', async () => {
-    await Notification.create({ tenantId: tenantA, user: userA._id, message: 'A1' });
-    await Notification.create({ tenantId: tenantB, user: userB._id, message: 'B1' });
+    await Notification.create({ tenantId: tenantA, user: userA._id, message: 'A1', title: 't1', type: 'info' });
+    await Notification.create({ tenantId: tenantB, user: userB._id, message: 'B1', title: 't2', type: 'info' });
 
     const res = await request(app)
       .get('/api/notifications')
       .set('Authorization', `Bearer ${tokenA}`)
       .expect(200);
 
-    expect(res.body.length).toBe(1);
-    expect(res.body[0].message).toBe('A1');
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].message).toBe('A1');
   });
 
   it('updates notification within tenant only', async () => {
-    const note = await Notification.create({ tenantId: tenantA, user: userA._id, message: 'A1' });
+    const note = await Notification.create({ tenantId: tenantA, user: userA._id, message: 'A1', title: 't1', type: 'info' });
 
     const res = await request(app)
       .put(`/api/notifications/${note._id}`)
@@ -116,7 +119,7 @@ describe('Notification Routes', () => {
       .send({ read: true })
       .expect(200);
 
-    expect(res.body.read).toBe(true);
+    expect(res.body.data.read).toBe(true);
 
     await request(app)
       .put(`/api/notifications/${note._id}`)


### PR DESCRIPTION
## Summary
- use sendResponse in NotificationController
- create notifications directly from validated request body
- adjust notification route tests for new response envelope

## Testing
- `npx --prefix backend vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a868ce48323a60ea2362d95b7b6