### PR TITLE
chore: type test routes in server

### DIFF
--- a/backend/controllers/PMTaskController.ts
+++ b/backend/controllers/PMTaskController.ts
@@ -9,8 +9,8 @@ import WorkOrder from '../models/WorkOrder';
 import Meter from '../models/Meter';
 import { nextCronOccurrenceWithin } from '../services/PMScheduler';
 import type { AuthedRequestHandler } from '../types/http';
-import type {
 import { sendResponse } from '../utils/sendResponse';
+import type {
   PMTaskRequest,
   PMTaskParams,
   PMTaskListResponse,

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -142,10 +142,10 @@ app.get("/", (_req: Request, res: Response) => {
 app.use("/static/uploads", express.static(path.join(process.cwd(), "uploads")));
 
 if (env.NODE_ENV === "test") {
-  app.post("/test/sanitize", (req, res) => {
+  app.post("/test/sanitize", (req: Request, res: Response) => {
     res.json(req.body);
   });
-  app.get("/test/sanitize", (req, res) => {
+  app.get("/test/sanitize", (req: Request, res: Response) => {
     res.json(req.query);
   });
 }


### PR DESCRIPTION
## Summary
- type express Request/Response in test-only routes
- fix PMTaskController imports

## Testing
- `npm --prefix backend run typecheck` *(fails: Cannot find module 'express-validator', 'zod', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c68f6ec1908323a4d12f2dd50b3012