### PR TITLE
feat: add work order document typing

### DIFF
--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -6,7 +6,7 @@ import type { ParamsDictionary } from 'express-serve-static-core';
 import type { Response, NextFunction } from 'express';
 import type { AuthedRequest, AuthedRequestHandler } from '../types/http';
 
-import WorkOrder from '../models/WorkOrder';
+import WorkOrder, { WorkOrderDocument } from '../models/WorkOrder';
 import { emitWorkOrderUpdate } from '../server';
 import notifyUser from '../utils/notify';
 import { AIAssistResult, getWorkOrderAssistance } from '../services/aiCopilot';
@@ -72,6 +72,29 @@ interface CompleteWorkOrderBody extends WorkOrderComplete {
   photos?: string[];
   failureCode?: string;
 }
+
+type UpdateWorkOrderBody = Partial<
+  Omit<
+    WorkOrderInput,
+    | 'assetId'
+    | 'partsUsed'
+    | 'checklists'
+    | 'signatures'
+    | 'pmTask'
+    | 'department'
+    | 'line'
+    | 'station'
+  >
+& {
+  assetId?: Types.ObjectId;
+  partsUsed?: { partId: Types.ObjectId; qty: number; cost: number }[];
+  checklists?: { text: string; done: boolean }[];
+  signatures?: { by: Types.ObjectId; ts: Date }[];
+  pmTask?: Types.ObjectId;
+  department?: Types.ObjectId;
+  line?: Types.ObjectId;
+  station?: Types.ObjectId;
+};
 
 function toWorkOrderUpdatePayload(doc: any): WorkOrderUpdatePayload {
   const plain = typeof doc.toObject === "function"

--- a/backend/models/WorkOrder.ts
+++ b/backend/models/WorkOrder.ts
@@ -2,12 +2,47 @@
  * SPDX-License-Identifier: MIT
  */
 
-import mongoose from 'mongoose';
+import mongoose, { Schema, Document, Model, Types } from 'mongoose';
 
-const workOrderSchema = new mongoose.Schema(
+export interface WorkOrderDocument extends Document {
+  _id: Types.ObjectId;
+  title: string;
+  assetId?: Types.ObjectId;
+  description?: string;
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  status: 'requested' | 'assigned' | 'in_progress' | 'completed' | 'cancelled';
+  approvalStatus: 'not-required' | 'pending' | 'approved' | 'rejected';
+  approvalRequestedBy?: Types.ObjectId;
+  approvedBy?: Types.ObjectId;
+  assignedTo?: Types.ObjectId;
+  assignees: Types.ObjectId[];
+  checklists: { text: string; done: boolean }[];
+  partsUsed: { partId: Types.ObjectId; qty: number; cost: number }[];
+  signatures: { by: Types.ObjectId; ts: Date }[];
+  timeSpentMin?: number;
+  photos: string[];
+  failureCode?: string;
+
+  /** Optional relationships */
+  pmTask?: Types.ObjectId;
+  department?: Types.ObjectId;
+  line?: Types.ObjectId;
+  station?: Types.ObjectId;
+
+  teamMemberName?: string;
+  importance?: 'low' | 'medium' | 'high' | 'severe';
+  tenantId: Types.ObjectId;
+
+  dueDate?: Date;
+  completedAt?: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const workOrderSchema = new Schema<WorkOrderDocument>(
   {
     title: { type: String, required: true },
-    assetId: { type: mongoose.Schema.Types.ObjectId, ref: 'Asset', index: true },
+    assetId: { type: Schema.Types.ObjectId, ref: 'Asset', index: true },
     description: String,
     priority: {
       type: String,
@@ -25,14 +60,14 @@ const workOrderSchema = new mongoose.Schema(
       enum: ['not-required', 'pending', 'approved', 'rejected'],
       default: 'not-required',
     },
-    approvalRequestedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-    approvedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-    assignedTo: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-    assignees: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+    approvalRequestedBy: { type: Schema.Types.ObjectId, ref: 'User' },
+    approvedBy: { type: Schema.Types.ObjectId, ref: 'User' },
+    assignedTo: { type: Schema.Types.ObjectId, ref: 'User' },
+    assignees: [{ type: Schema.Types.ObjectId, ref: 'User' }],
     checklists: [{ text: String, done: { type: Boolean, default: false } }],
     partsUsed: [
       {
-        partId: { type: mongoose.Schema.Types.ObjectId, ref: 'InventoryItem' },
+        partId: { type: Schema.Types.ObjectId, ref: 'InventoryItem' },
         qty: { type: Number, default: 1 },
         cost: { type: Number, default: 0 },
 
@@ -40,7 +75,7 @@ const workOrderSchema = new mongoose.Schema(
     ],
     signatures: [
       {
-        by: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+        by: { type: Schema.Types.ObjectId, ref: 'User' },
         ts: { type: Date, default: Date.now },
 
       },
@@ -50,10 +85,10 @@ const workOrderSchema = new mongoose.Schema(
     failureCode: String,
 
     /** Optional relationships */
-    pmTask: { type: mongoose.Schema.Types.ObjectId, ref: 'PMTask' },
-    department: { type: mongoose.Schema.Types.ObjectId, ref: 'Department' },
-    line: { type: mongoose.Schema.Types.ObjectId, ref: 'Line' },
-    station: { type: mongoose.Schema.Types.ObjectId, ref: 'Station' },
+    pmTask: { type: Schema.Types.ObjectId, ref: 'PMTask' },
+    department: { type: Schema.Types.ObjectId, ref: 'Department' },
+    line: { type: Schema.Types.ObjectId, ref: 'Line' },
+    station: { type: Schema.Types.ObjectId, ref: 'Station' },
 
     teamMemberName: String,
     importance: {
@@ -61,7 +96,7 @@ const workOrderSchema = new mongoose.Schema(
       enum: ['low', 'medium', 'high', 'severe'],
     },
 
-    tenantId: { type: mongoose.Schema.Types.ObjectId, required: true, index: true },
+    tenantId: { type: Schema.Types.ObjectId, required: true, index: true },
 
     dueDate: { type: Date },
     completedAt: Date,
@@ -69,5 +104,7 @@ const workOrderSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-export default mongoose.model('WorkOrder', workOrderSchema);
+const WorkOrder: Model<WorkOrderDocument> = mongoose.model<WorkOrderDocument>('WorkOrder', workOrderSchema);
+
+export default WorkOrder;
 


### PR DESCRIPTION
## Summary
- export WorkOrderDocument interface in model
- import WorkOrderDocument in controller
- define UpdateWorkOrderBody with ObjectId relation fields

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cafdb1c08323b1dbed0e61010e8f