### PR TITLE
Wrap App with AuthProvider context

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { AuthProvider } from '@/context/AuthContext';
 import App from './App';
 
 declare global {
@@ -17,6 +18,8 @@ window.initNavBar();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <BrowserRouter>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </BrowserRouter>
 );


### PR DESCRIPTION
## Summary
- import the AuthProvider context in the Vite entry point
- wrap the rendered App tree with AuthProvider while preserving BrowserRouter and nav bar bootstrap

## Testing
- npm --prefix frontend run build *(fails: missing @types/react packages due to restricted registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d0db7690b48323a465cfc98313b0d9