### PR TITLE
refactor: standardize controller responses

### DIFF
--- a/backend/controllers/AnalyticsController.ts
+++ b/backend/controllers/AnalyticsController.ts
@@ -7,12 +7,13 @@ import { getKPIs } from '../services/analytics';
 import { Parser as Json2csvParser } from 'json2csv';
 import PDFDocument from 'pdfkit';
 import { escapeXml } from '../utils/escapeXml';
+import { sendResponse } from '../utils/sendResponse';
 
  export const kpiJson = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
  
   try {
     const data = await getKPIs(req.tenantId!);
-    res.json(data);
+    sendResponse(res, data);
   } catch (err) {
     next(err);
   }
@@ -26,7 +27,7 @@ import { escapeXml } from '../utils/escapeXml';
     const csv = parser.parse([data]);
     res.header('Content-Type', 'text/csv');
     res.attachment('kpis.csv');
-    res.send(csv);
+    sendResponse(res, csv);
   } catch (err) {
     next(err);
   }
@@ -45,7 +46,7 @@ import { escapeXml } from '../utils/escapeXml';
     const xml = `<?xml version="1.0"?>\n<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet" xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"><Worksheet ss:Name="KPIs"><Table><Row><Cell><Data ss:Type="String">Metric</Data></Cell><Cell><Data ss:Type="String">Value</Data></Cell></Row>${rows}</Table></Worksheet></Workbook>`;
     res.header('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     res.attachment('kpis.xlsx');
-    res.send(xml);
+    sendResponse(res, xml);
   } catch (err) {
     next(err);
   }

--- a/backend/controllers/AuditController.ts
+++ b/backend/controllers/AuditController.ts
@@ -5,12 +5,13 @@
 import { FlattenMaps } from 'mongoose';
 import AuditLog, { AuditLogDocument } from '../models/AuditLog';
 import type { AuthedRequestHandler } from '../types/http';
+import { sendResponse } from '../utils/sendResponse';
 
 export const getAuditLogs: AuthedRequestHandler = async (req: { tenantId: any; query: { limit: any; entityType: any; entityId: any; userId: any; }; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): void; new(): any; }; }; json: (arg0: (FlattenMaps<AuditLogDocument> & Required<{ _id: FlattenMaps<unknown>; }> & { __v: number; })[]) => void; }, next: (arg0: unknown) => void) => {
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const limit = Math.min(parseInt(String(req.query.limit || '10'), 10), 100);
@@ -23,7 +24,7 @@ export const getAuditLogs: AuthedRequestHandler = async (req: { tenantId: any; q
       .sort({ ts: -1 })
       .limit(limit)
       .lean();
-    res.json(logs);
+    sendResponse(res, logs);
     return;
   } catch (err) {
     next(err);

--- a/backend/controllers/ConditionRuleController.ts
+++ b/backend/controllers/ConditionRuleController.ts
@@ -4,6 +4,7 @@
 
 import type { ParamsDictionary } from 'express-serve-static-core';
 import type { AuthedRequestHandler } from '../types/http';
+import { sendResponse } from '../utils/sendResponse';
 
 
 import ConditionRule from '../models/ConditionRule';
@@ -16,7 +17,7 @@ export const getAllConditionRules: AuthedRequestHandler<ParamsDictionary> = asyn
 ) => {
   try {
     const items = await ConditionRule.find({ tenantId: req.tenantId });
-    res.json(items);
+    sendResponse(res, items);
   } catch (err) {
     next(err);
   }
@@ -32,8 +33,8 @@ export const getConditionRuleById: AuthedRequestHandler<{ id: string }> = async 
       _id: req.params.id,
       tenantId: req.tenantId,
     });
-    if (!item) return res.status(404).json({ message: 'Not found' });
-    res.json(item);
+    if (!item) return sendResponse(res, null, 'Not found', 404);
+    sendResponse(res, item);
   } catch (err) {
     next(err);
   }
@@ -47,7 +48,7 @@ export const createConditionRule: AuthedRequestHandler<ParamsDictionary> = async
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const newItem = new ConditionRule({ ...req.body, tenantId });
     const saved = await newItem.save();
@@ -59,7 +60,7 @@ export const createConditionRule: AuthedRequestHandler<ParamsDictionary> = async
       entityId: saved._id,
       after: saved.toObject(),
     });
-    res.status(201).json(saved);
+    sendResponse(res, saved, null, 201);
   } catch (err) {
     next(err);
   }
@@ -73,10 +74,10 @@ export const updateConditionRule: AuthedRequestHandler<{ id: string }> = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const existing = await ConditionRule.findOne({ _id: req.params.id, tenantId });
-    if (!existing) return res.status(404).json({ message: 'Not found' });
+    if (!existing) return sendResponse(res, null, 'Not found', 404);
     const updated = await ConditionRule.findOneAndUpdate(
       { _id: req.params.id, tenantId },
       { ...req.body, tenantId },
@@ -91,7 +92,7 @@ export const updateConditionRule: AuthedRequestHandler<{ id: string }> = async (
       before: existing.toObject(),
       after: updated?.toObject(),
     });
-    res.json(updated);
+    sendResponse(res, updated);
   } catch (err) {
     next(err);
   }
@@ -105,13 +106,13 @@ export const deleteConditionRule: AuthedRequestHandler<{ id: string }> = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const deleted = await ConditionRule.findOneAndDelete({
       _id: req.params.id,
       tenantId,
     });
-    if (!deleted) return res.status(404).json({ message: 'Not found' });
+    if (!deleted) return sendResponse(res, null, 'Not found', 404);
     await writeAuditLog({
       tenantId,
       userId,
@@ -120,7 +121,7 @@ export const deleteConditionRule: AuthedRequestHandler<{ id: string }> = async (
       entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
   } catch (err) {
     next(err);
   }

--- a/backend/controllers/DashboardController.ts
+++ b/backend/controllers/DashboardController.ts
@@ -3,6 +3,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { sendResponse } from '../utils/sendResponse';
 
 import Asset from '../models/Asset';
 import WorkOrder from '../models/WorkOrder';
@@ -15,7 +16,7 @@ export const getAssetSummaries = async (_req: Request, res: Response, next: Next
     const summary = await Asset.aggregate([
       { $group: { _id: '$status', count: { $sum: 1 } } },
     ]);
-    res.json(summary);
+    sendResponse(res, summary);
   } catch (err) {
     next(err);
   }
@@ -26,7 +27,7 @@ export const getWorkOrderStatus = async (_req: Request, res: Response, next: Nex
     const summary = await WorkOrder.aggregate([
       { $group: { _id: '$status', count: { $sum: 1 } } },
     ]);
-    res.json(summary);
+    sendResponse(res, summary);
   } catch (err) {
     next(err);
   }
@@ -44,7 +45,7 @@ export const getUpcomingMaintenance = async (_req: Request, res: Response, next:
       return !!nextCronOccurrenceWithin(t.rule.cron, now, 7);
     });
 
-    res.json(upcoming);
+    sendResponse(res, upcoming);
   } catch (err) {
     next(err);
   }
@@ -56,7 +57,7 @@ export const getCriticalAlerts = async (_req: Request, res: Response, next: Next
       priority: 'critical',
       status: { $ne: 'completed' },
     });
-    res.json(alerts);
+    sendResponse(res, alerts);
   } catch (err) {
     next(err);
   }
@@ -67,7 +68,7 @@ export const getLowStockInventory = async (_req: Request, res: Response, next: N
     const items = await InventoryItem.find({
       $expr: { $lte: ['$quantity', '$reorderThreshold'] },
     }).populate('vendor');
-    res.json(items);
+    sendResponse(res, items);
   } catch (err) {
     next(err);
   }

--- a/backend/controllers/DepartmentController.ts
+++ b/backend/controllers/DepartmentController.ts
@@ -4,6 +4,7 @@
 
 import Department from '../models/Department';
 import type { Request, Response, NextFunction } from 'express';
+import { sendResponse } from '../utils/sendResponse';
 
 
 export const listDepartments = async (
@@ -19,7 +20,7 @@ export const listDepartments = async (
     if (q) filter.name = { $regex: new RegExp(q, 'i') };
 
     const items = await Department.find(filter).sort({ name: 1 });
-    res.json(items);
+    sendResponse(res, items);
     return;
   } catch (err) {
     next(err);

--- a/backend/controllers/GoodsReceiptController.ts
+++ b/backend/controllers/GoodsReceiptController.ts
@@ -3,6 +3,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { sendResponse } from '../utils/sendResponse';
 
 import GoodsReceipt from '../models/GoodsReceipt';
 import PurchaseOrder from '../models/PurchaseOrder';
@@ -22,12 +23,12 @@ export const createGoodsReceipt = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     const { purchaseOrder: poId, items } = req.body as any;
 
     const po = await PurchaseOrder.findById(poId);
     if (!po) {
-      res.status(404).json({ message: 'PO not found' });
+      sendResponse(res, null, 'PO not found', 404);
       return;
     }
 
@@ -91,7 +92,7 @@ export const createGoodsReceipt = async (
       }
     }
 
-    res.status(201).json(gr);
+    sendResponse(res, gr, null, 201);
     return;
   } catch (err) {
     next(err);

--- a/backend/controllers/ImportController.ts
+++ b/backend/controllers/ImportController.ts
@@ -6,12 +6,13 @@ import { parse } from 'csv-parse/sync';
 import Asset from '../models/Asset';
 import InventoryItem from '../models/InventoryItem';
 import type { AuthedRequestHandler } from '../types/http';
+import { sendResponse } from '../utils/sendResponse';
 
 export const importAssets: AuthedRequestHandler = async (req: { tenantId: any; siteId: any; }, res: { status: (arg0: number) => { (): any; new(): any; json: { (arg0: { message: string; }): void; new(): any; }; }; json: (arg0: { imported: number; }) => void; }, next: (arg0: unknown) => void) => {
   try {
     const file = (req as any).file;
     if (!file) {
-      res.status(400).json({ message: 'CSV file required' });
+      sendResponse(res, null, 'CSV file required', 400);
       return;
     }
     const records = parse(file.buffer, {
@@ -33,7 +34,7 @@ export const importAssets: AuthedRequestHandler = async (req: { tenantId: any; s
     }));
 
     const created = await Asset.insertMany(docs, { ordered: false });
-    res.json({ imported: created.length });
+    sendResponse(res, { imported: created.length });
     return;
   } catch (err) {
     next(err);
@@ -45,7 +46,7 @@ export const importParts: AuthedRequestHandler = async (req: { tenantId: any; si
   try {
     const file = (req as any).file;
     if (!file) {
-      res.status(400).json({ message: 'CSV file required' });
+      sendResponse(res, null, 'CSV file required', 400);
       return;
     }
 
@@ -70,7 +71,7 @@ export const importParts: AuthedRequestHandler = async (req: { tenantId: any; si
     }));
 
     const created = await InventoryItem.insertMany(docs, { ordered: false });
-    res.json({ imported: created.length });
+    sendResponse(res, { imported: created.length });
     return;
   } catch (err) {
     next(err);

--- a/backend/controllers/MeterController.ts
+++ b/backend/controllers/MeterController.ts
@@ -7,6 +7,7 @@ import Meter from '../models/Meter';
 import MeterReading from '../models/MeterReading';
 import { writeAuditLog } from '../utils/audit';
 import { Document, Types, UpdateQuery } from 'mongoose';
+import { sendResponse } from '../utils/sendResponse';
 
 
 export const getMeters: AuthedRequestHandler = async (req, res, next) => {
@@ -15,7 +16,7 @@ export const getMeters: AuthedRequestHandler = async (req, res, next) => {
     if (req.siteId) filter.siteId = req.siteId;
     if (req.query.asset) filter.asset = req.query.asset;
     const meters = await Meter.find(filter);
-    res.json(meters);
+    sendResponse(res, meters);
     return;
   } catch (err) {
     return next(err);
@@ -28,10 +29,10 @@ export const getMeterById: AuthedRequestHandler = async (req, res, next) => {
     if (req.siteId) filter.siteId = req.siteId;
     const meter = await Meter.findOne(filter);
     if (!meter) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json(meter);
+    sendResponse(res, meter);
     return;
   } catch (err) {
     return next(err);
@@ -41,7 +42,7 @@ export const getMeterById: AuthedRequestHandler = async (req, res, next) => {
 export const createMeter: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
-    if (!tenantId) return res.status(400).json({ message: 'Tenant ID required' });
+    if (!tenantId) return sendResponse(res, null, 'Tenant ID required', 400);
     const meter = await Meter.create({
       ...req.body,
       tenantId,
@@ -56,7 +57,7 @@ export const createMeter: AuthedRequestHandler = async (req, res, next) => {
       entityId: meter._id,
       after: meter.toObject(),
     });
-    res.status(201).json(meter);
+    sendResponse(res, meter, null, 201);
     return;
   } catch (err) {
     return next(err);
@@ -66,12 +67,12 @@ export const createMeter: AuthedRequestHandler = async (req, res, next) => {
 export const updateMeter: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
-    if (!tenantId) return res.status(400).json({ message: 'Tenant ID required' });
+    if (!tenantId) return sendResponse(res, null, 'Tenant ID required', 400);
     const filter: any = { _id: req.params.id, tenantId };
     if (req.siteId) filter.siteId = req.siteId;
     const existing = await Meter.findOne(filter);
     if (!existing) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const meter = await Meter.findOneAndUpdate(
@@ -89,7 +90,7 @@ export const updateMeter: AuthedRequestHandler = async (req, res, next) => {
       before: existing.toObject(),
       after: meter?.toObject(),
     });
-    res.json(meter);
+    sendResponse(res, meter);
     return;
   } catch (err) {
     return next(err);
@@ -99,12 +100,12 @@ export const updateMeter: AuthedRequestHandler = async (req, res, next) => {
 export const deleteMeter: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
-    if (!tenantId) return res.status(400).json({ message: 'Tenant ID required' });
+    if (!tenantId) return sendResponse(res, null, 'Tenant ID required', 400);
     const filter: any = { _id: req.params.id, tenantId };
     if (req.siteId) filter.siteId = req.siteId;
     const meter = await Meter.findOneAndDelete(filter);
     if (!meter) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
@@ -116,7 +117,7 @@ export const deleteMeter: AuthedRequestHandler = async (req, res, next) => {
       entityId: new Types.ObjectId(req.params.id),
       before: meter.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
     return;
   } catch (err) {
     return next(err);
@@ -126,12 +127,12 @@ export const deleteMeter: AuthedRequestHandler = async (req, res, next) => {
 export const addMeterReading: AuthedRequestHandler = async (req, res, next) => {
   try {
     const tenantId = req.tenantId;
-    if (!tenantId) return res.status(400).json({ message: 'Tenant ID required' });
+    if (!tenantId) return sendResponse(res, null, 'Tenant ID required', 400);
     const filter: any = { _id: req.params.id, tenantId };
     if (req.siteId) filter.siteId = req.siteId;
     const meter = await Meter.findOne(filter);
     if (!meter) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
 
@@ -152,7 +153,7 @@ export const addMeterReading: AuthedRequestHandler = async (req, res, next) => {
       entityId: meter._id,
       after: meter.toObject(),
     });
-    res.status(201).json(reading);
+    sendResponse(res, reading, null, 201);
     return;
   } catch (err) {
     return next(err);
@@ -165,7 +166,7 @@ export const getMeterReadings: AuthedRequestHandler = async (req, res, next) => 
     if (req.siteId) filter.siteId = req.siteId;
     const meter = await Meter.findOne(filter);
     if (!meter) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const readingFilter: any = { meter: meter._id, tenantId: req.tenantId };
@@ -173,7 +174,7 @@ export const getMeterReadings: AuthedRequestHandler = async (req, res, next) => 
     const readings = await MeterReading.find(readingFilter)
       .sort({ timestamp: -1 })
       .limit(100);
-    res.json(readings);
+    sendResponse(res, readings);
     return;
   } catch (err) {
     return next(err);

--- a/backend/controllers/NotificationController.ts
+++ b/backend/controllers/NotificationController.ts
@@ -6,6 +6,7 @@ import mongoose, { Types } from 'mongoose';
 import Notification, { NotificationDocument } from '../models/Notifications';
 import User from '../models/User';
 import nodemailer from 'nodemailer';
+import { sendResponse } from '../utils/sendResponse';
 
 import { assertEmail } from '../utils/assert';
 import type { AuthedRequestHandler } from '../types/http';
@@ -23,12 +24,12 @@ export const getAllNotifications: AuthedRequestHandler<
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const items = await Notification.find({ tenantId });
  
-    res.json(items);
+    sendResponse(res, items);
     return;
   } catch (err) {
     next(err);
@@ -44,15 +45,15 @@ export const getNotificationById: AuthedRequestHandler<
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const item = await Notification.findOne({ _id: req.params.id, tenantId });
     if (!item) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json(item);
+    sendResponse(res, item);
     return;
   } catch (err) {
     next(err);
@@ -68,7 +69,7 @@ export const createNotification: AuthedRequestHandler<
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
 
@@ -128,7 +129,7 @@ export const createNotification: AuthedRequestHandler<
       }
     }
 
-    res.status(201).json(saved);
+    sendResponse(res, saved, null, 201);
     return;
   } catch (err) {
     next(err);
@@ -142,14 +143,14 @@ export const markNotificationRead: AuthedRequestHandler<
 > = async (req, res, next) => {
 
   if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
-    res.status(400).json({ message: 'Invalid ID' });
+    sendResponse(res, null, 'Invalid ID', 400);
     return;
   }
 
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const updated = await Notification.findOneAndUpdate(
@@ -158,7 +159,7 @@ export const markNotificationRead: AuthedRequestHandler<
       { new: true },
     );
     if (!updated) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
@@ -171,7 +172,7 @@ export const markNotificationRead: AuthedRequestHandler<
       before: null,
       after: updated.toObject(),
     });
-    res.json(updated);
+    sendResponse(res, updated);
     return;
   } catch (err) {
     next(err);
@@ -185,19 +186,19 @@ export const updateNotification: AuthedRequestHandler<
 > = async (req, res, next) => {
 
   if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
-    res.status(400).json({ message: 'Invalid ID' });
+    sendResponse(res, null, 'Invalid ID', 400);
     return;
   }
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const existing = await Notification.findOne({ _id: req.params.id, tenantId });
     if (!existing) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const updated = await Notification.findOneAndUpdate(
@@ -217,7 +218,7 @@ export const updateNotification: AuthedRequestHandler<
       before: existing.toObject(),
       after: updated?.toObject(),
     });
-    res.json(updated);
+    sendResponse(res, updated);
     return;
   } catch (err) {
     next(err);
@@ -231,19 +232,19 @@ export const deleteNotification: AuthedRequestHandler<
 > = async (req, res, next) => {
 
   if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
-    res.status(400).json({ message: 'Invalid ID' });
+    sendResponse(res, null, 'Invalid ID', 400);
     return;
   }
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const deleted = await Notification.findOneAndDelete({ _id: req.params.id, tenantId });
     if (!deleted) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     await writeAuditLog({
@@ -254,7 +255,7 @@ export const deleteNotification: AuthedRequestHandler<
       entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
     return;
   } catch (err) {
     next(err);

--- a/backend/controllers/PMTaskController.ts
+++ b/backend/controllers/PMTaskController.ts
@@ -10,6 +10,7 @@ import Meter from '../models/Meter';
 import { nextCronOccurrenceWithin } from '../services/PMScheduler';
 import type { AuthedRequestHandler } from '../types/http';
 import type {
+import { sendResponse } from '../utils/sendResponse';
   PMTaskRequest,
   PMTaskParams,
   PMTaskListResponse,
@@ -32,7 +33,7 @@ export const getAllPMTasks: AuthedRequestHandler<ParamsDictionary, PMTaskListRes
     if (req.siteId) (filter as any).siteId = req.siteId;
 
     const tasks = await PMTask.find(filter);
-    res.json(tasks);
+    sendResponse(res, tasks);
   } catch (err) {
     next(err);
   }
@@ -45,7 +46,7 @@ export const getPMTaskById: AuthedRequestHandler<PMTaskParams, PMTaskResponse> =
 ) => {
   try {
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
-      res.status(400).json({ message: 'Invalid ID' });
+      sendResponse(res, null, 'Invalid ID', 400);
       return;
     }
 
@@ -55,11 +56,11 @@ export const getPMTaskById: AuthedRequestHandler<PMTaskParams, PMTaskResponse> =
     });
 
     if (!task) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
 
-    res.json(task);
+    sendResponse(res, task);
   } catch (err) {
     next(err);
   }
@@ -73,10 +74,10 @@ export const createPMTask: AuthedRequestHandler<ParamsDictionary, PMTaskResponse
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     const errors = validationResult(req as any);
     if (!errors.isEmpty()) {
-      res.status(400).json({ errors: errors.array() });
+      sendResponse(res, null, { errors: errors.array()  }, 400);
       return;
     }
     const payload = { ...req.body, tenantId, siteId: req.siteId };
@@ -90,7 +91,7 @@ export const createPMTask: AuthedRequestHandler<ParamsDictionary, PMTaskResponse
       entityId: task._id,
       after: task.toObject(),
     });
-    res.status(201).json(task);
+    sendResponse(res, task, null, 201);
   } catch (err) {
     next(err);
   }
@@ -104,21 +105,21 @@ export const updatePMTask: AuthedRequestHandler<PMTaskParams, PMTaskResponse | n
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
-      res.status(400).json({ message: 'Invalid ID' });
+      sendResponse(res, null, 'Invalid ID', 400);
       return;
     }
 
     const errors = validationResult(req as any);
     if (!errors.isEmpty()) {
-      res.status(400).json({ errors: errors.array() });
+      sendResponse(res, null, { errors: errors.array()  }, 400);
       return;
     }
 
     const existing = await PMTask.findOne({ _id: req.params.id, tenantId });
     if (!existing) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const task = await PMTask.findOneAndUpdate(
@@ -136,7 +137,7 @@ export const updatePMTask: AuthedRequestHandler<PMTaskParams, PMTaskResponse | n
       before: existing.toObject(),
       after: task?.toObject(),
     });
-    res.json(task);
+    sendResponse(res, task);
   } catch (err) {
     next(err);
   }
@@ -150,9 +151,9 @@ export const deletePMTask: AuthedRequestHandler<PMTaskParams, PMTaskDeleteRespon
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
-      res.status(400).json({ message: 'Invalid ID' });
+      sendResponse(res, null, 'Invalid ID', 400);
       return;
     }
 
@@ -162,7 +163,7 @@ export const deletePMTask: AuthedRequestHandler<PMTaskParams, PMTaskDeleteRespon
     });
 
     if (!task) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
@@ -174,7 +175,7 @@ export const deletePMTask: AuthedRequestHandler<PMTaskParams, PMTaskDeleteRespon
       entityId: new Types.ObjectId(req.params.id),
       before: task.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
   } catch (err) {
     next(err);
   }
@@ -235,7 +236,7 @@ export const generatePMWorkOrders: AuthedRequestHandler<ParamsDictionary, PMTask
         }
       }
     }
-    res.json({ generated: count });
+    sendResponse(res, { generated: count });
   } catch (err) {
     next(err);
   }

--- a/backend/controllers/PredictiveController.ts
+++ b/backend/controllers/PredictiveController.ts
@@ -3,6 +3,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { sendResponse } from '../utils/sendResponse';
 
 import predictiveService from '../utils/predictiveService';
 
@@ -14,11 +15,11 @@ export const getPredictions = async (
   try {
     const { tenantId } = req;
     if (!tenantId) {
-      res.status(400).json({ message: 'Missing tenantId' });
+      sendResponse(res, null, 'Missing tenantId', 400);
       return;
     }
     const results = await predictiveService.getPredictions(tenantId);
-    res.json(results);
+    sendResponse(res, results);
   } catch (err) {
     next(err);
   }
@@ -33,11 +34,11 @@ export const getTrend = async (
     const { assetId, metric } = req.params;
     const { tenantId } = req;
     if (!assetId || !metric || !tenantId) {
-      res.status(400).json({ message: 'Missing required parameters' });
+      sendResponse(res, null, 'Missing required parameters', 400);
       return;
     }
     const trend = await predictiveService.getPredictionTrend(assetId, metric, tenantId);
-    res.json(trend);
+    sendResponse(res, trend);
   } catch (err) {
     next(err);
   }

--- a/backend/controllers/PurchaseOrderController.ts
+++ b/backend/controllers/PurchaseOrderController.ts
@@ -4,6 +4,7 @@
 
 import { Request, Response, NextFunction } from 'express';
 import mongoose from 'mongoose';
+import { sendResponse } from '../utils/sendResponse';
 
 import PurchaseOrder from '../models/PurchaseOrder';
 import { writeAuditLog } from '../utils/audit';
@@ -18,7 +19,7 @@ export const createPurchaseOrder = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     const po = await PurchaseOrder.create({
       ...req.body,
       tenantId,
@@ -33,7 +34,7 @@ export const createPurchaseOrder = async (
       entityId,
       after: po.toObject(),
     });
-    res.status(201).json(po);
+    sendResponse(res, po, null, 201);
     return;
   } catch (err) {
     next(err);
@@ -49,16 +50,16 @@ export const getPurchaseOrder = async (
   try {
     const { id } = req.params;
     if (!isValidObjectId(id)) {
-      res.status(400).json({ message: 'Invalid id' });
+      sendResponse(res, null, 'Invalid id', 400);
       return;
     }
     const objectId = new Types.ObjectId(id);
     const po = await PurchaseOrder.findOne({ _id: objectId, tenantId: req.tenantId }).lean();
     if (!po) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json(po);
+    sendResponse(res, po);
     return;
   } catch (err) {
     next(err);
@@ -74,7 +75,7 @@ export const listVendorPurchaseOrders = async (
   try {
     const vendorId = req.vendorId;
     const pos = await PurchaseOrder.find({ vendor: vendorId }).lean();
-    res.json(pos);
+    sendResponse(res, pos);
     return;
   } catch (err) {
     next(err);
@@ -93,21 +94,21 @@ export const updateVendorPurchaseOrder = async (
     const { status } = req.body as { status: string };
     const allowed = ['acknowledged', 'shipped'];
     if (!allowed.includes(status)) {
-      res.status(400).json({ message: 'Invalid status' });
+      sendResponse(res, null, 'Invalid status', 400);
       return;
     }
     if (!isValidObjectId(id)) {
-      res.status(400).json({ message: 'Invalid id' });
+      sendResponse(res, null, 'Invalid id', 400);
       return;
     }
     const objectId = new Types.ObjectId(id);
     const po = await PurchaseOrder.findById(objectId);
     if (!po) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     if (po.vendor.toString() !== vendorId) {
-      res.status(403).json({ message: 'Forbidden' });
+      sendResponse(res, null, 'Forbidden', 403);
       return;
     }
     const before = po.toObject();
@@ -124,7 +125,7 @@ export const updateVendorPurchaseOrder = async (
       before,
       after: po.toObject(),
     });
-    res.json(po);
+    sendResponse(res, po);
     return;
   } catch (err) {
     next(err);

--- a/backend/controllers/ReportsController.ts
+++ b/backend/controllers/ReportsController.ts
@@ -12,6 +12,7 @@ import User from '../models/User';
 import TimeSheet from '../models/TimeSheet';
 import type { AuthedRequestHandler } from '../types/http';
 import { LABOR_RATE } from '../config/env';
+import { sendResponse } from '../utils/sendResponse';
  
 
 async function calculateStats(tenantId: string, role?: string) {
@@ -112,7 +113,7 @@ export const getAnalyticsReport: AuthedRequestHandler = async (req: { query: { r
     const role = typeof req.query.role === 'string' ? req.query.role : undefined;
     const tenantId = req.tenantId!;
     const stats = await calculateStats(tenantId, role);
-    res.json(stats);
+    sendResponse(res, stats);
     return;
   } catch (err) {
     return next(err);
@@ -175,7 +176,7 @@ export const getTrendData: AuthedRequestHandler = async (req: { tenantId: any; }
   try {
     const tenantId = req.tenantId!;
     const data = await aggregateTrends(tenantId);
-    res.json(data);
+    sendResponse(res, data);
     return;
   } catch (err) {
     return next(err);
@@ -194,11 +195,11 @@ export const exportTrendData: AuthedRequestHandler = async (req: { query: { form
       const csv = parser.parse(data);
       res.header('Content-Type', 'text/csv');
       res.attachment('trends.csv');
-      res.send(csv);
+      sendResponse(res, csv);
       return;
     }
 
-    res.json(data);
+    sendResponse(res, data);
     return;
   } catch (err) {
     return next(err);
@@ -282,7 +283,7 @@ export const getCostMetrics: AuthedRequestHandler = async (req: { tenantId: any;
   try {
     const tenantId = req.tenantId!;
     const data = await aggregateCosts(tenantId);
-    res.json(data);
+    sendResponse(res, data);
     return;
   } catch (err) {
     return next(err);
@@ -309,7 +310,7 @@ export const getDowntimeReport: AuthedRequestHandler = async (req: { tenantId: a
   try {
     const tenantId = req.tenantId!;
     const data = await aggregateDowntime(tenantId);
-    res.json(data);
+    sendResponse(res, data);
     return;
   } catch (err) {
     return next(err);
@@ -352,7 +353,7 @@ export const getPmCompliance: AuthedRequestHandler = async (req: { tenantId: any
   try {
     const tenantId = req.tenantId!;
     const data = await aggregatePmCompliance(tenantId);
-    res.json(data);
+    sendResponse(res, data);
     return;
   } catch (err) {
     return next(err);
@@ -393,7 +394,7 @@ export const getCostByAsset: AuthedRequestHandler = async (req: { tenantId: any;
   try {
     const tenantId = req.tenantId!;
     const data = await aggregateCostByAsset(tenantId);
-    res.json(data);
+    sendResponse(res, data);
     return;
   } catch (err) {
     return next(err);

--- a/backend/controllers/RoleController.ts
+++ b/backend/controllers/RoleController.ts
@@ -4,6 +4,7 @@
 
 import { Request, Response, NextFunction } from 'express';
 import mongoose from 'mongoose';
+import { sendResponse } from '../utils/sendResponse';
 
 import Role from '../models/Role';
 import { writeAuditLog } from '../utils/audit';
@@ -13,7 +14,7 @@ const { Types, isValidObjectId } = mongoose;
 export const getAllRoles = async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const roles = await Role.find();
-    res.json(roles);
+    sendResponse(res, roles);
   } catch (err) {
     next(err);
   }
@@ -23,14 +24,14 @@ export const getRoleById = async (req: Request, res: Response, next: NextFunctio
   try {
     const { id } = req.params;
     if (!isValidObjectId(id)) {
-      res.status(400).json({ message: 'Invalid id' });
+      sendResponse(res, null, 'Invalid id', 400);
       return;
     }
 
     const roleId = new Types.ObjectId(id);
     const role = await Role.findById(roleId);
-    if (!role) return res.status(404).json({ message: 'Not found' });
-    res.json(role);
+    if (!role) return sendResponse(res, null, 'Not found', 404);
+    sendResponse(res, role);
   } catch (err) {
     next(err);
   }
@@ -40,7 +41,7 @@ export const createRole = async (req: Request, res: Response, next: NextFunction
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
@@ -54,7 +55,7 @@ export const createRole = async (req: Request, res: Response, next: NextFunction
       entityId,
       after: role.toObject(),
     });
-    res.status(201).json(role);
+    sendResponse(res, role, null, 201);
   } catch (err) {
     next(err);
   }
@@ -64,20 +65,20 @@ export const updateRole = async (req: Request, res: Response, next: NextFunction
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
 
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const { id } = req.params;
     if (!isValidObjectId(id)) {
-      res.status(400).json({ message: 'Invalid id' });
+      sendResponse(res, null, 'Invalid id', 400);
       return;
     }
 
     const roleId = new Types.ObjectId(id);
     const existing = await Role.findById(roleId);
-    if (!existing) return res.status(404).json({ message: 'Not found' });
+    if (!existing) return sendResponse(res, null, 'Not found', 404);
     const role = await Role.findByIdAndUpdate(roleId, req.body, {
       new: true,
       runValidators: true,
@@ -92,7 +93,7 @@ export const updateRole = async (req: Request, res: Response, next: NextFunction
       before: existing.toObject(),
       after: role?.toObject(),
     });
-    res.json(role);
+    sendResponse(res, role);
   } catch (err) {
     next(err);
   }
@@ -102,20 +103,20 @@ export const deleteRole = async (req: Request, res: Response, next: NextFunction
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
 
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const { id } = req.params;
     if (!isValidObjectId(id)) {
-      res.status(400).json({ message: 'Invalid id' });
+      sendResponse(res, null, 'Invalid id', 400);
       return;
     }
 
     const roleId = new Types.ObjectId(id);
     const role = await Role.findByIdAndDelete(roleId);
-    if (!role) return res.status(404).json({ message: 'Not found' });
+    if (!role) return sendResponse(res, null, 'Not found', 404);
     const entityId = roleId;
     await writeAuditLog({
       tenantId,
@@ -125,7 +126,7 @@ export const deleteRole = async (req: Request, res: Response, next: NextFunction
       entityId,
       before: role.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
   } catch (err) {
     next(err);
   }

--- a/backend/controllers/ThemeController.ts
+++ b/backend/controllers/ThemeController.ts
@@ -5,6 +5,7 @@
 import type { AuthedRequestHandler } from '../types/http';
 import User from '../models/User';
 import { writeAuditLog } from '../utils/audit';
+import { sendResponse } from '../utils/sendResponse';
 
 export const getTheme: AuthedRequestHandler = async (req, res, next) => {
   try {
@@ -15,7 +16,7 @@ export const getTheme: AuthedRequestHandler = async (req, res, next) => {
       colorScheme?: string;
     };
 
-    res.json({ theme, colorScheme });
+    sendResponse(res, { theme, colorScheme });
     return;
   } catch (err) {
     return next(err);
@@ -28,10 +29,10 @@ export const updateTheme: AuthedRequestHandler = async (req, res, next) => {
     const { user } = req;
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
 
     if (!user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return sendResponse(res, null, 'Unauthorized', 401);
     }
 
     const updated = await User.findByIdAndUpdate(
@@ -41,7 +42,7 @@ export const updateTheme: AuthedRequestHandler = async (req, res, next) => {
     );
 
     if (!updated) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
 
@@ -55,7 +56,7 @@ export const updateTheme: AuthedRequestHandler = async (req, res, next) => {
       before: null,
       after: { theme: updated.theme, colorScheme: updated.colorScheme },
     });
-    res.json({ theme: updated.theme, colorScheme: updated.colorScheme });
+    sendResponse(res, { theme: updated.theme, colorScheme: updated.colorScheme });
     return;
   } catch (err) {
     return next(err);

--- a/backend/controllers/TimeSheetController.ts
+++ b/backend/controllers/TimeSheetController.ts
@@ -4,6 +4,7 @@
 
 import { Request, Response, NextFunction } from 'express';
 import { Types } from 'mongoose';
+import { sendResponse } from '../utils/sendResponse';
 
 import TimeSheet from '../models/TimeSheet';
 import { writeAuditLog } from '../utils/audit';
@@ -16,7 +17,7 @@ import { writeAuditLog } from '../utils/audit';
  
   try {
     const items = await TimeSheet.find();
-    res.json(items);
+    sendResponse(res, items);
     return;
   } catch (err) {
     next(err);
@@ -32,10 +33,10 @@ export const getTimeSheetById = async (
   try {
     const item = await TimeSheet.findById(req.params.id);
     if (!item) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json(item);
+    sendResponse(res, item);
     return;
   } catch (err) {
     next(err);
@@ -51,7 +52,7 @@ export const createTimeSheet = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
@@ -65,7 +66,7 @@ export const createTimeSheet = async (
       entityId: saved._id,
       after: saved.toObject(),
     });
-    res.status(201).json(saved);
+    sendResponse(res, saved, null, 201);
     return;
   } catch (err) {
     next(err);
@@ -81,13 +82,13 @@ export const updateTimeSheet = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const existing = await TimeSheet.findById(req.params.id);
     if (!existing) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const updated = await TimeSheet.findByIdAndUpdate(req.params.id, req.body, {
@@ -103,7 +104,7 @@ export const updateTimeSheet = async (
       before: existing.toObject(),
       after: updated?.toObject(),
     });
-    res.json(updated);
+    sendResponse(res, updated);
     return;
   } catch (err) {
     next(err);
@@ -119,13 +120,13 @@ export const deleteTimeSheet = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const deleted = await TimeSheet.findByIdAndDelete(req.params.id);
     if (!deleted) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     await writeAuditLog({
@@ -136,7 +137,7 @@ export const deleteTimeSheet = async (
       entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
     return;
   } catch (err) {
     next(err);

--- a/backend/controllers/UserController.ts
+++ b/backend/controllers/UserController.ts
@@ -7,6 +7,7 @@ import { filterFields } from '../utils/filterFields';
 import { Request, Response, NextFunction } from 'express';
 import { Types } from 'mongoose';
 import { writeAuditLog } from '../utils/audit';
+import { sendResponse } from '../utils/sendResponse';
 
 const userCreateFields = [
   'name',
@@ -38,11 +39,11 @@ export const getAllUsers = async (req: Request, res: Response, next: NextFunctio
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const items = await User.find({ tenantId }).select('-passwordHash');
-    res.json(items);
+    sendResponse(res, items);
     return;
   } catch (err) {
     next(err);
@@ -73,15 +74,15 @@ export const getUserById = async (req: Request, res: Response, next: NextFunctio
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const item = await User.findOne({ _id: req.params.id, tenantId }).select('-passwordHash');
     if (!item) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json(item);
+    sendResponse(res, item);
     return;
   } catch (err) {
     next(err);
@@ -110,7 +111,7 @@ export const createUser = async (req: Request, res: Response, next: NextFunction
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
@@ -126,7 +127,7 @@ export const createUser = async (req: Request, res: Response, next: NextFunction
       entityId: saved._id,
       after: safeUser,
     });
-    res.status(201).json(safeUser);
+    sendResponse(res, safeUser, null, 201);
     return;
   } catch (err) {
     next(err);
@@ -163,14 +164,14 @@ export const updateUser = async (req: Request, res: Response, next: NextFunction
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const update = filterFields(req.body, userUpdateFields);
     const existing = await User.findOne({ _id: req.params.id, tenantId }).select('-passwordHash');
     if (!existing) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const updated = await User.findOneAndUpdate(
@@ -190,7 +191,7 @@ export const updateUser = async (req: Request, res: Response, next: NextFunction
       before: existing.toObject(),
       after: updated?.toObject(),
     });
-    res.json(updated);
+    sendResponse(res, updated);
     return;
   } catch (err) {
     next(err);
@@ -221,13 +222,13 @@ export const deleteUser = async (req: Request, res: Response, next: NextFunction
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const deleted = await User.findOneAndDelete({ _id: req.params.id, tenantId });
     if (!deleted) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     await writeAuditLog({
@@ -238,7 +239,7 @@ export const deleteUser = async (req: Request, res: Response, next: NextFunction
       entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
     return;
   } catch (err) {
     next(err);
@@ -271,20 +272,20 @@ export const getUserTheme = async (req: Request, res: Response, next: NextFuncti
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
-      res.status(401).json({ message: 'Not authenticated' });
+      sendResponse(res, null, 'Not authenticated', 401);
       return;
     }
     if (req.params.id !== userId && !req.user?.roles?.includes('admin')) {
-      res.status(403).json({ message: 'Forbidden' });
+      sendResponse(res, null, 'Forbidden', 403);
       return;
     }
 
     const user = await User.findById(req.params.id).select('theme');
     if (!user) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json({ theme: user.theme ?? 'system' });
+    sendResponse(res, { theme: user.theme ?? 'system' });
     return;
   } catch (err) {
     next(err);
@@ -327,17 +328,17 @@ export const updateUserTheme = async (req: Request, res: Response, next: NextFun
   try {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
-      res.status(401).json({ message: 'Not authenticated' });
+      sendResponse(res, null, 'Not authenticated', 401);
       return;
     }
     if (req.params.id !== userId && !req.user?.roles?.includes('admin')) {
-      res.status(403).json({ message: 'Forbidden' });
+      sendResponse(res, null, 'Forbidden', 403);
       return;
     }
 
     const { theme } = req.body;
     if (!['light', 'dark', 'system'].includes(theme)) {
-      res.status(400).json({ message: 'Invalid theme' });
+      sendResponse(res, null, 'Invalid theme', 400);
       return;
     }
 
@@ -347,10 +348,10 @@ export const updateUserTheme = async (req: Request, res: Response, next: NextFun
       { new: true }
     ).select('theme');
     if (!user) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json({ theme: user.theme });
+    sendResponse(res, { theme: user.theme });
     return;
   } catch (err) {
     next(err);

--- a/backend/controllers/VendorController.ts
+++ b/backend/controllers/VendorController.ts
@@ -4,6 +4,7 @@
 
 import { Request, Response, NextFunction } from 'express';
 import { Types } from 'mongoose';
+import { sendResponse } from '../utils/sendResponse';
 
 import Vendor from '../models/Vendor';
 import { writeAuditLog } from '../utils/audit';
@@ -45,7 +46,7 @@ const validateVendorInput = (body: any) => {
  
   try {
     const items = await Vendor.find();
-    res.json(items);
+    sendResponse(res, items);
     return;
   } catch (err) {
     next(err);
@@ -61,10 +62,10 @@ export const getVendorById = async (
   try {
     const item = await Vendor.findById(req.params.id);
     if (!item) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json(item);
+    sendResponse(res, item);
     return;
   } catch (err) {
     next(err);
@@ -80,12 +81,12 @@ export const createVendor = async (
   try {
     const { data, error } = validateVendorInput(req.body);
     if (error) {
-      res.status(400).json({ message: error });
+      sendResponse(res, null, error , 400);
       return;
     }
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
@@ -99,7 +100,7 @@ export const createVendor = async (
       entityId: saved._id,
       after: saved.toObject(),
     });
-    res.status(201).json(saved);
+    sendResponse(res, saved, null, 201);
     return;
   } catch (err) {
     next(err);
@@ -115,18 +116,18 @@ export const updateVendor = async (
   try {
     const { data, error } = validateVendorInput(req.body);
     if (error) {
-      res.status(400).json({ message: error });
+      sendResponse(res, null, error , 400);
       return;
     }
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const existing = await Vendor.findById(req.params.id);
     if (!existing) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const updated = await Vendor.findByIdAndUpdate(req.params.id, data, {
@@ -142,7 +143,7 @@ export const updateVendor = async (
       before: existing.toObject(),
       after: updated?.toObject(),
     });
-    res.json(updated);
+    sendResponse(res, updated);
     return;
   } catch (err) {
     next(err);
@@ -158,13 +159,13 @@ export const deleteVendor = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const deleted = await Vendor.findByIdAndDelete(req.params.id);
     if (!deleted) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     await writeAuditLog({
@@ -175,7 +176,7 @@ export const deleteVendor = async (
       entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
     return;
   } catch (err) {
     next(err);

--- a/backend/controllers/VideoController.ts
+++ b/backend/controllers/VideoController.ts
@@ -4,6 +4,7 @@
 
 import { Request, Response, NextFunction } from 'express';
 import { Types } from 'mongoose';
+import { sendResponse } from '../utils/sendResponse';
 
 import Video from '../models/Video';
 import { writeAuditLog } from '../utils/audit';
@@ -11,7 +12,7 @@ import { writeAuditLog } from '../utils/audit';
 export const getAllVideos = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const items = await Video.find();
-    res.json(items);
+    sendResponse(res, items);
   } catch (err) {
     next(err);
   }
@@ -20,8 +21,8 @@ export const getAllVideos = async (req: Request, res: Response, next: NextFuncti
 export const getVideoById = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const item = await Video.findById(req.params.id);
-    if (!item) return res.status(404).json({ message: 'Not found' });
-    res.json(item);
+    if (!item) return sendResponse(res, null, 'Not found', 404);
+    sendResponse(res, item);
   } catch (err) {
     next(err);
   }
@@ -31,7 +32,7 @@ export const createVideo = async (req: Request, res: Response, next: NextFunctio
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const newItem = new Video({ ...req.body, tenantId });
     const saved = await newItem.save();
@@ -43,7 +44,7 @@ export const createVideo = async (req: Request, res: Response, next: NextFunctio
       entityId: saved._id,
       after: saved.toObject(),
     });
-    res.status(201).json(saved);
+    sendResponse(res, saved, null, 201);
   } catch (err) {
     next(err);
   }
@@ -53,10 +54,10 @@ export const updateVideo = async (req: Request, res: Response, next: NextFunctio
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const existing = await Video.findById(req.params.id);
-    if (!existing) return res.status(404).json({ message: 'Not found' });
+    if (!existing) return sendResponse(res, null, 'Not found', 404);
     const updated = await Video.findByIdAndUpdate(req.params.id, req.body, {
       new: true,
       runValidators: true,
@@ -70,7 +71,7 @@ export const updateVideo = async (req: Request, res: Response, next: NextFunctio
       before: existing.toObject(),
       after: updated?.toObject(),
     });
-    res.json(updated);
+    sendResponse(res, updated);
   } catch (err) {
     next(err);
   }
@@ -80,10 +81,10 @@ export const deleteVideo = async (req: Request, res: Response, next: NextFunctio
   try {
     const tenantId = req.tenantId;
     if (!tenantId)
-      return res.status(400).json({ message: 'Tenant ID required' });
+      return sendResponse(res, null, 'Tenant ID required', 400);
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const deleted = await Video.findByIdAndDelete(req.params.id);
-    if (!deleted) return res.status(404).json({ message: 'Not found' });
+    if (!deleted) return sendResponse(res, null, 'Not found', 404);
     await writeAuditLog({
       tenantId,
       userId,
@@ -92,7 +93,7 @@ export const deleteVideo = async (req: Request, res: Response, next: NextFunctio
       entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
   } catch (err) {
     next(err);
   }

--- a/backend/controllers/WebhookController.ts
+++ b/backend/controllers/WebhookController.ts
@@ -4,6 +4,7 @@
 
 import { Request, Response, NextFunction } from 'express';
 import logger from '../utils/logger';
+import { sendResponse } from '../utils/sendResponse';
 
 
 /**
@@ -18,5 +19,5 @@ export const handleWorkOrderHook = async (
   // In a real implementation the payload could be validated and used to
   // create or update work orders. For now we simply log it.
   logger.info('Webhook received:', req.body);
-  res.json({ status: 'received' });
+  sendResponse(res, { status: 'received' });
 };

--- a/backend/controllers/WorkHistoryController.ts
+++ b/backend/controllers/WorkHistoryController.ts
@@ -4,6 +4,7 @@
 
 import { Request, Response, NextFunction } from 'express';
 import { Types } from 'mongoose';
+import { sendResponse } from '../utils/sendResponse';
 
 import WorkHistory from '../models/WorkHistory';
 import { writeAuditLog } from '../utils/audit';
@@ -16,7 +17,7 @@ import { writeAuditLog } from '../utils/audit';
  
   try {
     const items = await WorkHistory.find();
-    res.json(items);
+    sendResponse(res, items);
     return;
   } catch (err) {
     next(err);
@@ -32,10 +33,10 @@ export const getWorkHistoryById = async (
   try {
     const item = await WorkHistory.findById(req.params.id);
     if (!item) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
-    res.json(item);
+    sendResponse(res, item);
     return;
   } catch (err) {
     next(err);
@@ -51,7 +52,7 @@ export const createWorkHistory = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
@@ -65,7 +66,7 @@ export const createWorkHistory = async (
       entityId: saved._id,
       after: saved.toObject(),
     });
-    res.status(201).json(saved);
+    sendResponse(res, saved, null, 201);
     return;
   } catch (err) {
     next(err);
@@ -81,13 +82,13 @@ export const updateWorkHistory = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const existing = await WorkHistory.findById(req.params.id);
     if (!existing) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     const updated = await WorkHistory.findByIdAndUpdate(req.params.id, req.body, {
@@ -103,7 +104,7 @@ export const updateWorkHistory = async (
       before: existing.toObject(),
       after: updated?.toObject(),
     });
-    res.json(updated);
+    sendResponse(res, updated);
     return;
   } catch (err) {
     next(err);
@@ -119,13 +120,13 @@ export const deleteWorkHistory = async (
   try {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     const userId = (req.user as any)?._id || (req.user as any)?.id;
     const deleted = await WorkHistory.findByIdAndDelete(req.params.id);
     if (!deleted) {
-      res.status(404).json({ message: 'Not found' });
+      sendResponse(res, null, 'Not found', 404);
       return;
     }
     await writeAuditLog({
@@ -136,7 +137,7 @@ export const deleteWorkHistory = async (
       entityId: new Types.ObjectId(req.params.id),
       before: deleted.toObject(),
     });
-    res.json({ message: 'Deleted successfully' });
+    sendResponse(res, { message: 'Deleted successfully' });
     return;
   } catch (err) {
     next(err);

--- a/backend/controllers/chat/utils.ts
+++ b/backend/controllers/chat/utils.ts
@@ -1,5 +1,6 @@
 import type { Response } from 'express';
 import type { AuthedRequest } from '../../types/http';
+import { sendResponse } from '../../utils/sendResponse';
 
 interface ResolveOptions {
   requireUser?: boolean;
@@ -18,7 +19,7 @@ export function resolveUserAndTenant(
   if (requireUser) {
     const userId = (req.user as any)?._id ?? req.user?.id;
     if (!userId) {
-      res.status(401).json({ message: 'Not authenticated' });
+      sendResponse(res, null, 'Not authenticated', 401);
       return;
     }
     if (!requireTenant) {
@@ -26,7 +27,7 @@ export function resolveUserAndTenant(
     }
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     return { userId, tenantId };
@@ -35,7 +36,7 @@ export function resolveUserAndTenant(
   if (requireTenant) {
     const tenantId = req.tenantId;
     if (!tenantId) {
-      res.status(400).json({ message: 'Tenant ID required' });
+      sendResponse(res, null, 'Tenant ID required', 400);
       return;
     }
     return { tenantId };


### PR DESCRIPTION
## Summary
- replace res.json/res.send with sendResponse across backend controllers
- return creation responses with sendResponse(..., null, 201)
- standardize error handling using sendResponse with messages and status codes

## Testing
- `npm test --prefix backend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a8ec0488323bf3e4b301001d199