### PR TITLE
fix: cast CSV stream response

### DIFF
--- a/backend/controllers/ReportsController.ts
+++ b/backend/controllers/ReportsController.ts
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+/// <reference types="node" />
+
 import PDFDocument from 'pdfkit';
 import { Parser as Json2csvParser, Transform as Json2csvTransform } from 'json2csv';
 import { Readable } from 'stream';
@@ -131,7 +133,9 @@ export const downloadReport: AuthedRequestHandler = async (req, res, next) => {
       const transform = new Json2csvTransform();
       res.setHeader('Content-Type', 'text/csv');
       res.setHeader('Content-Disposition', 'attachment; filename=report.csv');
-      Readable.from([stats]).pipe(transform).pipe(res);
+      Readable.from([stats]).pipe(transform).pipe(
+        res as unknown as NodeJS.WritableStream,
+      );
       return;
     }
 


### PR DESCRIPTION
## Summary
- reference NodeJS types for streaming responses
- cast Express response to NodeJS WritableStream for CSV output

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a8bdbc883239176b2ffa379a34e