### PR TITLE
Refactor login route responses

### DIFF
--- a/backend/routes/AuthRoutes.ts
+++ b/backend/routes/AuthRoutes.ts
@@ -20,6 +20,7 @@ import { assertEmail } from '../utils/assert';
 import { requireAuth } from '../middleware/requireAuth';
 import logger from '../utils/logger';
 import { isCookieSecure } from '../utils/isCookieSecure';
+import { sendResponse } from '../utils/sendResponse';
 
 
 const FAKE_PASSWORD_HASH =
@@ -55,7 +56,7 @@ router.post('/login', loginLimiter, async (
 ): Promise<void> => {
   const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) {
-    res.status(400).json({ message: 'Invalid request' });
+    sendResponse(res, null, { message: 'Invalid request' }, 400);
     return;
   }
   const { email, password } = parsed.data;
@@ -65,7 +66,7 @@ router.post('/login', loginLimiter, async (
     const user = await User.findOne({ email }).select('+password +mfaEnabled +tenantId +tokenVersion +email +name');
     if (!user) {
       await bcrypt.compare(password, FAKE_PASSWORD_HASH); // mitigate timing
-      res.status(400).json({ message: 'Invalid email or password' });
+      sendResponse(res, null, { message: 'Invalid email or password' }, 400);
       return;
     }
 
@@ -73,18 +74,18 @@ router.post('/login', loginLimiter, async (
     if (!hashed) {
       // If password is still missing due to schema, treat as invalid
       await bcrypt.compare(password, FAKE_PASSWORD_HASH);
-      res.status(400).json({ message: 'Invalid email or password' });
+      sendResponse(res, null, { message: 'Invalid email or password' }, 400);
       return;
     }
 
     const valid = await bcrypt.compare(password, hashed);
     if (!valid) {
-      res.status(400).json({ message: 'Invalid email or password' });
+      sendResponse(res, null, { message: 'Invalid email or password' }, 400);
       return;
     }
 
     if ((user as any).mfaEnabled) {
-      res.status(200).json({ mfaRequired: true });
+      sendResponse(res, { mfaRequired: true });
       return;
     }
 
@@ -94,7 +95,7 @@ router.post('/login', loginLimiter, async (
     try {
       secret = getJwtSecret();
     } catch {
-      res.status(500).json({ message: 'Server configuration issue' });
+      sendResponse(res, null, { message: 'Server configuration issue' }, 500);
       return;
     }
 
@@ -112,21 +113,22 @@ router.post('/login', loginLimiter, async (
     const userObj = user.toObject();
     delete (userObj as any).password;
 
-    const responseBody: Record<string, unknown> = {
+    const responseData: {
+      user: typeof userObj & { tenantId?: string };
+      token?: string;
+    } = {
       user: { ...userObj, tenantId },
     };
     if (process.env.INCLUDE_AUTH_TOKEN === 'true') {
-      responseBody.token = token;
+      responseData.token = token;
     }
 
-    res
-      .cookie('token', token, {
-        httpOnly: true,
-        sameSite: 'strict',
-        secure: isCookieSecure(),
-      })
-      .status(200)
-      .json(responseBody);
+    res.cookie('token', token, {
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: isCookieSecure(),
+    });
+    sendResponse(res, responseData);
     return;
   } catch (err) {
     logger.error('Login error:', err);


### PR DESCRIPTION
## Summary
- wrap the `/login` handler responses with the shared `sendResponse` helper while keeping cookie logic intact

## Testing
- npm test *(fails: vitest not found because the registry blocks package download in this environment)*
- npm run test *(fails: vitest not found because the registry blocks package download in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0eb4d2b8483239932dab46e48736e