### PR TITLE
refactor: improve PM task auditing

### DIFF
--- a/backend/controllers/PMTaskController.ts
+++ b/backend/controllers/PMTaskController.ts
@@ -2,9 +2,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-import mongoose, { Types } from 'mongoose';
+import { Error as MongooseError, Types } from 'mongoose';
 import { validationResult } from 'express-validator';
-import PMTask from '../models/PMTask';
+import PMTask, { PMTaskDocument } from '../models/PMTask';
 import WorkOrder from '../models/WorkOrder';
 import Meter from '../models/Meter';
 import { nextCronOccurrenceWithin } from '../services/PMScheduler';
@@ -20,7 +20,7 @@ import type {
   PMTaskGenerateWOResponse,
 } from '../types/pmTask';
 import type { ParamsDictionary } from 'express-serve-static-core';
-import { writeAuditLog } from '../utils/audit';
+import { writeAuditLog, toEntityId } from '../utils/audit';
 
 export const getAllPMTasks: AuthedRequestHandler<ParamsDictionary, PMTaskListResponse> = async (
   req: PMTaskRequest,
@@ -34,6 +34,10 @@ export const getAllPMTasks: AuthedRequestHandler<ParamsDictionary, PMTaskListRes
     const tasks = await PMTask.find(filter);
     res.json(tasks);
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      res.status(400).json({ message: err.message });
+      return;
+    }
     next(err);
   }
 };
@@ -44,7 +48,7 @@ export const getPMTaskById: AuthedRequestHandler<PMTaskParams, PMTaskResponse> =
   next,
 ) => {
   try {
-    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+    if (!Types.ObjectId.isValid(req.params.id)) {
       res.status(400).json({ message: 'Invalid ID' });
       return;
     }
@@ -61,6 +65,10 @@ export const getPMTaskById: AuthedRequestHandler<PMTaskParams, PMTaskResponse> =
 
     res.json(task);
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      res.status(400).json({ message: err.message });
+      return;
+    }
     next(err);
   }
 };
@@ -80,18 +88,22 @@ export const createPMTask: AuthedRequestHandler<ParamsDictionary, PMTaskResponse
       return;
     }
     const payload = { ...req.body, tenantId, siteId: req.siteId };
-    const task = await PMTask.create(payload);
+    const task: PMTaskDocument = await PMTask.create(payload);
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     await writeAuditLog({
       tenantId,
       userId,
       action: 'create',
       entityType: 'PMTask',
-      entityId: task._id,
+      entityId: toEntityId(task._id),
       after: task.toObject(),
     });
     res.status(201).json(task);
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      res.status(400).json({ message: err.message });
+      return;
+    }
     next(err);
   }
 };
@@ -105,7 +117,7 @@ export const updatePMTask: AuthedRequestHandler<PMTaskParams, PMTaskResponse | n
     const tenantId = req.tenantId;
     if (!tenantId)
       return res.status(400).json({ message: 'Tenant ID required' });
-    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+    if (!Types.ObjectId.isValid(req.params.id)) {
       res.status(400).json({ message: 'Invalid ID' });
       return;
     }
@@ -132,12 +144,16 @@ export const updatePMTask: AuthedRequestHandler<PMTaskParams, PMTaskResponse | n
       userId,
       action: 'update',
       entityType: 'PMTask',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(task!._id),
       before: existing.toObject(),
       after: task?.toObject(),
     });
     res.json(task);
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      res.status(400).json({ message: err.message });
+      return;
+    }
     next(err);
   }
 };
@@ -151,7 +167,7 @@ export const deletePMTask: AuthedRequestHandler<PMTaskParams, PMTaskDeleteRespon
     const tenantId = req.tenantId;
     if (!tenantId)
       return res.status(400).json({ message: 'Tenant ID required' });
-    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+    if (!Types.ObjectId.isValid(req.params.id)) {
       res.status(400).json({ message: 'Invalid ID' });
       return;
     }
@@ -171,11 +187,15 @@ export const deletePMTask: AuthedRequestHandler<PMTaskParams, PMTaskDeleteRespon
       userId,
       action: 'delete',
       entityType: 'PMTask',
-      entityId: new Types.ObjectId(req.params.id),
+      entityId: toEntityId(task._id),
       before: task.toObject(),
     });
     res.json({ message: 'Deleted successfully' });
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      res.status(400).json({ message: err.message });
+      return;
+    }
     next(err);
   }
 };
@@ -237,6 +257,10 @@ export const generatePMWorkOrders: AuthedRequestHandler<ParamsDictionary, PMTask
     }
     res.json({ generated: count });
   } catch (err) {
+    if (err instanceof MongooseError.ValidationError) {
+      res.status(400).json({ message: err.message });
+      return;
+    }
     next(err);
   }
 };

--- a/backend/models/PMTask.ts
+++ b/backend/models/PMTask.ts
@@ -11,7 +11,7 @@ interface Rule {
   threshold?: number;
 }
 
-export interface PmTaskDocument extends Document {
+export interface PMTaskDocument extends Document {
   title: string;
   tenantId: Schema.Types.ObjectId;
   notes?: string;
@@ -22,7 +22,7 @@ export interface PmTaskDocument extends Document {
   active: boolean;
 }
 
-const PmTaskSchema = new Schema<PmTaskDocument>(
+const PmTaskSchema = new Schema<PMTaskDocument>(
   {
     title: { type: String, required: true },
     tenantId: { type: Schema.Types.ObjectId, ref: 'Tenant', required: true, index: true },
@@ -45,4 +45,4 @@ const PmTaskSchema = new Schema<PmTaskDocument>(
   { timestamps: true }
 );
 
-export default mongoose.model<PmTaskDocument>('PmTask', PmTaskSchema);
+export default mongoose.model<PMTaskDocument>('PmTask', PmTaskSchema);

--- a/backend/types/pmTask.ts
+++ b/backend/types/pmTask.ts
@@ -5,7 +5,7 @@
 import type { ParamsDictionary } from 'express-serve-static-core';
 import type { UpdateQuery } from 'mongoose';
 import type { AuthedRequest } from './http';
-import type { PmTaskDocument } from '../models/PMTask';
+import type { PMTaskDocument } from '../models/PMTask';
 
 export interface PMTaskRequest<P extends ParamsDictionary = ParamsDictionary, ReqBody = unknown>
   extends AuthedRequest<P, unknown, ReqBody> {
@@ -18,9 +18,9 @@ export interface PMTaskParams {
   id: string;
 }
 
-export type PMTaskListResponse = PmTaskDocument[];
-export type PMTaskResponse = PmTaskDocument;
+export type PMTaskListResponse = PMTaskDocument[];
+export type PMTaskResponse = PMTaskDocument;
 export type PMTaskDeleteResponse = { message: string };
 export type PMTaskGenerateWOResponse = { generated: number };
-export type PMTaskCreateBody = Partial<PmTaskDocument>;
-export type PMTaskUpdateBody = UpdateQuery<PmTaskDocument>;
+export type PMTaskCreateBody = Partial<PMTaskDocument>;
+export type PMTaskUpdateBody = UpdateQuery<PMTaskDocument>;

--- a/backend/utils/audit.ts
+++ b/backend/utils/audit.ts
@@ -20,6 +20,9 @@ interface AuditPayload {
   after?: AuditVal;
 }
 
+export const toEntityId = (id: string | Types.ObjectId): Types.ObjectId =>
+  typeof id === 'string' ? new Types.ObjectId(id) : id;
+
 export async function writeAuditLog({
   tenantId,
   userId,


### PR DESCRIPTION
## Summary
- rename `PmTaskDocument` to `PMTaskDocument` and expose helper to convert ids
- handle Mongoose validation errors in PM task controller
- use `toEntityId` when writing PM task audit logs

## Testing
- `npm --prefix backend test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a86fd348323848ddb8e7393bd00