### PR TITLE
refactor backend controller typings and audit helper

### DIFF
--- a/backend/controllers/DocumentController.ts
+++ b/backend/controllers/DocumentController.ts
@@ -5,22 +5,16 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { randomUUID } from 'crypto';
-import type { Response as ExpressResponse } from 'express';
-import type { ParamsDictionary } from 'express-serve-static-core';
 
 import Document from '../models/Document';
 import type { AuthedRequestHandler } from '../types/http';
 import { sendResponse } from '../utils/sendResponse';
 import { writeAuditLog } from '../utils/audit';
-import { toObjectId } from '../utils/ids';
+import { toObjectId, toEntityId } from '../utils/ids';
 
 
 
-export const getAllDocuments: AuthedRequestHandler<ParamsDictionary> = async (
-  _req: any,
-  res: ExpressResponse,
-  next: (arg0: unknown) => void,
-) => {
+export const getAllDocuments: AuthedRequestHandler = async (_req, res, next) => {
 
   try {
     const items = await Document.find();
@@ -33,9 +27,9 @@ export const getAllDocuments: AuthedRequestHandler<ParamsDictionary> = async (
 };
 
 export const getDocumentById: AuthedRequestHandler<{ id: string }> = async (
-  req: { params: { id: any; }; },
-  res: ExpressResponse,
-  next: (arg0: unknown) => void,
+  req,
+  res,
+  next,
 ) => {
 
   try {
@@ -72,10 +66,10 @@ const validateFileName = (input: string): { base: string; ext: string } => {
   return { base, ext };
 };
 
-export const createDocument: AuthedRequestHandler<ParamsDictionary> = async (
-  req: { body: { base64?: string; url?: string; name?: string; }; tenantId: any; user: any; },
-  res: ExpressResponse,
-  next: (arg0: unknown) => void,
+export const createDocument: AuthedRequestHandler = async (
+  req,
+  res,
+  next,
 ) => {
 
   try {
@@ -147,7 +141,7 @@ export const createDocument: AuthedRequestHandler<ParamsDictionary> = async (
 
 export const updateDocument: AuthedRequestHandler<{ id: string }> = async (
   req,
-  res: ExpressResponse,
+  res,
   next,
 ) => {
 
@@ -233,7 +227,7 @@ export const updateDocument: AuthedRequestHandler<{ id: string }> = async (
 
 export const deleteDocument: AuthedRequestHandler<{ id: string }> = async (
   req,
-  res: ExpressResponse,
+  res,
   next,
 ) => {
 

--- a/backend/controllers/MeterController.ts
+++ b/backend/controllers/MeterController.ts
@@ -7,7 +7,7 @@ import Meter from '../models/Meter';
 import MeterReading from '../models/MeterReading';
 import { writeAuditLog } from '../utils/audit';
 import { toEntityId } from '../utils/ids';
-import { Document, Types, UpdateQuery } from 'mongoose';
+import { Types, UpdateQuery, Error as MongooseError } from 'mongoose';
 import { sendResponse } from '../utils/sendResponse';
 
 

--- a/backend/utils/audit.ts
+++ b/backend/utils/audit.ts
@@ -5,7 +5,7 @@
 import { Types } from 'mongoose';
 import AuditLog from '../models/AuditLog';
 import logger from './logger';
-import { toEntityId } from '../src/utils/toEntityId';
+import { toEntityId } from './ids';
 
 type AuditVal = unknown;
 
@@ -20,9 +20,6 @@ interface AuditPayload {
   before?: AuditVal;
   after?: AuditVal;
 }
-
-export const toEntityId = (id: string | Types.ObjectId): Types.ObjectId =>
-  typeof id === 'string' ? new Types.ObjectId(id) : id;
 
 export async function writeAuditLog({
   tenantId,


### PR DESCRIPTION
## Summary
- refine DocumentController type usage and import utilities
- import MongooseError in MeterController
- simplify audit utility and reuse shared toEntityId

## Testing
- `npm --prefix backend run typecheck` *(fails: Cannot find module 'express' or its type declarations)*
- `npm --prefix backend test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6afdcfe9483239807fb051dd508ad