### PR TITLE
fix: remove duplicate sendResponse import

### DIFF
--- a/backend/controllers/NotificationController.ts
+++ b/backend/controllers/NotificationController.ts
@@ -15,7 +15,6 @@ import { writeAuditLog } from '../utils/audit';
 import { toEntityId } from '../utils/ids';
 import logger from '../utils/logger';
 import { enqueueEmailRetry } from '../utils/emailQueue';
-import { sendResponse } from '../utils/sendResponse';
 
 type IdParams = { id: string };
 


### PR DESCRIPTION
## Summary
- remove duplicate sendResponse import in NotificationController

## Testing
- `npm --prefix backend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c68f6989988323a4610191d33e4209