### PR TITLE
Add safety permit management backend and UI

### DIFF
--- a/backend/controllers/PermitController.ts
+++ b/backend/controllers/PermitController.ts
@@ -1,0 +1,648 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { ParamsDictionary } from 'express-serve-static-core';
+import type { Response, NextFunction } from 'express';
+import { Types } from 'mongoose';
+
+import Permit, {
+  type PermitDocument,
+  type PermitApprovalStep,
+} from '../models/Permit';
+import SafetyIncident from '../models/SafetyIncident';
+import WorkOrder from '../models/WorkOrder';
+import { sendResponse } from '../utils/sendResponse';
+import { writeAuditLog } from '../utils/audit';
+import { toEntityId } from '../utils/ids';
+import notifyUser from '../utils/notify';
+import type { AuthedRequest, AuthedRequestHandler } from '../types/http';
+import {
+  permitCreateSchema,
+  permitUpdateSchema,
+  permitDecisionSchema,
+  permitIsolationSchema,
+  permitIncidentSchema,
+} from '../src/schemas/permit';
+
+const toObjectId = (value: Types.ObjectId | string): Types.ObjectId =>
+  value instanceof Types.ObjectId ? value : new Types.ObjectId(value);
+
+function getActiveStep(permit: PermitDocument): PermitApprovalStep | undefined {
+  return permit.approvalChain.find((step) => step.status === 'pending');
+}
+
+function initializeApprovalChain(chain: PermitApprovalStep[] = []): PermitApprovalStep[] {
+  return chain
+    .map((step, index) => ({
+      ...step,
+      sequence: index,
+      status: index === 0 ? 'pending' : 'blocked',
+      escalateAt:
+        step.escalateAfterHours && index === 0
+          ? new Date(Date.now() + step.escalateAfterHours * 60 * 60 * 1000)
+          : undefined,
+    }))
+    .map((step) => ({
+      ...step,
+      escalateAt: step.escalateAt ?? null,
+    }));
+}
+
+async function processEscalations(tenantId: string): Promise<void> {
+  const now = new Date();
+  const permits = await Permit.find({
+    tenantId,
+    status: { $in: ['pending', 'escalated'] },
+    'approvalChain.status': 'pending',
+    'approvalChain.escalateAt': { $lte: now },
+  });
+
+  await Promise.all(
+    permits.map(async (permit) => {
+      const active = getActiveStep(permit);
+      if (!active || !active.escalateAt || active.escalateAt > now) return;
+      active.status = 'escalated';
+      permit.status = 'escalated';
+      permit.history.push({
+        action: 'escalated',
+        at: new Date(),
+        notes: `Escalated approval step for role ${active.role}`,
+      });
+      await permit.save();
+      await Promise.all(
+        permit.watchers.map((watcher) =>
+          notifyUser(toObjectId(watcher), `Permit ${permit.permitNumber} was escalated`),
+        ),
+      );
+    }),
+  );
+}
+
+function ensureTenant(req: AuthedRequest, res: Response): string | null {
+  const tenantId = req.tenantId;
+  if (!tenantId) {
+    sendResponse(res, null, 'Tenant ID required', 400);
+    return null;
+  }
+  return tenantId;
+}
+
+export const listPermits: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    await processEscalations(tenantId);
+    const query: Record<string, unknown> = { tenantId };
+    if (req.query.status) query.status = req.query.status;
+    if (req.query.type) query.type = req.query.type;
+    const permits = await Permit.find(query).sort({ updatedAt: -1 });
+    sendResponse(res, permits);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getPermit: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const permit = await Permit.findOne({ _id: req.params.id, tenantId });
+    if (!permit) {
+      sendResponse(res, null, 'Not found', 404);
+      return;
+    }
+    sendResponse(res, permit);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createPermit: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const parsed = permitCreateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendResponse(res, null, parsed.error.flatten(), 400);
+      return;
+    }
+    const body = parsed.data;
+    const permitNumber =
+      body.permitNumber ?? `PER-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+    const approvalChain = initializeApprovalChain(body.approvalChain);
+    const permit = await Permit.create({
+      tenantId,
+      permitNumber,
+      type: body.type,
+      description: body.description,
+      status: 'pending',
+      requestedBy: toObjectId(body.requestedBy),
+      workOrder: body.workOrder ? toObjectId(body.workOrder) : undefined,
+      approvalChain,
+      isolationSteps:
+        body.isolationSteps?.map((step, index) => ({
+          index,
+          description: step.description,
+          verificationNotes: step.verificationNotes,
+        })) ?? [],
+      watchers: body.watchers?.map(toObjectId) ?? [],
+      validFrom: body.validFrom,
+      validTo: body.validTo,
+      riskLevel: body.riskLevel,
+      history: [
+        {
+          action: 'created',
+          by: req.user?._id ? toObjectId(req.user._id) : undefined,
+          at: new Date(),
+          notes: body.description,
+        },
+      ],
+    });
+
+    if (permit.workOrder) {
+      await WorkOrder.findByIdAndUpdate(
+        permit.workOrder,
+        {
+          $addToSet: { permits: permit._id, requiredPermitTypes: permit.type },
+        },
+        { new: true },
+      );
+    }
+
+    const active = getActiveStep(permit);
+    if (active?.user) {
+      await notifyUser(toObjectId(active.user), `Permit ${permit.permitNumber} requires your approval.`);
+    }
+
+    await writeAuditLog({
+      tenantId,
+      userId: req.user?._id,
+      action: 'create',
+      entityType: 'Permit',
+      entityId: toEntityId(permit._id),
+      after: permit.toObject(),
+    });
+
+    sendResponse(res, permit, null, 201);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updatePermit: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const parsed = permitUpdateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendResponse(res, null, parsed.error.flatten(), 400);
+      return;
+    }
+    const update = parsed.data;
+    if (update.approvalChain) {
+      update.approvalChain = initializeApprovalChain(update.approvalChain as PermitApprovalStep[]);
+    }
+    const permit = await Permit.findOne({ _id: req.params.id, tenantId });
+    if (!permit) {
+      sendResponse(res, null, 'Not found', 404);
+      return;
+    }
+    const before = permit.toObject();
+    if (update.type) permit.type = update.type;
+    if (update.description !== undefined) permit.description = update.description;
+    if (update.validFrom !== undefined) permit.validFrom = update.validFrom;
+    if (update.validTo !== undefined) permit.validTo = update.validTo;
+    if (update.riskLevel !== undefined) permit.riskLevel = update.riskLevel;
+    if (update.watchers) permit.watchers = update.watchers.map(toObjectId);
+    if (update.approvalChain) permit.approvalChain = update.approvalChain as PermitApprovalStep[];
+    if (update.isolationSteps) {
+      permit.isolationSteps = update.isolationSteps.map((step, index) => ({
+        index,
+        description: step.description,
+        completed: step.completed,
+        completedAt: step.completedAt,
+        completedBy: step.completedBy ? toObjectId(step.completedBy) : undefined,
+        verificationNotes: step.verificationNotes,
+      }));
+    }
+    if (update.workOrder) {
+      permit.workOrder = toObjectId(update.workOrder);
+      await WorkOrder.findByIdAndUpdate(
+        permit.workOrder,
+        {
+          $addToSet: { permits: permit._id, requiredPermitTypes: permit.type },
+        },
+        { new: true },
+      );
+    }
+
+    permit.history.push({
+      action: 'updated',
+      by: req.user?._id ? toObjectId(req.user._id) : undefined,
+      at: new Date(),
+      notes: update.description,
+    });
+
+    const saved = await permit.save();
+
+    await writeAuditLog({
+      tenantId,
+      userId: req.user?._id,
+      action: 'update',
+      entityType: 'Permit',
+      entityId: toEntityId(saved._id),
+      before,
+      after: saved.toObject(),
+    });
+
+    sendResponse(res, saved);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const approvePermit: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const parsed = permitDecisionSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendResponse(res, null, parsed.error.flatten(), 400);
+      return;
+    }
+    const permit = await Permit.findOne({ _id: req.params.id, tenantId });
+    if (!permit) {
+      sendResponse(res, null, 'Not found', 404);
+      return;
+    }
+    const active = getActiveStep(permit);
+    if (!active) {
+      sendResponse(res, permit, null, 200);
+      return;
+    }
+    const userId = req.user?._id ? toObjectId(req.user._id) : undefined;
+    const userRoles = (req.user as any)?.roles ?? [];
+    if (active.user) {
+      if (!userId || !toObjectId(active.user).equals(userId)) {
+        sendResponse(res, null, 'You are not assigned to approve this step', 403);
+        return;
+      }
+    } else if (active.role && !userRoles.includes(active.role)) {
+      sendResponse(res, null, 'Insufficient role to approve this permit', 403);
+      return;
+    }
+
+    active.status = 'approved';
+    active.approvedAt = new Date();
+    active.actedBy = userId;
+    active.notes = parsed.data.notes;
+
+    permit.history.push({
+      action: 'approved',
+      by: userId,
+      at: new Date(),
+      notes: `Step approved for role ${active.role}`,
+    });
+
+    const remaining = permit.approvalChain.find((step) => step.status === 'blocked');
+    if (remaining) {
+      remaining.status = 'pending';
+      if (remaining.escalateAfterHours) {
+        remaining.escalateAt = new Date(
+          Date.now() + remaining.escalateAfterHours * 60 * 60 * 1000,
+        );
+      }
+      if (remaining.user) {
+        await notifyUser(
+          toObjectId(remaining.user),
+          `Permit ${permit.permitNumber} is awaiting your approval`,
+        );
+      }
+      permit.status = 'pending';
+    } else {
+      permit.status = 'approved';
+    }
+
+    const saved = await permit.save();
+    await writeAuditLog({
+      tenantId,
+      userId,
+      action: 'approve',
+      entityType: 'Permit',
+      entityId: toEntityId(saved._id),
+      after: saved.toObject(),
+    });
+    sendResponse(res, saved);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const rejectPermit: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const parsed = permitDecisionSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendResponse(res, null, parsed.error.flatten(), 400);
+      return;
+    }
+    const permit = await Permit.findOne({ _id: req.params.id, tenantId });
+    if (!permit) {
+      sendResponse(res, null, 'Not found', 404);
+      return;
+    }
+    const active = getActiveStep(permit);
+    if (!active) {
+      sendResponse(res, null, 'Permit already decided', 400);
+      return;
+    }
+    active.status = 'rejected';
+    active.actedBy = req.user?._id ? toObjectId(req.user._id) : undefined;
+    active.notes = parsed.data.notes;
+    permit.status = 'rejected';
+    permit.history.push({
+      action: 'rejected',
+      by: active.actedBy,
+      at: new Date(),
+      notes: parsed.data.notes,
+    });
+    const saved = await permit.save();
+    await writeAuditLog({
+      tenantId,
+      userId: active.actedBy,
+      action: 'reject',
+      entityType: 'Permit',
+      entityId: toEntityId(saved._id),
+      after: saved.toObject(),
+    });
+    sendResponse(res, saved);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const escalatePermit: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const permit = await Permit.findOne({ _id: req.params.id, tenantId });
+    if (!permit) {
+      sendResponse(res, null, 'Not found', 404);
+      return;
+    }
+    const active = getActiveStep(permit);
+    if (!active) {
+      sendResponse(res, null, 'Permit has no pending approvals', 400);
+      return;
+    }
+    active.status = 'escalated';
+    active.escalateAt = null;
+    permit.status = 'escalated';
+    permit.history.push({
+      action: 'escalated',
+      by: req.user?._id ? toObjectId(req.user._id) : undefined,
+      at: new Date(),
+      notes: `Escalated approval for role ${active.role}`,
+    });
+    await Promise.all(
+      permit.watchers.map((watcher) =>
+        notifyUser(toObjectId(watcher), `Permit ${permit.permitNumber} has been escalated.`),
+      ),
+    );
+    const saved = await permit.save();
+    await writeAuditLog({
+      tenantId,
+      userId: req.user?._id,
+      action: 'escalate',
+      entityType: 'Permit',
+      entityId: toEntityId(saved._id),
+      after: saved.toObject(),
+    });
+    sendResponse(res, saved);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const completeIsolationStep: AuthedRequestHandler<
+  ParamsDictionary,
+  PermitDocument,
+  unknown,
+  { index?: string }
+> = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const parsed = permitIsolationSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendResponse(res, null, parsed.error.flatten(), 400);
+      return;
+    }
+    const permit = await Permit.findOne({ _id: req.params.id, tenantId });
+    if (!permit) {
+      sendResponse(res, null, 'Not found', 404);
+      return;
+    }
+    const index = Number(req.params.stepIndex ?? req.query.index);
+    if (Number.isNaN(index) || index < 0 || index >= permit.isolationSteps.length) {
+      sendResponse(res, null, 'Invalid isolation step index', 400);
+      return;
+    }
+    const step = permit.isolationSteps[index];
+    step.completed = true;
+    step.completedAt = new Date();
+    step.completedBy = req.user?._id ? toObjectId(req.user._id) : undefined;
+    step.verificationNotes = parsed.data.verificationNotes;
+    permit.history.push({
+      action: 'isolation-step-completed',
+      by: step.completedBy,
+      at: new Date(),
+      notes: `Step ${index + 1}: ${step.description}`,
+    });
+    const saved = await permit.save();
+    await writeAuditLog({
+      tenantId,
+      userId: step.completedBy,
+      action: 'isolation-step-completed',
+      entityType: 'Permit',
+      entityId: toEntityId(saved._id),
+      after: saved.toObject(),
+    });
+    sendResponse(res, saved);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const logPermitIncident: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const parsed = permitIncidentSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendResponse(res, null, parsed.error.flatten(), 400);
+      return;
+    }
+    const permit = await Permit.findOne({ _id: req.params.id, tenantId });
+    if (!permit) {
+      sendResponse(res, null, 'Not found', 404);
+      return;
+    }
+    const incident = await SafetyIncident.create({
+      tenantId: toObjectId(tenantId),
+      permit: permit._id,
+      workOrder: permit.workOrder,
+      title: parsed.data.title,
+      description: parsed.data.description,
+      severity: parsed.data.severity,
+      status: parsed.data.status ?? 'open',
+      reportedBy: req.user?._id ? toObjectId(req.user._id) : permit.requestedBy,
+      actions:
+        parsed.data.actions?.map((action) => ({
+          description: action.description,
+          assignedTo: action.assignedTo ? toObjectId(action.assignedTo) : undefined,
+          dueDate: action.dueDate,
+        })) ?? [],
+      timeline: parsed.data.message
+        ? [
+            {
+              at: new Date(),
+              by: req.user?._id ? toObjectId(req.user._id) : undefined,
+              message: parsed.data.message,
+            },
+          ]
+        : [],
+    });
+    permit.incidents.push(incident._id);
+    permit.history.push({
+      action: 'incident-logged',
+      by: req.user?._id ? toObjectId(req.user._id) : undefined,
+      at: new Date(),
+      notes: parsed.data.title,
+    });
+    await permit.save();
+    sendResponse(res, incident, null, 201);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getPermitHistory: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const permit = await Permit.findOne({ _id: req.params.id, tenantId });
+    if (!permit) {
+      sendResponse(res, null, 'Not found', 404);
+      return;
+    }
+    sendResponse(res, permit.history);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getSafetyKpis: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const activeCount = await Permit.countDocuments({
+      tenantId,
+      status: { $in: ['pending', 'approved', 'active'] },
+    });
+    const overdueApprovals = await Permit.countDocuments({
+      tenantId,
+      'approvalChain.status': 'pending',
+      'approvalChain.escalateAt': { $lt: new Date() },
+    });
+    const incidentsLast30 = await SafetyIncident.countDocuments({
+      tenantId,
+      reportedAt: { $gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) },
+    });
+    const approvalDurations = await Permit.aggregate([
+      {
+        $match: {
+          tenantId: toObjectId(tenantId),
+          status: { $in: ['approved', 'active', 'closed'] },
+          createdAt: { $ne: null },
+          updatedAt: { $ne: null },
+        },
+      },
+      {
+        $project: {
+          durationMs: { $subtract: ['$updatedAt', '$createdAt'] },
+        },
+      },
+      {
+        $group: {
+          _id: null,
+          avgDuration: { $avg: '$durationMs' },
+        },
+      },
+    ]);
+    const avgApprovalHours = approvalDurations[0]?.avgDuration
+      ? approvalDurations[0].avgDuration / (1000 * 60 * 60)
+      : 0;
+    sendResponse(res, {
+      activeCount,
+      overdueApprovals,
+      incidentsLast30,
+      avgApprovalHours,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getPermitActivity: AuthedRequestHandler = async (req, res, next) => {
+  try {
+    const tenantId = ensureTenant(req, res);
+    if (!tenantId) return;
+    const userId = req.query.userId as string | undefined;
+    if (!userId || !Types.ObjectId.isValid(userId)) {
+      sendResponse(res, null, 'userId is required', 400);
+      return;
+    }
+    const userObjectId = new Types.ObjectId(userId);
+    const permits = await Permit.find({
+      tenantId,
+      $or: [
+        { requestedBy: userObjectId },
+        { watchers: userObjectId },
+        { 'approvalChain.user': userObjectId },
+        { 'history.by': userObjectId },
+      ],
+    }).sort({ updatedAt: -1 });
+    const pendingApprovals = permits.filter((permit) => {
+      const step = getActiveStep(permit);
+      if (!step) return false;
+      if (step.user && toObjectId(step.user).equals(userObjectId)) return true;
+      return step.role ? (req.user as any)?.roles?.includes(step.role) ?? false : false;
+    }).length;
+    const activePermits = permits.filter((permit) => permit.status === 'active').length;
+    const recentHistory = permits
+      .flatMap((permit) =>
+        permit.history
+          .filter((entry) => entry.by && toObjectId(entry.by).equals(userObjectId))
+          .map((entry) => ({
+            permitId: permit._id,
+            permitNumber: permit.permitNumber,
+            action: entry.action,
+            at: entry.at,
+            notes: entry.notes,
+          })),
+      )
+      .sort((a, b) => b.at.getTime() - a.at.getTime())
+      .slice(0, 10);
+    sendResponse(res, {
+      totalInvolved: permits.length,
+      pendingApprovals,
+      activePermits,
+      recentHistory,
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/backend/controllers/WorkOrderController.ts
+++ b/backend/controllers/WorkOrderController.ts
@@ -7,6 +7,7 @@ import type { Response, NextFunction } from 'express';
 import type { AuthedRequest, AuthedRequestHandler } from '../types/http';
 
 import WorkOrder, { WorkOrderDocument } from '../models/WorkOrder';
+import Permit, { type PermitDocument } from '../models/Permit';
 import { emitWorkOrderUpdate } from '../server';
 import notifyUser from '../utils/notify';
 import { AIAssistResult, getWorkOrderAssistance } from '../services/aiCopilot';
@@ -61,35 +62,17 @@ const workOrderCreateFields = [
   'failureCode',
   'pmTask',
   'department',
-  
   'line',
   'station',
   'teamMemberName',
   'importance',
   'dueDate',
   'completedAt',
+  'permits',
+  'requiredPermitTypes',
 ];
 
 const workOrderUpdateFields = [...workOrderCreateFields];
-
-type UpdateWorkOrderBody = Partial<
-  Omit<
-    WorkOrderInput,
-    'assetId' | 'pmTask' | 'department' | 'line' | 'station' | 'partsUsed'
-  >
-> & {
-  assetId?: Types.ObjectId;
-  pmTask?: Types.ObjectId;
-  department?: Types.ObjectId;
-  line?: Types.ObjectId;
-  station?: Types.ObjectId;
-  partsUsed?: { partId: Types.ObjectId; qty: number; cost?: number }[];
-};
-
-interface CompleteWorkOrderBody extends WorkOrderComplete {
-  photos?: string[];
-  failureCode?: string;
-}
 
 type UpdateWorkOrderBody = Partial<
   Omit<
@@ -102,8 +85,10 @@ type UpdateWorkOrderBody = Partial<
     | 'department'
     | 'line'
     | 'station'
+    | 'permits'
+    | 'requiredPermitTypes'
   >
-& {
+> & {
   assetId?: Types.ObjectId;
   partsUsed?: { partId: Types.ObjectId; qty: number; cost: number }[];
   checklists?: { text: string; done: boolean }[];
@@ -112,7 +97,84 @@ type UpdateWorkOrderBody = Partial<
   department?: Types.ObjectId;
   line?: Types.ObjectId;
   station?: Types.ObjectId;
+  permits?: Types.ObjectId[];
+  requiredPermitTypes?: string[];
 };
+
+interface CompleteWorkOrderBody extends WorkOrderComplete {
+  photos?: string[];
+  failureCode?: string;
+}
+
+const START_APPROVED_STATUSES = new Set(['approved', 'active']);
+const COMPLETION_ALLOWED_STATUSES = new Set(['active', 'approved', 'closed']);
+
+const toObjectId = (value: Types.ObjectId | string): Types.ObjectId =>
+  value instanceof Types.ObjectId ? value : new Types.ObjectId(value);
+
+async function ensurePermitReadiness(
+  tenantId: string,
+  permitIds: (Types.ObjectId | string)[] | undefined,
+  requiredTypes: string[] | undefined,
+  stage: 'start' | 'complete',
+): Promise<{ ok: boolean; message?: string; permits: PermitDocument[] }> {
+  const ids = permitIds?.filter(Boolean) ?? [];
+  const normalizedIds = ids.map((id) => toObjectId(id));
+  const permits = normalizedIds.length
+    ? await Permit.find({ tenantId, _id: { $in: normalizedIds } })
+    : [];
+
+  if (normalizedIds.length && permits.length !== normalizedIds.length) {
+    return {
+      ok: false,
+      message: 'One or more linked permits could not be found',
+      permits,
+    };
+  }
+
+  const required = requiredTypes ?? [];
+  for (const type of required) {
+    if (!permits.some((permit) => permit.type === type)) {
+      return {
+        ok: false,
+        message: `Permit type ${type} is required before this action`,
+        permits,
+      };
+    }
+  }
+
+  if (stage === 'start') {
+    const notReady = permits.find((permit) => !START_APPROVED_STATUSES.has(permit.status));
+    if (notReady) {
+      return {
+        ok: false,
+        message: `Permit ${notReady.permitNumber} is not approved for activation`,
+        permits,
+      };
+    }
+  } else {
+    const pendingIsolation = permits.find((permit) =>
+      permit.isolationSteps?.some((step) => !step.completed),
+    );
+    if (pendingIsolation) {
+      return {
+        ok: false,
+        message: `Isolation steps remain open on permit ${pendingIsolation.permitNumber}`,
+        permits,
+      };
+    }
+    const blocked = permits.find((permit) => !COMPLETION_ALLOWED_STATUSES.has(permit.status));
+    if (blocked) {
+      return {
+        ok: false,
+        message: `Permit ${blocked.permitNumber} must be active before completion`,
+        permits,
+      };
+    }
+  }
+
+  return { ok: true, permits };
+}
 
 
 function toWorkOrderUpdatePayload(doc: any): WorkOrderUpdatePayload {
@@ -313,7 +375,18 @@ export const createWorkOrder: AuthedRequestHandler<
       return;
     }
 
-    const { assignees, checklists, partsUsed, signatures, ...rest } = parsed.data;
+    const {
+      assignees,
+      checklists,
+      partsUsed,
+      signatures,
+      permits,
+      requiredPermitTypes,
+      ...rest
+    } = parsed.data;
+    const normalizedRequiredPermitTypes = requiredPermitTypes
+      ? Array.from(new Set(requiredPermitTypes))
+      : [];
     const validParts = validateItems<RawPart>(
       res,
       partsUsed,
@@ -342,16 +415,54 @@ export const createWorkOrder: AuthedRequestHandler<
       'signature'
     );
     if (signatures && !validSignatures) return;
+    const validPermits = validateItems<string>(
+      res,
+      permits,
+      id => Types.ObjectId.isValid(id),
+      'permit'
+    );
+    if (permits && !validPermits) return;
+    let permitDocs: PermitDocument[] = [];
+    if (validPermits && validPermits.length) {
+      permitDocs = await Permit.find({
+        _id: { $in: validPermits.map((id) => new Types.ObjectId(id)) },
+        tenantId,
+      });
+      if (permitDocs.length !== validPermits.length) {
+        sendResponse(res, null, 'One or more permits were not found', 404);
+        return;
+      }
+    }
     const newItem = new WorkOrder({
       ...rest,
       ...(validAssignees && { assignees: mapAssignees(validAssignees) }),
       ...(validChecklists && { checklists: mapChecklists(validChecklists as RawChecklist[]) }),
       ...(validParts && { partsUsed: mapPartsUsed(validParts as RawPart[]) }),
       ...(validSignatures && { signatures: mapSignatures(validSignatures as RawSignature[]) }),
+      ...(validPermits && { permits: validPermits.map((id) => new Types.ObjectId(id)) }),
+      requiredPermitTypes: normalizedRequiredPermitTypes,
       tenantId,
     });
     const saved = await newItem.save();
-    const userId = (req.user as any)?._id || (req.user as any)?.id;
+    const userIdStr = (req.user as any)?._id || (req.user as any)?.id;
+    const userObjectId = userIdStr ? new Types.ObjectId(userIdStr) : undefined;
+    if (permitDocs.length) {
+      await Promise.all(
+        permitDocs.map(async (doc) => {
+          if (!doc.workOrder || !doc.workOrder.equals(saved._id)) {
+            doc.workOrder = saved._id;
+          }
+          doc.history.push({
+            action: 'linked-work-order',
+            by: userObjectId,
+            at: new Date(),
+            notes: `Linked to work order ${saved.title}`,
+          });
+          await doc.save();
+        }),
+      );
+    }
+    const userId = userObjectId;
     await writeAuditLog({
       tenantId,
       userId,
@@ -410,7 +521,10 @@ export const updateWorkOrder: AuthedRequestHandler = async (
       sendResponse(res, null, parsed.error.flatten(), 400);
       return;
     }
+    const incomingPermits = parsed.data?.permits;
+    const incomingRequiredPermitTypes = parsed.data?.requiredPermitTypes;
     const update: UpdateWorkOrderBody = parsed.data as UpdateWorkOrderBody;
+    let permitDocs: PermitDocument[] | undefined;
     if (update.partsUsed) {
       const validParts = validateItems<RawPart>(
         res,
@@ -451,6 +565,27 @@ export const updateWorkOrder: AuthedRequestHandler = async (
       if (!validSignatures) return;
       update.signatures = mapSignatures(validSignatures as RawSignature[]);
     }
+    if (incomingPermits) {
+      const validPermits = validateItems<string>(
+        res,
+        incomingPermits,
+        id => Types.ObjectId.isValid(id),
+        'permit'
+      );
+      if (!validPermits) return;
+      permitDocs = await Permit.find({
+        _id: { $in: validPermits.map((id) => new Types.ObjectId(id)) },
+        tenantId,
+      });
+      if (permitDocs.length !== validPermits.length) {
+        sendResponse(res, null, 'One or more permits were not found', 404);
+        return;
+      }
+      update.permits = permitDocs.map((doc) => doc._id);
+    }
+    if (incomingRequiredPermitTypes) {
+      update.requiredPermitTypes = Array.from(new Set(incomingRequiredPermitTypes));
+    }
     const existing = await WorkOrder.findOne({ _id: req.params.id, tenantId }) as WorkOrderDocument | null;
     if (!existing) {
       sendResponse(res, null, 'Not found', 404);
@@ -465,10 +600,31 @@ export const updateWorkOrder: AuthedRequestHandler = async (
       sendResponse(res, null, 'Not found', 404);
       return;
     }
-    const userId = (req.user as any)?._id || (req.user as any)?.id;
+    const userIdStr = (req.user as any)?._id || (req.user as any)?.id;
+    const userObjectId = userIdStr ? new Types.ObjectId(userIdStr) : undefined;
+    if (permitDocs) {
+      const newIds = new Set(permitDocs.map((doc) => doc._id.toString()));
+      const previousIds = (existing.permits ?? []).map((id) => id.toString());
+      const removedIds = previousIds.filter((id) => !newIds.has(id));
+      if (removedIds.length) {
+        await Permit.updateMany({ _id: { $in: removedIds.map(toObjectId) } }, { $unset: { workOrder: '' } });
+      }
+      await Promise.all(
+        permitDocs.map(async (doc) => {
+          doc.workOrder = updated._id;
+          doc.history.push({
+            action: 'linked-work-order',
+            by: userObjectId,
+            at: new Date(),
+            notes: `Linked to work order ${updated.title}`,
+          });
+          await doc.save();
+        }),
+      );
+    }
     await writeAuditLog({
       tenantId,
-      userId,
+      userId: userObjectId,
       action: 'update',
       entityType: 'WorkOrder',
       entityId: toEntityId(new Types.ObjectId(req.params.id)),
@@ -597,6 +753,16 @@ export const approveWorkOrder: AuthedRequestHandler = async (
       sendResponse(res, null, 'Not found', 404);
       return;
     }
+    const readiness = await ensurePermitReadiness(
+      tenantId,
+      workOrder.permits,
+      workOrder.requiredPermitTypes,
+      'start'
+    );
+    if (!readiness.ok) {
+      sendResponse(res, null, readiness.message ?? 'Permits are not approved for work start', 409);
+      return;
+    }
 
     const before = workOrder.toObject();
     workOrder.approvalStatus = status;
@@ -650,6 +816,26 @@ export const assignWorkOrder: AuthedRequestHandler = async (
     const workOrder = await WorkOrder.findOne({ _id: req.params.id, tenantId });
     if (!workOrder) {
       sendResponse(res, null, 'Not found', 404);
+      return;
+    }
+    const readiness = await ensurePermitReadiness(
+      tenantId,
+      workOrder.permits,
+      workOrder.requiredPermitTypes,
+      'complete'
+    );
+    if (!readiness.ok) {
+      sendResponse(res, null, readiness.message ?? 'Permits not satisfied for completion', 409);
+      return;
+    }
+    const readiness = await ensurePermitReadiness(
+      tenantId,
+      workOrder.permits,
+      workOrder.requiredPermitTypes,
+      'start'
+    );
+    if (!readiness.ok) {
+      sendResponse(res, null, readiness.message ?? 'Permits are not approved for work start', 409);
       return;
     }
     const parsed = assignWorkOrderSchema.safeParse(req.body);
@@ -706,14 +892,40 @@ export const startWorkOrder: AuthedRequestHandler = async (
       sendResponse(res, null, 'Not found', 404);
       return;
     }
+    const readiness = await ensurePermitReadiness(
+      tenantId,
+      workOrder.permits,
+      workOrder.requiredPermitTypes,
+      'start'
+    );
+    if (!readiness.ok) {
+      sendResponse(res, null, readiness.message ?? 'Permits are not approved for work start', 409);
+      return;
+    }
     const before = workOrder.toObject();
     workOrder.status = 'in_progress';
     const saved = await workOrder.save();
     const userIdStr = (req.user as any)?._id || (req.user as any)?.id;
-    const userId = userIdStr ? new Types.ObjectId(userIdStr) : undefined;
+    const userObjectId = userIdStr ? new Types.ObjectId(userIdStr) : undefined;
+    if (readiness.permits.length) {
+      await Promise.all(
+        readiness.permits.map(async (permit) => {
+          if (permit.status === 'approved') {
+            permit.status = 'active';
+          }
+          permit.history.push({
+            action: 'work-order-started',
+            by: userObjectId,
+            at: new Date(),
+            notes: `Work order ${workOrder.title} started`,
+          });
+          await permit.save();
+        }),
+      );
+    }
     await writeAuditLog({
       tenantId,
-      userId,
+      userId: userObjectId,
       action: 'start',
       entityType: 'WorkOrder',
       entityId: toEntityId(new Types.ObjectId(req.params.id)),
@@ -750,6 +962,16 @@ export const completeWorkOrder: AuthedRequestHandler = async (
       sendResponse(res, null, 'Not found', 404);
       return;
     }
+    const readiness = await ensurePermitReadiness(
+      tenantId,
+      workOrder.permits,
+      workOrder.requiredPermitTypes,
+      'start'
+    );
+    if (!readiness.ok) {
+      sendResponse(res, null, readiness.message ?? 'Permits are not approved for work start', 409);
+      return;
+    }
     const body = req.body as CompleteWorkOrderBody;
     const before = workOrder.toObject();
     workOrder.status = 'completed';
@@ -774,10 +996,27 @@ export const completeWorkOrder: AuthedRequestHandler = async (
     if (body.failureCode !== undefined) workOrder.failureCode = body.failureCode;
 
     const saved = await workOrder.save();
-    const userId = (req.user as any)?._id || (req.user as any)?.id;
+    const userIdStr = (req.user as any)?._id || (req.user as any)?.id;
+    const userObjectId = userIdStr ? new Types.ObjectId(userIdStr) : undefined;
+    if (readiness.permits.length) {
+      await Promise.all(
+        readiness.permits.map(async (permit) => {
+          if (!permit.status || permit.status !== 'closed') {
+            permit.status = 'closed';
+          }
+          permit.history.push({
+            action: 'work-order-completed',
+            by: userObjectId,
+            at: new Date(),
+            notes: `Work order ${workOrder.title} completed`,
+          });
+          await permit.save();
+        }),
+      );
+    }
     await writeAuditLog({
       tenantId,
-      userId,
+      userId: userObjectId,
       action: 'complete',
       entityType: 'WorkOrder',
       entityId: toEntityId(new Types.ObjectId(req.params.id)),
@@ -812,6 +1051,16 @@ export const cancelWorkOrder: AuthedRequestHandler = async (
     const workOrder = await WorkOrder.findOne({ _id: req.params.id, tenantId });
     if (!workOrder) {
       sendResponse(res, null, 'Not found', 404);
+      return;
+    }
+    const readiness = await ensurePermitReadiness(
+      tenantId,
+      workOrder.permits,
+      workOrder.requiredPermitTypes,
+      'start'
+    );
+    if (!readiness.ok) {
+      sendResponse(res, null, readiness.message ?? 'Permits are not approved for work start', 409);
       return;
     }
     const before = workOrder.toObject();

--- a/backend/models/Permit.ts
+++ b/backend/models/Permit.ts
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import mongoose, { Schema, Document, Model, Types } from 'mongoose';
+
+export type PermitStatus =
+  | 'draft'
+  | 'pending'
+  | 'approved'
+  | 'active'
+  | 'rejected'
+  | 'closed'
+  | 'escalated';
+
+export interface PermitApprovalStep {
+  sequence: number;
+  role: string;
+  user?: Types.ObjectId;
+  status: 'blocked' | 'pending' | 'approved' | 'rejected' | 'escalated';
+  approvedAt?: Date;
+  actedBy?: Types.ObjectId;
+  notes?: string;
+  escalateAfterHours?: number;
+  escalateAt?: Date | null;
+}
+
+export interface PermitIsolationStep {
+  index: number;
+  description: string;
+  completed?: boolean;
+  completedAt?: Date;
+  completedBy?: Types.ObjectId;
+  verificationNotes?: string;
+}
+
+export interface PermitHistoryEntry {
+  action: string;
+  by?: Types.ObjectId;
+  at: Date;
+  notes?: string;
+}
+
+export interface PermitDocument extends Document {
+  _id: Types.ObjectId;
+  tenantId: Types.ObjectId;
+  permitNumber: string;
+  type: string;
+  description?: string;
+  status: PermitStatus;
+  requestedBy: Types.ObjectId;
+  workOrder?: Types.ObjectId;
+  approvalChain: PermitApprovalStep[];
+  isolationSteps: PermitIsolationStep[];
+  watchers: Types.ObjectId[];
+  history: PermitHistoryEntry[];
+  validFrom?: Date;
+  validTo?: Date;
+  riskLevel?: 'low' | 'medium' | 'high' | 'critical';
+  incidents: Types.ObjectId[];
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const approvalStepSchema = new Schema<PermitApprovalStep>(
+  {
+    sequence: { type: Number, required: true },
+    role: { type: String, required: true },
+    user: { type: Schema.Types.ObjectId, ref: 'User' },
+    status: {
+      type: String,
+      enum: ['blocked', 'pending', 'approved', 'rejected', 'escalated'],
+      default: 'blocked',
+    },
+    approvedAt: { type: Date },
+    actedBy: { type: Schema.Types.ObjectId, ref: 'User' },
+    notes: { type: String },
+    escalateAfterHours: { type: Number },
+    escalateAt: { type: Date },
+  },
+  { _id: false }
+);
+
+const isolationStepSchema = new Schema<PermitIsolationStep>(
+  {
+    index: { type: Number, required: true },
+    description: { type: String, required: true },
+    completed: { type: Boolean, default: false },
+    completedAt: { type: Date },
+    completedBy: { type: Schema.Types.ObjectId, ref: 'User' },
+    verificationNotes: { type: String },
+  },
+  { _id: false }
+);
+
+const historySchema = new Schema<PermitHistoryEntry>(
+  {
+    action: { type: String, required: true },
+    by: { type: Schema.Types.ObjectId, ref: 'User' },
+    at: { type: Date, default: Date.now },
+    notes: { type: String },
+  },
+  { _id: false }
+);
+
+const permitSchema = new Schema<PermitDocument>(
+  {
+    tenantId: { type: Schema.Types.ObjectId, required: true, index: true },
+    permitNumber: { type: String, required: true, unique: true },
+    type: { type: String, required: true },
+    description: { type: String },
+    status: {
+      type: String,
+      enum: ['draft', 'pending', 'approved', 'active', 'rejected', 'closed', 'escalated'],
+      default: 'pending',
+      index: true,
+    },
+    requestedBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    workOrder: { type: Schema.Types.ObjectId, ref: 'WorkOrder' },
+    approvalChain: { type: [approvalStepSchema], default: [] },
+    isolationSteps: { type: [isolationStepSchema], default: [] },
+    watchers: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+    history: { type: [historySchema], default: [] },
+    validFrom: { type: Date },
+    validTo: { type: Date },
+    riskLevel: { type: String, enum: ['low', 'medium', 'high', 'critical'] },
+    incidents: [{ type: Schema.Types.ObjectId, ref: 'SafetyIncident' }],
+  },
+  { timestamps: true }
+);
+
+permitSchema.index({ tenantId: 1, permitNumber: 1 }, { unique: true });
+permitSchema.index({ tenantId: 1, status: 1 });
+permitSchema.index({ tenantId: 1, workOrder: 1 });
+
+const Permit: Model<PermitDocument> = mongoose.model<PermitDocument>('Permit', permitSchema);
+
+export default Permit;

--- a/backend/models/SafetyIncident.ts
+++ b/backend/models/SafetyIncident.ts
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import mongoose, { Schema, Document, Model, Types } from 'mongoose';
+
+export type SafetyIncidentSeverity = 'minor' | 'moderate' | 'major' | 'critical';
+export type SafetyIncidentStatus = 'open' | 'investigating' | 'resolved' | 'closed';
+
+export interface SafetyIncidentAction {
+  description: string;
+  assignedTo?: Types.ObjectId;
+  dueDate?: Date;
+  completedAt?: Date;
+}
+
+export interface SafetyIncidentLogEntry {
+  at: Date;
+  by?: Types.ObjectId;
+  message: string;
+}
+
+export interface SafetyIncidentDocument extends Document {
+  _id: Types.ObjectId;
+  tenantId: Types.ObjectId;
+  permit?: Types.ObjectId;
+  workOrder?: Types.ObjectId;
+  title: string;
+  description?: string;
+  severity: SafetyIncidentSeverity;
+  status: SafetyIncidentStatus;
+  reportedBy: Types.ObjectId;
+  reportedAt: Date;
+  actions: SafetyIncidentAction[];
+  timeline: SafetyIncidentLogEntry[];
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const actionSchema = new Schema<SafetyIncidentAction>(
+  {
+    description: { type: String, required: true },
+    assignedTo: { type: Schema.Types.ObjectId, ref: 'User' },
+    dueDate: { type: Date },
+    completedAt: { type: Date },
+  },
+  { _id: false }
+);
+
+const logSchema = new Schema<SafetyIncidentLogEntry>(
+  {
+    at: { type: Date, default: Date.now },
+    by: { type: Schema.Types.ObjectId, ref: 'User' },
+    message: { type: String, required: true },
+  },
+  { _id: false }
+);
+
+const safetyIncidentSchema = new Schema<SafetyIncidentDocument>(
+  {
+    tenantId: { type: Schema.Types.ObjectId, required: true, index: true },
+    permit: { type: Schema.Types.ObjectId, ref: 'Permit' },
+    workOrder: { type: Schema.Types.ObjectId, ref: 'WorkOrder' },
+    title: { type: String, required: true },
+    description: { type: String },
+    severity: {
+      type: String,
+      enum: ['minor', 'moderate', 'major', 'critical'],
+      default: 'minor',
+    },
+    status: {
+      type: String,
+      enum: ['open', 'investigating', 'resolved', 'closed'],
+      default: 'open',
+      index: true,
+    },
+    reportedBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    reportedAt: { type: Date, default: Date.now },
+    actions: { type: [actionSchema], default: [] },
+    timeline: { type: [logSchema], default: [] },
+  },
+  { timestamps: true }
+);
+
+safetyIncidentSchema.index({ tenantId: 1, permit: 1 });
+safetyIncidentSchema.index({ tenantId: 1, workOrder: 1 });
+
+const SafetyIncident: Model<SafetyIncidentDocument> = mongoose.model<SafetyIncidentDocument>(
+  'SafetyIncident',
+  safetyIncidentSchema,
+);
+
+export default SafetyIncident;

--- a/backend/models/WorkOrder.ts
+++ b/backend/models/WorkOrder.ts
@@ -20,6 +20,8 @@ export interface WorkOrderDocument extends Document {
   checklists: { text: string; done: boolean }[];
   partsUsed: { partId: Types.ObjectId; qty: number; cost: number }[];
   signatures: { by: Types.ObjectId; ts: Date }[];
+  permits: Types.ObjectId[];
+  requiredPermitTypes: string[];
   timeSpentMin?: number;
   photos: string[];
   failureCode?: string;
@@ -81,6 +83,11 @@ const workOrderSchema = new Schema<WorkOrderDocument>(
 
       },
     ],
+    permits: {
+      type: [{ type: Schema.Types.ObjectId, ref: 'Permit' }],
+      default: [],
+    },
+    requiredPermitTypes: { type: [String], default: [] },
     timeSpentMin: Number,
     photos: [String],
     failureCode: String,

--- a/backend/routes/PermitRoutes.ts
+++ b/backend/routes/PermitRoutes.ts
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import express from 'express';
+import { requireAuth, requireRole } from '../middleware/authMiddleware';
+import validateObjectId from '../middleware/validateObjectId';
+import type { UserRole } from '../types/auth';
+import {
+  listPermits,
+  getPermit,
+  createPermit,
+  updatePermit,
+  approvePermit,
+  rejectPermit,
+  escalatePermit,
+  completeIsolationStep,
+  logPermitIncident,
+  getPermitHistory,
+  getSafetyKpis,
+  getPermitActivity,
+} from '../controllers/PermitController';
+
+const router = express.Router();
+
+const ADMIN_SUPERVISOR_MANAGER: UserRole[] = ['admin', 'supervisor', 'manager'];
+const APPROVER_ROLES: UserRole[] = ['admin', 'supervisor', 'manager', 'technician'];
+
+router.use(requireAuth);
+
+router.get('/', listPermits);
+router.get('/kpis', getSafetyKpis);
+router.get('/activity', getPermitActivity);
+router.get('/:id/history', validateObjectId('id'), getPermitHistory);
+router.get('/:id', validateObjectId('id'), getPermit);
+
+router.post('/', requireRole(...ADMIN_SUPERVISOR_MANAGER), createPermit);
+router.put(
+  '/:id',
+  validateObjectId('id'),
+  requireRole(...ADMIN_SUPERVISOR_MANAGER),
+  updatePermit,
+);
+
+router.post(
+  '/:id/approve',
+  validateObjectId('id'),
+  requireRole(...APPROVER_ROLES),
+  approvePermit,
+);
+router.post(
+  '/:id/reject',
+  validateObjectId('id'),
+  requireRole(...APPROVER_ROLES),
+  rejectPermit,
+);
+router.post(
+  '/:id/escalate',
+  validateObjectId('id'),
+  requireRole(...ADMIN_SUPERVISOR_MANAGER),
+  escalatePermit,
+);
+router.post(
+  '/:id/isolation/:stepIndex/complete',
+  validateObjectId('id'),
+  requireRole(...APPROVER_ROLES),
+  completeIsolationStep,
+);
+router.post(
+  '/:id/incidents',
+  validateObjectId('id'),
+  requireRole(...ADMIN_SUPERVISOR_MANAGER),
+  logPermitIncident,
+);
+
+export default router;

--- a/backend/routes/index.ts
+++ b/backend/routes/index.ts
@@ -37,3 +37,4 @@ export { default as TenantRoutes } from './TenantRoutes';
 export { default as workOrdersRoutes } from './WorkOrderRoutes';
 export { default as webhooksRoutes } from './WebhooksRoutes';
 export { default as publicRequestRoutes } from './publicRequestRoutes';
+export { default as permitRoutes } from './PermitRoutes';

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -48,6 +48,7 @@ import {
   summaryRoutes,
   auditRoutes,
   attachmentRoutes,
+  permitRoutes,
 } from "./routes";
 
 import { startPMScheduler } from "./utils/PMScheduler";
@@ -164,6 +165,7 @@ app.use(/^\/api(?!\/(auth|public))/, generalLimiter);
 
 app.use("/api/departments", departmentRoutes);
 app.use("/api/workorders", workOrdersRoutes);
+app.use("/api/permits", permitRoutes);
 app.use("/api/assets", assetsRoutes);
 app.use("/api/meters", meterRoutes);
 app.use("/api/condition-rules", conditionRuleRoutes);

--- a/backend/src/schemas/permit.ts
+++ b/backend/src/schemas/permit.ts
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { z } from 'zod';
+
+export const permitApprovalStepSchema = z.object({
+  sequence: z.number().int().min(0).optional(),
+  role: z.string().min(1),
+  user: z.string().optional(),
+  escalateAfterHours: z.number().int().positive().optional(),
+  notes: z.string().optional(),
+});
+
+export const permitIsolationStepSchema = z.object({
+  description: z.string().min(1),
+  verificationNotes: z.string().optional(),
+  completed: z.boolean().optional(),
+  completedBy: z.string().optional(),
+  completedAt: z.coerce.date().optional(),
+});
+
+export const permitCreateSchema = z.object({
+  permitNumber: z.string().optional(),
+  type: z.string().min(1),
+  description: z.string().optional(),
+  requestedBy: z.string(),
+  workOrder: z.string().optional(),
+  approvalChain: z.array(permitApprovalStepSchema).min(1),
+  isolationSteps: z.array(permitIsolationStepSchema).optional(),
+  watchers: z.array(z.string()).optional(),
+  validFrom: z.coerce.date().optional(),
+  validTo: z.coerce.date().optional(),
+  riskLevel: z.enum(['low', 'medium', 'high', 'critical']).optional(),
+});
+
+export const permitUpdateSchema = permitCreateSchema.partial();
+
+export const permitDecisionSchema = z.object({
+  notes: z.string().optional(),
+});
+
+export const permitIsolationSchema = z.object({
+  verificationNotes: z.string().optional(),
+});
+
+export const permitIncidentSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  severity: z.enum(['minor', 'moderate', 'major', 'critical']).default('minor'),
+  status: z.enum(['open', 'investigating', 'resolved', 'closed']).optional(),
+  actions: z
+    .array(
+      z.object({
+        description: z.string().min(1),
+        assignedTo: z.string().optional(),
+        dueDate: z.coerce.date().optional(),
+      }),
+    )
+    .optional(),
+  message: z.string().optional(),
+});

--- a/backend/src/schemas/workOrder.ts
+++ b/backend/src/schemas/workOrder.ts
@@ -48,6 +48,8 @@ export const workOrderCreateSchema = z.object({
   importance: z.enum(['low', 'medium', 'high', 'severe']).optional(),
   dueDate: z.coerce.date().optional(),
   completedAt: z.coerce.date().optional(),
+  permits: z.array(z.string()).optional(),
+  requiredPermitTypes: z.array(z.string()).optional(),
 });
 
 export const workOrderUpdateSchema = workOrderCreateSchema.partial();

--- a/backend/tests/permitRoutes.test.ts
+++ b/backend/tests/permitRoutes.test.ts
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+
+import PermitRoutes from '../routes/PermitRoutes';
+import WorkOrderRoutes from '../routes/WorkOrderRoutes';
+import User from '../models/User';
+import WorkOrder from '../models/WorkOrder';
+import Permit from '../models/Permit';
+
+const app = express();
+app.use(express.json());
+app.use('/api/permits', PermitRoutes);
+app.use('/api/workorders', WorkOrderRoutes);
+
+let mongo: MongoMemoryServer;
+let tenantId: mongoose.Types.ObjectId;
+
+const buildToken = (userId: mongoose.Types.ObjectId) =>
+  jwt.sign({ id: userId.toString() }, process.env.JWT_SECRET!);
+
+describe('Permit routes', () => {
+  beforeAll(async () => {
+    process.env.JWT_SECRET = 'testsecret';
+    mongo = await MongoMemoryServer.create();
+    await mongoose.connect(mongo.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongo.stop();
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.db?.dropDatabase();
+    tenantId = new mongoose.Types.ObjectId();
+  });
+
+  it('enforces approval workflow and work order readiness', async () => {
+    const admin = await User.create({
+      name: 'Admin',
+      email: 'admin@example.com',
+      passwordHash: 'pass',
+      roles: ['admin'],
+      tenantId,
+      employeeId: 'EMP-A',
+    });
+    const supervisor = await User.create({
+      name: 'Supervisor',
+      email: 'supervisor@example.com',
+      passwordHash: 'pass',
+      roles: ['supervisor'],
+      tenantId,
+      employeeId: 'EMP-S',
+    });
+    const manager = await User.create({
+      name: 'Manager',
+      email: 'manager@example.com',
+      passwordHash: 'pass',
+      roles: ['manager'],
+      tenantId,
+      employeeId: 'EMP-M',
+    });
+    const viewer = await User.create({
+      name: 'Viewer',
+      email: 'viewer@example.com',
+      passwordHash: 'pass',
+      roles: ['viewer'],
+      tenantId,
+      employeeId: 'EMP-V',
+    });
+
+    const adminToken = buildToken(admin._id);
+    const supervisorToken = buildToken(supervisor._id);
+    const managerToken = buildToken(manager._id);
+    const viewerToken = buildToken(viewer._id);
+
+    const workOrderRes = await request(app)
+      .post('/api/workorders')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        title: 'Safety Maintenance',
+        priority: 'medium',
+        status: 'requested',
+      })
+      .expect(201);
+
+    const workOrderId = workOrderRes.body._id as string;
+
+    const permitRes = await request(app)
+      .post('/api/permits')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        type: 'hot-work',
+        description: 'Welding in confined space',
+        requestedBy: admin._id.toString(),
+        workOrder: workOrderId,
+        approvalChain: [
+          { user: supervisor._id.toString(), role: 'supervisor' },
+          { role: 'manager' },
+        ],
+        isolationSteps: [
+          { description: 'Verify lockout devices' },
+        ],
+      })
+      .expect(201);
+
+    const permitId = permitRes.body._id as string;
+
+    const viewerAttempt = await request(app)
+      .post(`/api/permits/${permitId}/approve`)
+      .set('Authorization', `Bearer ${viewerToken}`)
+      .send({ notes: 'Attempted by viewer' })
+      .expect(403);
+
+    expect(viewerAttempt.body.error).toBeDefined();
+
+    const startDenied = await request(app)
+      .post(`/api/workorders/${workOrderId}/start`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send({})
+      .expect(409);
+    expect(startDenied.body.error).toContain('Permits');
+
+    await request(app)
+      .post(`/api/permits/${permitId}/approve`)
+      .set('Authorization', `Bearer ${supervisorToken}`)
+      .send({ notes: 'Supervisor approved' })
+      .expect(200);
+
+    const permitAfterSupervisor = await Permit.findById(permitId).lean();
+    expect(permitAfterSupervisor?.approvalChain[0].status).toBe('approved');
+    expect(permitAfterSupervisor?.status).toBe('pending');
+
+    await request(app)
+      .post(`/api/permits/${permitId}/approve`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send({ notes: 'Manager approved' })
+      .expect(200);
+
+    const permitApproved = await Permit.findById(permitId).lean();
+    expect(permitApproved?.status).toBe('approved');
+
+    await request(app)
+      .post(`/api/workorders/${workOrderId}/start`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send({})
+      .expect(200);
+
+    const permitActive = await Permit.findById(permitId).lean();
+    expect(permitActive?.status).toBe('active');
+
+    await request(app)
+      .post(`/api/workorders/${workOrderId}/complete`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send({})
+      .expect(200);
+
+    const permitClosed = await Permit.findById(permitId).lean();
+    expect(permitClosed?.status).toBe('closed');
+
+    const workOrder = await WorkOrder.findById(workOrderId).lean();
+    expect(workOrder?.permits.map(String)).toContain(permitId);
+    expect(workOrder?.requiredPermitTypes).toContain('hot-work');
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import Layout from './components/layout/Layout';
 import ErrorBoundary from './components/common/ErrorBoundary';
 import Reports from './pages/Reports';
 import { useAuth } from '@/context/AuthContext';
+import SafetyPermits from './pages/SafetyPermits';
 import {
   setUnauthorizedCallback,
   TOKEN_KEY,
@@ -42,6 +43,7 @@ export default function App() {
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/analytics" element={<Analytics />} />
           <Route path="/reports" element={<Reports />} />
+          <Route path="/permits" element={<SafetyPermits />} />
           <Route path="/imports" element={<Imports />} />
         </Route>
       </Routes>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,9 +2,31 @@
  * SPDX-License-Identifier: MIT
  */
 
-import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+const links = [
+  { to: '/dashboard', label: 'Dashboard' },
+  { to: '/permits', label: 'Safety Permits' },
+  { to: '/workorders', label: 'Work Orders' },
+];
 
 export default function Sidebar() {
-  return <aside className="w-64 border-r p-4">Sidebar</aside>;
+  return (
+    <aside className="w-64 border-r bg-neutral-50 p-4">
+      <nav className="space-y-2 text-sm font-medium text-neutral-700">
+        {links.map((link) => (
+          <NavLink
+            key={link.to}
+            to={link.to}
+            className={({ isActive }) =>
+              `block rounded px-3 py-2 transition hover:bg-neutral-100 ${isActive ? 'bg-neutral-200 text-neutral-900' : ''}`
+            }
+          >
+            {link.label}
+          </NavLink>
+        ))}
+      </nav>
+    </aside>
+  );
 }
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import KpiCard from '@/components/dashboard/KpiCard';
 import RecentActivity, { AuditLog } from '@/components/dashboard/RecentActivity';
 import http from '@/lib/http';
+import type { SafetyKpiResponse } from '@/types';
 
 interface Summary {
   pmCompliance: number;
@@ -24,6 +25,7 @@ export default function Dashboard() {
   const [logs, setLogs] = useState<AuditLog[]>([]);
   const [loadingLogs, setLoadingLogs] = useState(false);
   const [logsError, setLogsError] = useState<string | null>(null);
+  const [safetyKpis, setSafetyKpis] = useState<SafetyKpiResponse | null>(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -39,8 +41,18 @@ export default function Dashboard() {
       }
     };
     fetchData();
+    fetchSafetyKpis();
     refreshLogs();
   }, []);
+
+  const fetchSafetyKpis = async () => {
+    try {
+      const res = await http.get<SafetyKpiResponse>('/permits/kpis');
+      setSafetyKpis(res.data);
+    } catch (err) {
+      console.error('Failed to load safety KPIs', err);
+    }
+  };
 
   const refreshLogs = async () => {
     setLoadingLogs(true);
@@ -122,6 +134,31 @@ export default function Dashboard() {
             />
           ))}
         </div>
+        {safetyKpis && (
+          <div className="grid gap-4 sm:grid-cols-3">
+            <KpiCard
+              key="activePermits"
+              title="Active Permits"
+              value={safetyKpis.activeCount}
+              deltaPct={0}
+              series={[]}
+            />
+            <KpiCard
+              key="overdueApprovals"
+              title="Overdue Approvals"
+              value={safetyKpis.overdueApprovals}
+              deltaPct={0}
+              series={[]}
+            />
+            <KpiCard
+              key="incidents30"
+              title="Incidents (30d)"
+              value={safetyKpis.incidentsLast30}
+              deltaPct={0}
+              series={[]}
+            />
+          </div>
+        )}
       </div>
       <div className="w-80">
         <RecentActivity

--- a/frontend/src/pages/SafetyPermits.tsx
+++ b/frontend/src/pages/SafetyPermits.tsx
@@ -1,0 +1,448 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import http from '@/lib/http';
+import { useAuth } from '@/context/AuthContext';
+import type {
+  Permit,
+  PermitHistoryEntry,
+  PermitApprovalStep,
+  SafetyKpiResponse,
+  PermitActivitySummary,
+} from '@/types';
+import Button from '@/components/common/Button';
+
+const PERMIT_TYPES = ['hot-work', 'confined-space', 'lockout-tagout', 'general'];
+
+function normalizePermit(raw: Permit): Permit {
+  const id = raw._id ?? raw.id ?? '';
+  return { ...raw, id };
+}
+
+const defaultApprovalChain: Omit<PermitApprovalStep, 'status'>[] = [
+  { role: 'supervisor' },
+  { role: 'manager' },
+];
+
+export default function SafetyPermits() {
+  const { user } = useAuth();
+  const [permits, setPermits] = useState<Permit[]>([]);
+  const [selectedPermit, setSelectedPermit] = useState<Permit | null>(null);
+  const [history, setHistory] = useState<PermitHistoryEntry[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [kpis, setKpis] = useState<SafetyKpiResponse | null>(null);
+  const [activity, setActivity] = useState<PermitActivitySummary | null>(null);
+  const [activityError, setActivityError] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    type: PERMIT_TYPES[0],
+    description: '',
+    isolation: '',
+    watchers: '',
+  });
+  const [requesting, setRequesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canApprove = useMemo(() => {
+    if (!user || !selectedPermit) return false;
+    const activeStep = selectedPermit.approvalChain.find((step) => step.status === 'pending');
+    if (!activeStep) return false;
+    if (activeStep.user && activeStep.user === user.id) return true;
+    if (activeStep.role && user.role && activeStep.role === user.role) return true;
+    return false;
+  }, [user, selectedPermit]);
+
+  const fetchPermits = async (): Promise<Permit[]> => {
+    try {
+      const res = await http.get<Permit[]>('/permits');
+      const normalized = res.data.map(normalizePermit);
+      setPermits(normalized);
+      if (selectedPermit) {
+        const updated = normalized.find((item) => (item.id ?? item._id) === (selectedPermit.id ?? selectedPermit._id));
+        if (updated) setSelectedPermit(updated);
+      }
+      return normalized;
+    } catch (err) {
+      console.error('Failed to load permits', err);
+      setError('Failed to load permits');
+      return [] as Permit[];
+    }
+  };
+
+  const fetchKpis = async () => {
+    try {
+      const res = await http.get<SafetyKpiResponse>('/permits/kpis');
+      setKpis(res.data);
+    } catch (err) {
+      console.error('Failed to load safety KPIs', err);
+    }
+  };
+
+  const fetchActivity = async (userId: string) => {
+    try {
+      const res = await http.get<PermitActivitySummary>('/permits/activity', {
+        params: { userId },
+      });
+      setActivity(res.data);
+      setActivityError(null);
+    } catch (err) {
+      console.error('Failed to load permit activity', err);
+      setActivityError('Unable to load permit activity');
+    }
+  };
+
+  useEffect(() => {
+    fetchPermits();
+    fetchKpis();
+  }, []);
+
+  useEffect(() => {
+    if (user?.id) {
+      fetchActivity(user.id);
+    }
+  }, [user?.id]);
+
+  const openHistory = async (permit: Permit) => {
+    setSelectedPermit(permit);
+    setHistory([]);
+    setHistoryLoading(true);
+    setHistoryError(null);
+    try {
+      const res = await http.get<PermitHistoryEntry[]>(`/permits/${permit.id ?? permit._id}/history`);
+      setHistory(res.data);
+    } catch (err) {
+      console.error('Failed to load history', err);
+      setHistoryError('Unable to load permit history');
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  const submitPermit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!user) return;
+    setRequesting(true);
+    try {
+      const isolationSteps = form.isolation
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((description) => ({ description }));
+      const watchers = form.watchers
+        .split(',')
+        .map((id) => id.trim())
+        .filter(Boolean);
+      await http.post('/permits', {
+        type: form.type,
+        description: form.description,
+        requestedBy: user.id,
+        approvalChain: defaultApprovalChain,
+        isolationSteps,
+        watchers,
+      });
+      setForm({ type: PERMIT_TYPES[0], description: '', isolation: '', watchers: '' });
+      fetchPermits();
+      fetchKpis();
+      if (user.id) fetchActivity(user.id);
+    } catch (err) {
+      console.error('Failed to create permit', err);
+      setError('Failed to request permit');
+    } finally {
+      setRequesting(false);
+    }
+  };
+
+  const approve = async (permit: Permit, notes?: string) => {
+    try {
+      await http.post(`/permits/${permit.id ?? permit._id}/approve`, { notes });
+      const updatedList = await fetchPermits();
+      fetchKpis();
+      if (user?.id) fetchActivity(user.id);
+      const refreshed = updatedList.find((item) => (item.id ?? item._id) === (permit.id ?? permit._id));
+      if (refreshed) {
+        openHistory(refreshed);
+      }
+    } catch (err) {
+      console.error('Failed to approve permit', err);
+      setError('Unable to approve permit');
+    }
+  };
+
+  const reject = async (permit: Permit, notes?: string) => {
+    try {
+      await http.post(`/permits/${permit.id ?? permit._id}/reject`, { notes });
+      fetchPermits();
+      fetchKpis();
+      if (user?.id) fetchActivity(user.id);
+    } catch (err) {
+      console.error('Failed to reject permit', err);
+      setError('Unable to reject permit');
+    }
+  };
+
+  const escalate = async (permit: Permit) => {
+    try {
+      await http.post(`/permits/${permit.id ?? permit._id}/escalate`);
+      fetchPermits();
+    } catch (err) {
+      console.error('Failed to escalate permit', err);
+      setError('Unable to escalate permit');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Safety Permits</h1>
+          <p className="text-sm text-neutral-500">
+            Request, review, and audit critical permits to keep work safe.
+          </p>
+        </div>
+        {kpis && (
+          <div className="flex gap-4">
+            <div className="rounded-lg border bg-white px-4 py-2 shadow-sm">
+              <p className="text-xs text-neutral-500">Active Permits</p>
+              <p className="text-lg font-semibold text-neutral-900">{kpis.activeCount}</p>
+            </div>
+            <div className="rounded-lg border bg-white px-4 py-2 shadow-sm">
+              <p className="text-xs text-neutral-500">Overdue Approvals</p>
+              <p className="text-lg font-semibold text-neutral-900">{kpis.overdueApprovals}</p>
+            </div>
+            <div className="rounded-lg border bg-white px-4 py-2 shadow-sm">
+              <p className="text-xs text-neutral-500">Incidents (30d)</p>
+              <p className="text-lg font-semibold text-neutral-900">{kpis.incidentsLast30}</p>
+            </div>
+          </div>
+        )}
+      </header>
+
+      {error && <div className="rounded border border-error-200 bg-error-50 p-3 text-sm text-error-600">{error}</div>}
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="space-y-4">
+          <div className="rounded-lg border bg-white p-4 shadow-sm">
+            <h2 className="text-lg font-semibold text-neutral-900">Request new permit</h2>
+            <p className="text-sm text-neutral-500">
+              Submit a permit request with automatic supervisor and manager approval steps.
+            </p>
+            <form className="mt-4 space-y-4" onSubmit={submitPermit}>
+              <div>
+                <label className="block text-sm font-medium text-neutral-700">Permit type</label>
+                <select
+                  className="mt-1 w-full rounded border border-neutral-300 bg-white p-2"
+                  value={form.type}
+                  onChange={(event) => setForm((prev) => ({ ...prev, type: event.target.value }))}
+                  required
+                >
+                  {PERMIT_TYPES.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-neutral-700">Description</label>
+                <textarea
+                  className="mt-1 w-full rounded border border-neutral-300 p-2"
+                  rows={3}
+                  value={form.description}
+                  onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+                  placeholder="Describe the work and hazards..."
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-neutral-700">Isolation steps (one per line)</label>
+                <textarea
+                  className="mt-1 w-full rounded border border-neutral-300 p-2"
+                  rows={3}
+                  value={form.isolation}
+                  onChange={(event) => setForm((prev) => ({ ...prev, isolation: event.target.value }))}
+                  placeholder="Lockout main breaker\nVerify zero energy state"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-neutral-700">Watchers (user IDs comma separated)</label>
+                <input
+                  className="mt-1 w-full rounded border border-neutral-300 p-2"
+                  value={form.watchers}
+                  onChange={(event) => setForm((prev) => ({ ...prev, watchers: event.target.value }))}
+                  placeholder="Optional"
+                />
+              </div>
+              <Button type="submit" disabled={requesting}>
+                {requesting ? 'Submitting…' : 'Submit permit request'}
+              </Button>
+            </form>
+          </div>
+
+          <div className="rounded-lg border bg-white p-4 shadow-sm">
+            <h2 className="text-lg font-semibold text-neutral-900">Open permits</h2>
+            <div className="mt-4 overflow-x-auto">
+              <table className="min-w-full divide-y divide-neutral-200 text-sm">
+                <thead className="bg-neutral-50">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-medium text-neutral-600">Permit</th>
+                    <th className="px-3 py-2 text-left font-medium text-neutral-600">Type</th>
+                    <th className="px-3 py-2 text-left font-medium text-neutral-600">Status</th>
+                    <th className="px-3 py-2 text-left font-medium text-neutral-600">Next step</th>
+                    <th className="px-3 py-2 text-right font-medium text-neutral-600">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-200">
+                  {permits.map((permit) => {
+                    const activeStep = permit.approvalChain.find((step) => step.status === 'pending');
+                    const canUserApprove = (() => {
+                      if (!user) return false;
+                      if (activeStep?.user && activeStep.user === user.id) return true;
+                      if (activeStep?.role && user.role && activeStep.role === user.role) return true;
+                      return false;
+                    })();
+                    const canUserEscalate = user?.role === 'admin' || user?.role === 'supervisor';
+                    return (
+                      <tr key={permit.id ?? permit._id}>
+                        <td className="px-3 py-2">
+                          <button
+                            type="button"
+                            onClick={() => openHistory(permit)}
+                            className="font-medium text-primary-600 hover:underline"
+                          >
+                            {permit.permitNumber || permit.id}
+                          </button>
+                        </td>
+                        <td className="px-3 py-2 capitalize">{permit.type}</td>
+                        <td className="px-3 py-2">
+                          <span className="rounded-full bg-neutral-100 px-2 py-1 text-xs font-medium text-neutral-700">
+                            {permit.status}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-neutral-600">
+                          {activeStep ? (
+                            <div>
+                              <div className="font-medium">{activeStep.role}</div>
+                              {activeStep.user && <div className="text-xs">Assigned: {activeStep.user}</div>}
+                            </div>
+                          ) : (
+                            <span className="text-xs text-neutral-500">All steps complete</span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2 text-right space-x-2">
+                          {canUserApprove && (
+                            <Button size="sm" variant="primary" onClick={() => approve(permit)}>
+                              Approve
+                            </Button>
+                          )}
+                          {canUserApprove && (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onClick={() => reject(permit)}
+                              className="text-error-600"
+                            >
+                              Reject
+                            </Button>
+                          )}
+                          {canUserEscalate && permit.status === 'pending' && (
+                            <Button size="sm" variant="ghost" onClick={() => escalate(permit)}>
+                              Escalate
+                            </Button>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+              {!permits.length && (
+                <div className="py-8 text-center text-sm text-neutral-500">No permits requested yet.</div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="rounded-lg border bg-white p-4 shadow-sm">
+            <h3 className="text-lg font-semibold text-neutral-900">My safety activity</h3>
+            {activityError && <p className="text-sm text-error-600">{activityError}</p>}
+            {!activity && !activityError && <p className="text-sm text-neutral-500">Loading activity…</p>}
+            {activity && (
+              <div className="space-y-4">
+                <div className="grid grid-cols-3 gap-3 text-center text-sm">
+                  <div className="rounded border bg-neutral-50 p-3">
+                    <div className="text-xs text-neutral-500">Total permits</div>
+                    <div className="text-lg font-semibold text-neutral-900">{activity.totalInvolved}</div>
+                  </div>
+                  <div className="rounded border bg-neutral-50 p-3">
+                    <div className="text-xs text-neutral-500">Pending approvals</div>
+                    <div className="text-lg font-semibold text-neutral-900">{activity.pendingApprovals}</div>
+                  </div>
+                  <div className="rounded border bg-neutral-50 p-3">
+                    <div className="text-xs text-neutral-500">Active permits</div>
+                    <div className="text-lg font-semibold text-neutral-900">{activity.activePermits}</div>
+                  </div>
+                </div>
+                <div>
+                  <h4 className="text-sm font-semibold text-neutral-700">Recent history</h4>
+                  <ul className="mt-2 space-y-2 text-sm text-neutral-600">
+                    {activity.recentHistory.length ? (
+                      activity.recentHistory.map((entry) => (
+                        <li key={`${entry.permitId}-${entry.at}`} className="rounded border border-neutral-200 p-2">
+                          <div className="font-medium text-neutral-900">{entry.permitNumber}</div>
+                          <div className="text-xs text-neutral-500">
+                            {new Date(entry.at).toLocaleString()} — {entry.action}
+                          </div>
+                          {entry.notes && <div className="text-xs text-neutral-500">{entry.notes}</div>}
+                        </li>
+                      ))
+                    ) : (
+                      <li className="text-xs text-neutral-400">No recent activity</li>
+                    )}
+                  </ul>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {selectedPermit && (
+            <div className="rounded-lg border bg-white p-4 shadow-sm">
+              <h3 className="text-lg font-semibold text-neutral-900">Permit history</h3>
+              <p className="text-sm text-neutral-500">
+                {selectedPermit.permitNumber} • {selectedPermit.status}
+              </p>
+              {historyLoading && <p className="mt-3 text-sm text-neutral-500">Loading history…</p>}
+              {historyError && <p className="mt-3 text-sm text-error-600">{historyError}</p>}
+              {!historyLoading && !historyError && (
+                <ul className="mt-3 space-y-2 text-sm text-neutral-600">
+                  {history.length ? (
+                    history.map((entry) => (
+                      <li key={`${entry.action}-${entry.at}`} className="rounded border border-neutral-200 p-2">
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium text-neutral-800">{entry.action}</span>
+                          <span className="text-xs text-neutral-500">{new Date(entry.at).toLocaleString()}</span>
+                        </div>
+                        {entry.notes && <div className="text-xs text-neutral-500">{entry.notes}</div>}
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-xs text-neutral-400">No history yet.</li>
+                  )}
+                </ul>
+              )}
+              {canApprove && (
+                <div className="mt-4 space-x-2">
+                  <Button size="sm" onClick={() => approve(selectedPermit)}>Approve current step</Button>
+                  <Button size="sm" variant="ghost" onClick={() => reject(selectedPermit)}>
+                    Reject
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/TeamMemberProfile.tsx
+++ b/frontend/src/pages/TeamMemberProfile.tsx
@@ -2,18 +2,19 @@
  * SPDX-License-Identifier: MIT
  */
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
- import Avatar from '@/components/common/Avatar';
+import Avatar from '@/components/common/Avatar';
 import WorkHistoryCard from '@/components/teams/WorkHistoryCard';
 import { teamMembers } from '@/utils/data';
-import type { WorkHistory, WorkHistoryEntry } from '@/types';
- 
- 
-
-const TeamMemberProfile: React.FC = () => {
+import http from '@/lib/http';
+import type { WorkHistory, WorkHistoryEntry, PermitActivitySummary } from '@/types';
+const TeamMemberProfile = () => {
   const { id } = useParams<{ id: string }>();
   const member = teamMembers.find(m => m.id === id);
+  const [permitActivity, setPermitActivity] = useState<PermitActivitySummary | null>(null);
+  const [activityError, setActivityError] = useState<string | null>(null);
+  const [loadingActivity, setLoadingActivity] = useState(false);
 
   if (!member) {
     return (
@@ -23,6 +24,26 @@ const TeamMemberProfile: React.FC = () => {
 
   const manager = member.managerId ? teamMembers.find(m => m.id === member.managerId) : null;
   const subordinates = teamMembers.filter(m => m.managerId === member.id);
+
+  useEffect(() => {
+    const loadActivity = async () => {
+      try {
+        setLoadingActivity(true);
+        const res = await http.get<PermitActivitySummary>('/permits/activity', {
+          params: { userId: member.id },
+        });
+        setPermitActivity(res.data);
+        setActivityError(null);
+      } catch (err) {
+        setActivityError('Unable to load permit activity');
+      } finally {
+        setLoadingActivity(false);
+      }
+    };
+    if (member.id) {
+      loadActivity();
+    }
+  }, [member.id]);
 
   const sampleWorkHistory: WorkHistory = {
     metrics: {
@@ -124,7 +145,51 @@ const TeamMemberProfile: React.FC = () => {
           </div>
         </div>
 
-        <WorkHistoryCard metrics={sampleWorkHistory.metrics} recentWork={sampleWorkHistory.recentWork} />
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+            <h3 className="text-lg font-semibold text-neutral-900">Permit Activity</h3>
+            {loadingActivity && <p className="text-sm text-neutral-500">Loading activity…</p>}
+            {activityError && <p className="text-sm text-error-600">{activityError}</p>}
+            {permitActivity && !loadingActivity && !activityError && (
+              <div className="space-y-4 text-sm text-neutral-700">
+                <div className="grid grid-cols-3 gap-3 text-center">
+                  <div className="rounded border bg-neutral-50 p-3">
+                    <div className="text-xs text-neutral-500">Permits Involved</div>
+                    <div className="text-lg font-semibold text-neutral-900">{permitActivity.totalInvolved}</div>
+                  </div>
+                  <div className="rounded border bg-neutral-50 p-3">
+                    <div className="text-xs text-neutral-500">Pending Approvals</div>
+                    <div className="text-lg font-semibold text-neutral-900">{permitActivity.pendingApprovals}</div>
+                  </div>
+                  <div className="rounded border bg-neutral-50 p-3">
+                    <div className="text-xs text-neutral-500">Active Permits</div>
+                    <div className="text-lg font-semibold text-neutral-900">{permitActivity.activePermits}</div>
+                  </div>
+                </div>
+                <div>
+                  <h4 className="text-sm font-semibold text-neutral-700">Recent Actions</h4>
+                  <ul className="mt-2 space-y-2">
+                    {permitActivity.recentHistory.length ? (
+                      permitActivity.recentHistory.map((entry) => (
+                        <li key={`${entry.permitId}-${entry.at}`} className="rounded border border-neutral-200 p-2">
+                          <div className="flex items-center justify-between">
+                            <span className="font-medium text-neutral-900">{entry.permitNumber}</span>
+                            <span className="text-xs text-neutral-500">{new Date(entry.at).toLocaleString()}</span>
+                          </div>
+                          <div className="text-xs text-neutral-500">{entry.action}</div>
+                          {entry.notes && <div className="text-xs text-neutral-500">{entry.notes}</div>}
+                        </li>
+                      ))
+                    ) : (
+                      <li className="text-xs text-neutral-400">No recent permit activity.</li>
+                    )}
+                  </ul>
+                </div>
+              </div>
+            )}
+          </div>
+          <WorkHistoryCard metrics={sampleWorkHistory.metrics} recentWork={sampleWorkHistory.recentWork} />
+        </div>
       </div>
   );
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,6 +3,15 @@ export type { WorkOrder as SharedWorkOrder } from '@shared/workOrder';
 export type { InventoryItem, InventoryUpdatePayload } from '@shared/inventory';
 export type { UploadedFile, UploadResponse } from '@shared/uploads';
 export type { ApiResult } from '@shared/http';
+export type {
+  Permit,
+  PermitHistoryEntry,
+  PermitApprovalStep,
+  PermitIsolationStep,
+  SafetyIncident,
+  SafetyKpiResponse,
+  PermitActivitySummary,
+} from '@shared/permit';
 
 /**
  * Defines the allowed maintenance categories for upcoming maintenance tasks.
@@ -103,6 +112,8 @@ export interface WorkOrder {
   timeSpentMin?: number;
   photos?: string[];
   failureCode?: string;
+  permits?: string[];
+  requiredPermitTypes?: string[];
 
   /** Department associated with the work order */
   department: string;

--- a/shared/types/permit.ts
+++ b/shared/types/permit.ts
@@ -1,0 +1,117 @@
+export type PermitStatus =
+  | 'draft'
+  | 'pending'
+  | 'approved'
+  | 'active'
+  | 'rejected'
+  | 'closed'
+  | 'escalated';
+
+export type PermitApprovalStepStatus =
+  | 'blocked'
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'escalated';
+
+export interface PermitApprovalStep {
+  sequence: number;
+  role: string;
+  user?: string;
+  status: PermitApprovalStepStatus;
+  approvedAt?: string;
+  actedBy?: string;
+  notes?: string;
+  escalateAfterHours?: number;
+  escalateAt?: string | null;
+}
+
+export interface PermitIsolationStep {
+  index: number;
+  description: string;
+  completed?: boolean;
+  completedAt?: string;
+  completedBy?: string;
+  verificationNotes?: string;
+}
+
+export interface PermitHistoryEntry {
+  action: string;
+  by?: string;
+  at: string;
+  notes?: string;
+}
+
+export interface Permit {
+  _id?: string;
+  id?: string;
+  permitNumber: string;
+  type: string;
+  description?: string;
+  status: PermitStatus;
+  requestedBy: string;
+  workOrder?: string;
+  approvalChain: PermitApprovalStep[];
+  isolationSteps: PermitIsolationStep[];
+  watchers: string[];
+  history: PermitHistoryEntry[];
+  validFrom?: string;
+  validTo?: string;
+  riskLevel?: 'low' | 'medium' | 'high' | 'critical';
+  incidents?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export type SafetyIncidentSeverity = 'minor' | 'moderate' | 'major' | 'critical';
+export type SafetyIncidentStatus = 'open' | 'investigating' | 'resolved' | 'closed';
+
+export interface SafetyIncidentAction {
+  description: string;
+  assignedTo?: string;
+  dueDate?: string;
+  completedAt?: string;
+}
+
+export interface SafetyIncidentLogEntry {
+  at: string;
+  by?: string;
+  message: string;
+}
+
+export interface SafetyIncident {
+  _id?: string;
+  id?: string;
+  permit?: string;
+  workOrder?: string;
+  title: string;
+  description?: string;
+  severity: SafetyIncidentSeverity;
+  status: SafetyIncidentStatus;
+  reportedBy: string;
+  reportedAt: string;
+  actions: SafetyIncidentAction[];
+  timeline: SafetyIncidentLogEntry[];
+}
+
+export interface SafetyKpiResponse {
+  activeCount: number;
+  overdueApprovals: number;
+  incidentsLast30: number;
+  avgApprovalHours: number;
+}
+
+export interface PermitActivityHistoryEntry {
+  permitId: string;
+  permitNumber: string;
+  action: string;
+  at: string;
+  notes?: string;
+}
+
+export interface PermitActivitySummary {
+  totalInvolved: number;
+  pendingApprovals: number;
+  activePermits: number;
+  recentHistory: PermitActivityHistoryEntry[];
+}

--- a/shared/types/workOrder.ts
+++ b/shared/types/workOrder.ts
@@ -39,6 +39,8 @@ export interface WorkOrder {
   timeSpentMin?: number;
   photos?: string[];
   failureCode?: string;
+  permits?: string[];
+  requiredPermitTypes?: string[];
   pmTask?: string;
   department?: string;
   line?: string;


### PR DESCRIPTION
## Summary
- add permit and safety incident data models, controllers, and routes with escalation, isolation, and KPI handling
- integrate permit linkage and approval requirements into work order logic and shared schemas
- deliver safety permit frontend pages, dashboard widgets, and types wired to new APIs plus lifecycle tests

## Testing
- `CI=1 npm ci` *(fails: npm registry returned 403 for multiple package tarballs, preventing dependency install so test suite could not be executed)*

------
https://chatgpt.com/codex/tasks/task_e_68cd36fc66bc83238bd5ae4bc6e127e6