### PR TITLE
refactor: share work order mappers

### DIFF
--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -27,6 +27,12 @@ import {
   cancelWorkOrderSchema,
   type WorkOrderComplete,
 } from '../src/schemas/workOrder';
+import {
+  mapAssignees,
+  mapPartsUsed,
+  mapChecklists,
+  mapSignatures,
+} from '../src/utils/workOrder';
 
 
 
@@ -69,61 +75,11 @@ interface CompleteWorkOrderBody extends WorkOrderComplete {
 function toWorkOrderUpdatePayload(doc: any): WorkOrderUpdatePayload {
   const plain = typeof doc.toObject === "function"
     ? doc.toObject({ getters: true, virtuals: false })
-
     : doc;
   return {
     ...plain,
     _id: (plain._id as Types.ObjectId | string)?.toString(),
   } as WorkOrderUpdatePayload;
-}
-
-type RawPart = {
-  partId: string;
-  quantity: number;
-  cost?: number;
-};
-
-type RawChecklist = {
-  description: string;
-  completed?: boolean;
-};
-
-type RawSignature = {
-  userId: string;
-  signedAt?: Date;
-};
-
-function mapPartsUsed(parts: RawPart[]) {
-  return parts.map((p) => ({
-    partId: new Types.ObjectId(p.partId),
-    qty: p.quantity,
-    cost: p.cost ?? 0,
-  }));
-}
-
-function mapAssignees(ids: string[]) {
-  return ids.map((id) => new Types.ObjectId(id));
-}
-
-function mapChecklists(items: RawChecklist[]) {
-  return items.map((c) => ({
-    text: c.description,
-    description: c.description,
-    done: Boolean(c.completed),
-    completed: Boolean(c.completed),
-  }));
-}
-
-function mapSignatures(items: RawSignature[]) {
-  return items.map((s) => {
-    const signed = s.signedAt ? new Date(s.signedAt) : new Date();
-    return {
-      by: new Types.ObjectId(s.userId),
-      userId: s.userId,
-      ts: signed,
-      signedAt: signed,
-    };
-  });
 }
 
 /**

--- a/backend/src/lib/audit.ts
+++ b/backend/src/lib/audit.ts
@@ -2,6 +2,7 @@ import type { Request, Response, NextFunction } from 'express';
 import type { Types } from 'mongoose';
 import AuditLog from '../../models/AuditLog';
 import logger from '../../utils/logger';
+import { toEntityId } from '../utils/toEntityId';
 
 export type AuditValue = unknown;
 
@@ -18,7 +19,7 @@ export async function auditAction(
   try {
     const tenantId = req.tenantId;
     const siteId = req.siteId;
-    const userId = (req.user as any)?._id || (req.user as any)?.id;
+    const userId = toEntityId((req.user as any)?._id || (req.user as any)?.id);
     if (!tenantId) return;
     await AuditLog.create({
       tenantId,
@@ -26,7 +27,7 @@ export async function auditAction(
       userId,
       action,
       entityType,
-      entityId: String(targetId),
+      entityId: toEntityId(targetId),
       before: before === undefined ? undefined : normalize(before),
       after: after === undefined ? undefined : normalize(after),
       ts: new Date(),

--- a/backend/src/utils/toEntityId.ts
+++ b/backend/src/utils/toEntityId.ts
@@ -1,0 +1,6 @@
+import { Types } from 'mongoose';
+
+export function toEntityId(id?: string | Types.ObjectId) {
+  if (!id) return undefined;
+  return typeof id === 'string' ? id : id.toString();
+}

--- a/backend/src/utils/workOrder.ts
+++ b/backend/src/utils/workOrder.ts
@@ -1,0 +1,50 @@
+import { Types } from 'mongoose';
+
+export type RawPart = {
+  partId: string;
+  quantity: number;
+  cost?: number;
+};
+
+export function mapPartsUsed(parts: RawPart[]) {
+  return parts.map((p) => ({
+    partId: new Types.ObjectId(p.partId),
+    qty: p.quantity,
+    cost: p.cost ?? 0,
+  }));
+}
+
+export function mapAssignees(ids: string[]) {
+  return ids.map((id) => new Types.ObjectId(id));
+}
+
+export type RawChecklist = {
+  description: string;
+  completed?: boolean;
+};
+
+export function mapChecklists(items: RawChecklist[]) {
+  return items.map((c) => ({
+    text: c.description,
+    description: c.description,
+    done: Boolean(c.completed),
+    completed: Boolean(c.completed),
+  }));
+}
+
+export type RawSignature = {
+  userId: string;
+  signedAt?: Date;
+};
+
+export function mapSignatures(items: RawSignature[]) {
+  return items.map((s) => {
+    const signed = s.signedAt ? new Date(s.signedAt) : new Date();
+    return {
+      by: new Types.ObjectId(s.userId),
+      userId: s.userId,
+      ts: signed,
+      signedAt: signed,
+    };
+  });
+}

--- a/backend/utils/audit.ts
+++ b/backend/utils/audit.ts
@@ -5,6 +5,7 @@
 import { Types } from 'mongoose';
 import AuditLog from '../models/AuditLog';
 import logger from './logger';
+import { toEntityId } from '../src/utils/toEntityId';
 
 type AuditVal = unknown;
 
@@ -33,10 +34,10 @@ export async function writeAuditLog({
     if (!tenantId) return;
     const payload = {
       tenantId,
-      userId,
+      userId: toEntityId(userId),
       action,
       entityType,
-      entityId: String(entityId),
+      entityId: toEntityId(entityId),
       before: before === undefined ? undefined : normalize(before),
       after: after === undefined ? undefined : normalize(after),
       ts: new Date(),


### PR DESCRIPTION
## Summary
- use shared work order mappers
- normalize audit identifiers

## Testing
- `npm --prefix backend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a8cec8883239199d1dd3d509aea