### PR TITLE
Return MFA login envelope with user id

### DIFF
--- a/backend/routes/AuthRoutes.ts
+++ b/backend/routes/AuthRoutes.ts
@@ -20,6 +20,7 @@ import { assertEmail } from '../utils/assert';
 import { requireAuth } from '../middleware/requireAuth';
 import logger from '../utils/logger';
 import { isCookieSecure } from '../utils/isCookieSecure';
+import { sendResponse } from '../utils/sendResponse';
 
 
 const FAKE_PASSWORD_HASH =
@@ -83,12 +84,15 @@ router.post('/login', loginLimiter, async (
       return;
     }
 
+    const tenantId = (user as any).tenantId ? (user as any).tenantId.toString() : undefined;
+
     if ((user as any).mfaEnabled) {
-      res.status(200).json({ mfaRequired: true });
+      sendResponse(res, {
+        mfaRequired: true,
+        userId: user._id.toString(),
+      });
       return;
     }
-
-    const tenantId = (user as any).tenantId ? (user as any).tenantId.toString() : undefined;
 
     let secret: string;
     try {

--- a/frontend/src/test/oauthMfa.e2e.test.ts
+++ b/frontend/src/test/oauthMfa.e2e.test.ts
@@ -54,7 +54,8 @@ describe('OAuth and MFA flows', () => {
     const loginRes = await request(app)
       .post('/api/auth/login')
       .send({ email: 'mfa@example.com', password: 'pass123' });
-    expect(loginRes.body.mfaRequired).toBe(true);
+    expect(loginRes.body.data.mfaRequired).toBe(true);
+    expect(loginRes.body.data.userId).toBe(user._id.toString());
 
     const verifyRes = await request(app)
       .post('/api/auth/mfa/verify')


### PR DESCRIPTION
## Summary
- reuse the shared response envelope when MFA is required during login and include the user identifier
- cover the MFA-required login path in backend tests and align the frontend MFA e2e expectation with the API shape

## Testing
- npm test *(fails: local vitest binary is unavailable because dependency installation from the npm registry is blocked by 403 errors in this environment)*
- npm run test -- loginMfa *(fails: local vitest binary is unavailable because dependency installation from the npm registry is blocked by 403 errors in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0eb4e4f708323b4c1291ddf62236e