### PR TITLE
refactor: allow undefined work order fields

### DIFF
--- a/backend/src/utils/workOrder.ts
+++ b/backend/src/utils/workOrder.ts
@@ -20,26 +20,27 @@ export function mapAssignees(ids: string[]) {
 
 export type RawChecklist = {
   description: string;
-  completed?: boolean;
+  completed?: boolean | undefined;
 };
 
 export function mapChecklists(items: RawChecklist[]) {
   return items.map((c) => ({
     text: c.description,
     description: c.description,
-    done: Boolean(c.completed),
-    completed: Boolean(c.completed),
+    done: c.completed ?? false,
+    completed: c.completed ?? false,
   }));
 }
 
 export type RawSignature = {
   userId: string;
-  signedAt?: Date;
+  signedAt?: Date | undefined;
 };
 
 export function mapSignatures(items: RawSignature[]) {
   return items.map((s) => {
-    const signed = s.signedAt ? new Date(s.signedAt) : new Date();
+    const signed =
+      s.signedAt === undefined ? new Date() : new Date(s.signedAt);
     return {
       by: new Types.ObjectId(s.userId),
       userId: s.userId,


### PR DESCRIPTION
## Summary
- allow explicit `undefined` on work order checklist and signature fields
- default checklist completion and signature date when undefined

## Testing
- `npx --prefix backend vitest run` *(fails: 403 Forbidden from registry)*
- `npm --prefix backend run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cafd15fc8323b99f799b318e551d