### PR TITLE
fix: use plain arrays in UpdateWorkOrderBody

### DIFF
--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -27,12 +27,16 @@ import {
   completeWorkOrderSchema,
   cancelWorkOrderSchema,
   type WorkOrderComplete,
+  type WorkOrderUpdate,
 } from '../src/schemas/workOrder';
 import {
   mapAssignees,
   mapPartsUsed,
   mapChecklists,
   mapSignatures,
+  type RawPart,
+  type RawChecklist,
+  type RawSignature,
 } from '../src/utils/workOrder';
 
 
@@ -71,6 +75,12 @@ const workOrderUpdateFields = [...workOrderCreateFields];
 interface CompleteWorkOrderBody extends WorkOrderComplete {
   photos?: string[];
   failureCode?: string;
+}
+
+interface UpdateWorkOrderBody extends WorkOrderUpdate {
+  partsUsed?: RawPart[];
+  checklists?: RawChecklist[];
+  signatures?: RawSignature[];
 }
 
 function toWorkOrderUpdatePayload(doc: any): WorkOrderUpdatePayload {


### PR DESCRIPTION
## Summary
- define UpdateWorkOrderBody so partsUsed, checklists, and signatures are typed as plain arrays
- import raw item types and WorkOrderUpdate to support new body shape

## Testing
- `npm --prefix backend test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cafd375c8323ac543ac4f1b70258