### PR TITLE
refactor: narrow Axios errors in useSummary

### DIFF
--- a/frontend/src/hooks/useSummaryData.ts
+++ b/frontend/src/hooks/useSummaryData.ts
@@ -3,6 +3,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { AxiosError } from 'axios';
 import http from '@/lib/http';
 
 type CacheEntry<T> = { promise?: Promise<T | undefined>; data?: T; ts?: number };
@@ -42,9 +43,9 @@ export function useSummary<T = unknown>(
           setTick((t) => t + 1);
           return c.data;
         })
-        .catch(async (err) => {
+        .catch(async (err: AxiosError | unknown) => {
           c.promise = undefined;
-          if (err?.response?.status === 429) {
+          if (err instanceof AxiosError && err.response?.status === 429) {
             await new Promise((r) => setTimeout(r, backoffRef.current));
             backoffRef.current = Math.min(backoffRef.current * 2, 30_000);
           }


### PR DESCRIPTION
## Summary
- refine error handling in `useSummaryData` by typing Axios errors and narrowing before checking responses

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c091b7d483239519cc8e7ec62636