### PR TITLE
Pin Vite dev dependency for Windows compatibility

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,7 +74,7 @@
         "tailwindcss": "^4",
         "typescript": "^5.4.0",
         "typescript-eslint": "^8.10.0",
-        "vite": "^7.1.4",
+        "vite": "7.1.4",
         "vitest": "^3.2.4"
       }
     },
@@ -9067,9 +9067,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
-      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
+      "integrity": "sha512-rCkAEze9AEaZUrT0mRqP3xDG0bh1XeZpXDtcZJL44sS7fmN1Rmo65cR13QVbSeKtomcJIEu1hVW/2aDsnz33ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,7 +77,7 @@
     "tailwindcss": "^4",
     "typescript": "^5.4.0",
     "typescript-eslint": "^8.10.0",
-    "vite": "^7.1.4",
+    "vite": "7.1.4",
     "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- pin the frontend Vite devDependency to version 7.1.4 to avoid caret updates on Windows
- update the lockfile so the resolved Vite package also targets 7.1.4

## Testing
- `npm install` *(fails: registry.npmjs.org returned 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0cee4f51483238033e318dfca337b